### PR TITLE
chore(cursor): expand skills and rules for team parity

### DIFF
--- a/.cursor/rules/api-routes.mdc
+++ b/.cursor/rules/api-routes.mdc
@@ -1,0 +1,56 @@
+---
+description: Next.js API route conventions
+globs: "packages/web/app/api/**/*.ts"
+---
+
+# API Route Conventions
+
+## Handler Format
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  // Auth check if needed
+  // Validate input
+  // Business logic
+  // Return response
+}
+```
+
+## Auth Pattern
+```typescript
+import { createClient } from '@/lib/supabase/server';
+
+const supabase = await createClient();
+const { data: { user }, error } = await supabase.auth.getUser();
+if (!user) {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+}
+```
+
+## Error Response Format
+```typescript
+NextResponse.json(
+  { error: 'Error code', message: 'Human-readable description' },
+  { status: 400 }
+);
+```
+
+## Pagination (cursor-based)
+```typescript
+const cursor = request.nextUrl.searchParams.get('cursor');
+const limit = Number(request.nextUrl.searchParams.get('limit')) || 20;
+```
+
+## Route Organization
+- Base path: `app/api/v1/`
+- RESTful: `GET` (list/read), `POST` (create), `PATCH` (update), `DELETE` (remove)
+- Dynamic segments: `[postId]`, `[userId]`
+- Nested resources: `posts/[postId]/spots`, `spots/[spotId]/solutions`
+
+## Best Practices
+- Validate request body with type guards or zod schemas
+- Use `NextResponse.json()` for all responses
+- Set appropriate status codes (200, 201, 400, 401, 404, 500)
+- Log errors server-side before returning generic error messages
+- Use `export const dynamic = 'force-dynamic'` for non-cacheable routes

--- a/.cursor/rules/monorepo.mdc
+++ b/.cursor/rules/monorepo.mdc
@@ -1,12 +1,12 @@
 ---
-description: decoded-monorepo conventions
+description: decoded-monorepo conventions and architecture
 globs: "**/*"
 ---
 
 # decoded-monorepo
 
 ## Structure
-- `packages/web/` — Next.js 16 frontend
+- `packages/web/` — Next.js 16 frontend (main app)
 - `packages/shared/` — Shared types, hooks, Supabase queries
 - `packages/mobile/` — Expo 54 React Native
 - `packages/api-server/` — Rust/Axum API server (independent Cargo workspace)
@@ -18,21 +18,60 @@ globs: "**/*"
 
 ## Key Conventions
 - TypeScript strict mode
-- Conventional Commits: feat:, fix:, docs:, refactor:, test:, chore:
+- Conventional Commits: `type(scope): description`
+  - types: feat, fix, docs, refactor, test, chore, perf, ci, build
+  - scope: web, api-server, ai-server, shared, mobile (optional)
 - ESLint 10 flat config (requires Node 22+)
 - React 19 — `useRef(null)` required, `RefObject<T | null>`
 - `proxy.ts` (not middleware.ts) — Next.js 16
-- Design system components: `packages/web/lib/design-system/`
+- All request APIs are async: `await cookies()`, `await headers()`, `await params`
+
+## Design System (v2.0)
+- Import from `@/lib/design-system` (barrel export)
+- Components: Heading, Text, Card, ProductCard, Input, Badge, Tabs, BottomSheet, etc.
+- Tokens: `typography`, `colors`, `spacing`, `shadows`, `borderRadius`, `zIndex`
+- Use design system components over raw HTML/Tailwind when a matching component exists
+
+## Naming Conventions
+| Type | Convention | Example |
+|------|-----------|---------|
+| Components | PascalCase | `ProductCard.tsx` |
+| Hooks | camelCase, `use` prefix | `useImages.ts` |
+| Stores | camelCase, `Store` suffix | `authStore.ts` |
+| Utils | camelCase | `formatDate.ts` |
+| API routes | kebab-case dirs | `app/api/v1/posts/` |
+| Constants | UPPER_SNAKE | `MAX_FILE_SIZE` |
+
+## Key Paths
 - Supabase queries: `packages/web/lib/supabase/queries/`
-- State management: Zustand stores in `packages/web/lib/stores/`
+- Zustand stores: `packages/web/lib/stores/`
+- Custom hooks: `packages/web/lib/hooks/`
+- API client: `packages/web/lib/api/`
+- Design system: `packages/web/lib/design-system/`
+- Feature specs: `specs/`
+
+## Commands
+```bash
+bun run dev             # Dev server (all JS packages)
+bun run dev:api-server  # Rust API (cargo watch)
+bun run dev:ai-server   # Python AI server (uv)
+bun run build           # Production build
+bun run lint            # ESLint
+just ci-web             # Frontend CI (lint + format + tsc)
+```
+
+## Git Workflow
+- Branch: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/` prefix
+- main 직접 push 금지 — PR로만 머지
+- Pre-push: ESLint + Prettier + TypeScript checks
+- Guide: `docs/GIT-WORKFLOW.md`
 
 ## API server (Rust)
-- Builds via `cargo` (not bun)
+- Builds via `cargo` (not bun): `cd packages/api-server && cargo build`
 - Axum 0.8, SeaORM, tokio, Meilisearch
-- `cd packages/api-server && cargo build`
 
 ## AI server (Python)
-- uv in `packages/ai-server`; `uv run python -m src.main` or `bun run dev:ai-server` from root (after `uv sync`)
+- uv: `cd packages/ai-server && uv sync && uv run python -m src.main`
 
 ## Environment
 - Copy `packages/web/.env.local.example` → `.env.local`

--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -1,0 +1,58 @@
+---
+description: React component conventions for decoded web package
+globs: "packages/web/**/*.tsx"
+---
+
+# React Component Conventions
+
+## Server vs Client Components
+- Default to Server Components. Only add `'use client'` when needed.
+- `'use client'` triggers: useState, useEffect, event handlers, browser APIs, Zustand stores
+- Push `'use client'` boundary as far down the component tree as possible
+
+## Design System
+- Import from `@/lib/design-system` (barrel export)
+- Use `Heading`, `Text`, `Card`, `Input`, `Badge`, `Tabs`, `BottomSheet` etc.
+- Use design tokens (`spacing`, `colors`, `typography`) over hardcoded values
+- Use `cn()` utility (from `@/lib/utils`) for className merging
+
+## Component Structure
+```tsx
+// Props interface — extend HTML attributes when wrapping DOM elements
+interface MyComponentProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  variant?: 'default' | 'compact';
+}
+
+export function MyComponent({ title, variant = 'default', className, ...props }: MyComponentProps) {
+  return (
+    <div className={cn('base-styles', className)} {...props}>
+      <Heading variant="h3">{title}</Heading>
+    </div>
+  );
+}
+```
+
+## React 19 Specifics
+- `useRef<T | null>(null)` — null initial value required
+- `RefObject<T | null>` — includes null in type
+- All request APIs async: `await cookies()`, `await headers()`, `await params`
+
+## Suspense & Loading
+- Create `loading.tsx` or Skeleton components for Suspense boundaries
+- Use `CardSkeleton` from design system for card loading states
+
+## Accessibility
+- All images: `alt` text required
+- Interactive elements: `aria-label` when text not visible
+- Keyboard navigation: focusable interactive elements
+- Color contrast: use design system color tokens
+
+## Hooks
+- Location: `lib/hooks/` (general) or `lib/hooks/admin/` (admin-specific)
+- Naming: `useXxx` pattern (e.g., `useImages`, `usePostLike`)
+- Data fetching: React Query (`useQuery`, `useMutation`)
+
+## State Management
+- Zustand stores in `lib/stores/` (e.g., `authStore.ts`, `searchStore.ts`)
+- Pattern: `create<T>()((set, get) => ({ ... }))`

--- a/.cursor/rules/rust-api.mdc
+++ b/.cursor/rules/rust-api.mdc
@@ -1,0 +1,64 @@
+---
+description: Rust API server conventions (Axum + SeaORM)
+globs: "packages/api-server/**/*.rs"
+---
+
+# Rust API Server Conventions
+
+## Stack
+- **Framework**: Axum 0.8
+- **ORM**: SeaORM 1.1
+- **Runtime**: tokio
+- **Search**: Meilisearch
+- **Build**: cargo (not bun)
+
+## Handler Pattern
+```rust
+use axum::{extract::State, Json};
+use crate::AppState;
+
+pub async fn handler(
+    State(state): State<AppState>,
+    Json(body): Json<RequestBody>,
+) -> Result<Json<ResponseBody>, AppError> {
+    // Business logic
+    Ok(Json(response))
+}
+```
+
+## Error Handling
+- Use `thiserror` for error type definitions
+- Implement `IntoResponse` for custom error types
+- Return appropriate HTTP status codes
+
+## SeaORM Entities
+- Location: `src/entities/`
+- Generated with `sea-orm-cli generate entity`
+- Use `ActiveModel` for inserts/updates
+
+## Commands
+```bash
+cargo build           # Build
+cargo run             # Run server
+cargo test            # Run tests
+cargo clippy          # Lint
+cargo fmt             # Format
+```
+
+## Key Directories
+```
+packages/api-server/
+├── src/
+│   ├── main.rs         # Entry point
+│   ├── routes/         # Axum route handlers
+│   ├── entities/       # SeaORM entities
+│   ├── services/       # Business logic
+│   └── grpc/           # gRPC client to ai-server
+├── Cargo.toml
+└── .env.dev.example
+```
+
+## Notes
+- This package is NOT in bun workspaces (independent Cargo workspace)
+- gRPC communication with `packages/ai-server`
+- Port alignment: GRPC_PORT must match AI server's GRPC_BACKEND_PORT

--- a/.cursor/skills/api-contract/SKILL.md
+++ b/.cursor/skills/api-contract/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: api-contract
+description: >-
+  Feature spec에서 OpenAPI 스타일 API 문서 생성.
+  엔드포인트 정의, Request/Response 타입, 화면-API 매핑 테이블 포함.
+  "API contract", "OpenAPI", "endpoint spec", "API 문서 생성" 요청 시 적용.
+---
+
+# API Contract Generator
+
+## 개요
+
+Feature spec과 화면 명세를 분석하여 API 계약 문서를 자동 생성합니다.
+`specs/shared/api-contracts.md` 형식을 준수합니다.
+
+## 생성 프로세스
+
+### Step 1: 데이터 요구사항 추출
+
+```
+[spec.md] → User Stories 분석
+[SCR-XXX-##] → 화면별 API 호출 식별
+[data-models.md] → 타입 참조
+```
+
+### Step 2: 엔드포인트 도출
+
+각 화면 명세에서:
+1. "데이터 요구사항" 섹션 추출
+2. CRUD 작업 식별
+3. 필터/검색/페이지네이션 요구사항 파악
+
+## API 문서 구조
+
+### 엔드포인트 정의
+
+```markdown
+## {리소스} API
+
+### {HTTP Method} {Path}
+
+**설명**: {엔드포인트 목적}
+
+| 항목 | 내용 |
+|------|------|
+| Method | GET / POST / PATCH / DELETE |
+| Path | `/api/v1/{resource}` |
+| Auth | Required / Optional |
+| 관련 화면 | SCR-XXX-## |
+
+#### Query Parameters (GET)
+
+| 파라미터 | 타입 | 필수 | 기본값 | 설명 |
+|----------|------|:---:|-------|------|
+| cursor | string | - | - | 페이지네이션 커서 |
+| limit | number | - | 20 | 페이지 크기 |
+
+#### Request Body (POST/PATCH)
+
+\```typescript
+interface RequestBody {
+  field: string;
+}
+\```
+
+#### Response
+
+**성공 (200/201):**
+
+\```typescript
+interface SuccessResponse {
+  data: ResourceType;
+}
+\```
+```
+
+### 에러 코드
+
+| 코드 | HTTP | 설명 |
+|------|:---:|------|
+| VALIDATION_ERROR | 400 | 입력값 검증 실패 |
+| UNAUTHORIZED | 401 | 인증 필요 |
+| FORBIDDEN | 403 | 권한 없음 |
+| NOT_FOUND | 404 | 리소스 없음 |
+| CONFLICT | 409 | 리소스 충돌 |
+| INTERNAL_ERROR | 500 | 서버 오류 |
+
+### 화면-API 매핑 테이블
+
+```markdown
+| 화면 ID | 기능 | API | 설명 |
+|---------|------|-----|------|
+| SCR-DISC-01 | 목록 로드 | GET /posts | 최신 Post 목록 |
+| SCR-DISC-01 | 필터 조회 | GET /posts?category= | 필터 적용 |
+```
+
+## 출력 위치
+
+```
+specs/{feature}/api-endpoints.md
+```
+
+## 참조 파일
+
+- `specs/shared/api-contracts.md` — 기존 API 계약 패턴
+- `specs/shared/data-models.md` — TypeScript 타입 참조
+- `docs/api/` — API 문서 디렉토리
+
+## 검증 체크리스트
+
+- [ ] 모든 화면 명세의 API 요구사항 충족
+- [ ] Request/Response 타입이 data-models.md와 일치
+- [ ] 인증 요구사항 명시
+- [ ] 페이지네이션 전략 정의 (cursor-based)
+- [ ] 에러 코드 문서화
+- [ ] 화면-API 매핑 테이블 완성
+
+## 사용 예시
+
+```
+> specs/discovery/spec.md를 기반으로 API 계약 문서 생성해줘
+> 이 화면들에 필요한 API 엔드포인트를 정리해줘
+> OpenAPI 스타일로 API 명세 작성해줘
+```

--- a/.cursor/skills/code-reviewer/SKILL.md
+++ b/.cursor/skills/code-reviewer/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: code-reviewer
+description: >-
+  Git diff 기반 코드 리뷰. Two-pass(CRITICAL/INFORMATIONAL) 분류,
+  Fix-First 접근, decoded 전용 규칙(디자인 시스템, 네이밍, Supabase RLS).
+  "/review", "코드 리뷰", "PR 리뷰" 요청 시 적용.
+---
+
+# Code Reviewer
+
+## 역할
+
+Git diff 기반으로 변경된 코드를 분석하여 실질적 이슈만 지적합니다.
+스타일/포맷 이슈는 ESLint/Prettier가 처리하므로 여기서는 다루지 않습니다.
+
+## 리뷰 프로세스
+
+### Step 1: 변경 범위 파악
+
+```bash
+# 베이스 브랜치 감지
+BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "main")
+git fetch origin $BASE --quiet 2>/dev/null || true
+
+# 변경 파일 목록 + 통계
+git diff origin/$BASE...HEAD --name-only --diff-filter=ACMR
+git diff origin/$BASE...HEAD --stat
+```
+
+### Step 2: Scope Drift 감지
+
+커밋 메시지에서 의도를 파악하고 실제 변경과 비교:
+
+```bash
+git log origin/$BASE..HEAD --oneline
+```
+
+- **DRIFT**: 의도와 무관한 파일 변경
+- **MISSING**: 커밋 메시지에 언급된 요구사항이 diff에 없음
+- **CLEAN**: 일치
+
+### Step 3: Two-Pass 리뷰
+
+**Pass 1 — CRITICAL (차단)**
+
+| 카테고리 | 검사 항목 |
+|----------|----------|
+| 보안 | 하드코딩 시크릿/API 키, `dangerouslySetInnerHTML` 미검증, 인증 누락 (API route에서 세션 체크 없음) |
+| 타입 안전성 | `any` 타입, unsafe `as` 단언, nullable 미처리 |
+| 버그 | 무한 루프/리렌더, useEffect deps 오류, 비동기 에러 미처리, 메모리 누수 (cleanup 없는 listener/timer) |
+| 데이터 | Race condition, 동시성 이슈 |
+
+**Pass 2 — INFORMATIONAL (권장)**
+
+| 카테고리 | 검사 항목 |
+|----------|----------|
+| 성능 | 매 렌더마다 새 객체/배열, 큰 번들 임포트, `'use client'` 남용 |
+| 디자인 시스템 | 직접 색상/spacing 값 (토큰 사용), `lib/design-system/` 컴포넌트 미사용 |
+| 접근성 | 키보드 접근성 누락, img alt 없음, label 연결 없음 |
+| 코드 품질 | console.log 잔존, 주석 처리된 코드, 빈 catch 블록 |
+
+### Step 4: Fix-First 분류
+
+각 이슈를 분류:
+- **AUTO-FIX**: 기계적 수정 가능 → 직접 적용, 한 줄 요약
+- **ASK**: 판단 필요 → 모아서 일괄 질문, 승인 후 적용
+
+## decoded 전용 규칙
+
+### 디자인 시스템 컴포넌트 확인
+
+변경 파일에서 다음을 확인:
+- `lib/design-system/`에 동일 역할 컴포넌트가 있는데 자체 구현했는지
+- 디자인 토큰 (`colors`, `spacing`, `typography`) 대신 직접 값 사용했는지
+
+### 네이밍 컨벤션
+
+| 대상 | 규칙 | 예시 |
+|------|------|------|
+| 컴포넌트 파일 | PascalCase | `UserProfile.tsx` |
+| 훅 파일/함수 | `use` 접두사 | `useProfile.ts` |
+| 스토어 | `Store` 접미사 | `authStore.ts` |
+| API 라우트 | kebab-case | `app/api/v1/posts/route.ts` |
+| 상수 | UPPER_SNAKE_CASE | `MAX_UPLOAD_SIZE` |
+
+### Supabase 쿼리 안전성
+
+- RLS 정책 의존 여부 확인
+- `.single()` 사용 시 결과 없을 때 에러 처리
+- 인증 필요 쿼리에서 세션 체크
+
+## 참조 파일
+
+- `.planning/codebase/CONVENTIONS.md` — 코딩 컨벤션
+- `lib/design-system/` — 디자인 시스템 컴포넌트
+- `packages/web/eslint.config.mjs` — ESLint 규칙
+- `docs/GIT-WORKFLOW.md` — Git 워크플로우
+
+## 출력 형식
+
+```markdown
+## Code Review: N issues (X critical, Y informational)
+
+**Scope**: CLEAN / DRIFT / MISSING
+**Intent**: {커밋에서 파악한 의도}
+**Delivered**: {실제 변경 요약}
+
+### AUTO-FIXED
+- [파일:라인] 문제 → 수정 내용
+
+### CRITICAL (확인 필요)
+1. **[파일:라인] 이슈**
+   - 문제: `코드`
+   - 권장: `수정`
+   → A) Fix  B) Skip
+
+### INFORMATIONAL
+1. **[파일:라인] 이슈** — 설명
+
+### 긍정적 사항
+- 잘 된 패턴 언급
+```
+
+## 주의사항
+
+- 변경된 코드만 리뷰 (주변은 컨텍스트 참조만)
+- ESLint/Prettier가 잡는 건 건너뛰기
+- 과도한 지적 금지 — 실질적 문제만
+- 증거 기반 — "아마 문제" 대신 구체적 코드/라인 인용
+- 긍정적 사항 반드시 포함

--- a/.cursor/skills/component-template/SKILL.md
+++ b/.cursor/skills/component-template/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: component-template
+description: >-
+  화면 스펙에서 React 컴포넌트 보일러플레이트 생성.
+  Server/Client 컴포넌트 분리, 스켈레톤, barrel export 포함.
+  "scaffold component", "컴포넌트 생성", "컴포넌트 템플릿" 요청 시 적용.
+---
+
+# Component Template Generator
+
+## 개요
+
+화면 명세(SCR-XXX-##)를 분석하여 React 컴포넌트 보일러플레이트를 자동 생성합니다.
+프로젝트의 코딩 컨벤션과 디자인 시스템을 준수합니다.
+
+## 생성 프로세스
+
+### Step 1: 화면 명세 분석
+
+```
+[specs/{feature}/screens/SCR-XXX-##.md]
+  ↓
+UI 요소 추출 (IMG, TXT, BTN, INP...)
+  ↓
+상태 정의 추출
+  ↓
+데이터 요구사항 추출
+```
+
+### Step 2: 컴포넌트 구조 결정
+
+```
+페이지 컴포넌트 (app/route/page.tsx)
+├── 레이아웃 컴포넌트
+├── 섹션 컴포넌트 (lib/components/feature/)
+│   ├── 프레젠테이셔널 컴포넌트
+│   └── 컨테이너 컴포넌트
+└── UI 컴포넌트 (lib/components/ui/)
+```
+
+## 컴포넌트 템플릿
+
+### 1. 페이지 컴포넌트
+
+```tsx
+// app/{route}/page.tsx
+import { Suspense } from 'react';
+import { FeatureSection } from '@/lib/components/{feature}';
+import { FeatureSkeleton } from '@/lib/components/{feature}/skeleton';
+
+export const metadata = {
+  title: '{페이지 제목}',
+  description: '{페이지 설명}',
+};
+
+export default function FeaturePage() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <Suspense fallback={<FeatureSkeleton />}>
+        <FeatureSection />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+### 2. 섹션 컴포넌트 (Server Component)
+
+```tsx
+// lib/components/{feature}/FeatureSection.tsx
+import { fetchFeatureData } from '@/lib/api/{feature}';
+import { FeatureClient } from './FeatureClient';
+
+export async function FeatureSection() {
+  const data = await fetchFeatureData();
+  return <FeatureClient initialData={data} />;
+}
+```
+
+### 3. 클라이언트 컴포넌트
+
+```tsx
+// lib/components/{feature}/FeatureClient.tsx
+'use client';
+
+import { useState } from 'react';
+import type { FeatureData } from '@/lib/types/{feature}';
+
+interface FeatureClientProps {
+  initialData: FeatureData[];
+}
+
+export function FeatureClient({ initialData }: FeatureClientProps) {
+  const [data, setData] = useState(initialData);
+
+  if (!data.length) {
+    return <EmptyState message="데이터가 없습니다" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* UI 렌더링 */}
+    </div>
+  );
+}
+```
+
+### 4. 스켈레톤 컴포넌트
+
+```tsx
+// lib/components/{feature}/skeleton.tsx
+export function FeatureSkeleton() {
+  return (
+    <div className="animate-pulse space-y-4">
+      <div className="h-8 bg-muted rounded w-1/3" />
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="h-48 bg-muted rounded" />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+### 5. UI 컴포넌트
+
+```tsx
+// lib/components/ui/{ComponentName}.tsx
+import { cn } from '@/lib/utils';
+
+interface ComponentNameProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'outline';
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export function ComponentName({
+  className, variant = 'default', size = 'md', children, ...props
+}: ComponentNameProps) {
+  return (
+    <div
+      className={cn('base-styles', variant === 'outline' && 'outline-styles', className)}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+```
+
+## 파일 구조 생성
+
+```
+lib/components/{feature}/
+├── index.ts              # barrel export
+├── FeatureSection.tsx    # Server component
+├── FeatureClient.tsx     # Client component
+├── FeatureCard.tsx       # 개별 아이템
+├── skeleton.tsx          # 로딩 스켈레톤
+└── types.ts              # 로컬 타입 (필요시)
+```
+
+## 네이밍 컨벤션
+
+| 유형 | 규칙 | 예시 |
+|------|------|------|
+| 파일명 | PascalCase | `FeatureCard.tsx` |
+| 컴포넌트 | PascalCase | `FeatureCard` |
+| 훅 | camelCase + use | `useFeatureData` |
+| 유틸 | camelCase | `formatFeature` |
+| 상수 | UPPER_SNAKE | `MAX_ITEMS` |
+
+## 참조 파일
+
+- `specs/{feature}/screens/` — 화면 스펙
+- `lib/components/` — 기존 컴포넌트 패턴
+- `lib/design-system/` — 디자인 시스템
+
+## 생성 후 체크리스트
+
+- [ ] TypeScript 타입 정의
+- [ ] Props interface 정의
+- [ ] 상태 처리 (로딩, 에러, 빈 상태)
+- [ ] 반응형 스타일
+- [ ] 접근성 속성 (aria-*)
+- [ ] barrel export 추가
+
+## 사용 예시
+
+```
+> SCR-DISC-01 화면의 컴포넌트 스캐폴드 생성해줘
+> PostGrid 컴포넌트 보일러플레이트 만들어줘
+> 이 화면 명세에 맞는 React 컴포넌트 생성해줘
+```

--- a/.cursor/skills/git-workflow/SKILL.md
+++ b/.cursor/skills/git-workflow/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: git-workflow
+description: >-
+  Git 워크플로우 컨벤션 가이드 및 검증.
+  "브랜치 이름", "commit convention", "PR 준비", "git workflow" 요청 시 적용.
+---
+
+# Git Workflow
+
+## 개요
+
+`docs/GIT-WORKFLOW.md`를 기반으로 git 컨벤션을 검증하고 안내합니다.
+
+## 트리거 조건
+
+- "브랜치 이름", "branch naming"
+- "커밋 컨벤션", "commit convention"
+- "PR 준비", "PR readiness"
+- "git workflow", "git 규칙"
+
+## 기능
+
+### 1. 브랜치명 검증
+
+```bash
+BRANCH=$(git branch --show-current)
+```
+
+허용 접두사: `feat/`, `fix/`, `docs/`, `refactor/`, `chore/`, `test/`, `ci/`
+
+### 2. 커밋 메시지 검증
+
+```bash
+git log --oneline -10
+```
+
+Conventional Commits 형식 확인:
+- `type(scope): description`
+- 허용 타입: feat, fix, docs, refactor, test, chore, ci, perf, style
+
+### 3. PR 준비 상태 체크
+
+- [ ] 브랜치명 컨벤션 준수
+- [ ] 커밋 메시지 형식 준수
+- [ ] pre-push 체크 통과 (`bun run ci:local`)
+- [ ] `/review` 코드 리뷰 완료
+- [ ] P0 이슈 없음
+
+### 4. 워크플로우 안내
+
+`docs/GIT-WORKFLOW.md`를 참조하여 질문에 답변합니다.
+
+## 참조
+
+- `docs/GIT-WORKFLOW.md` — 팀 워크플로우 source of truth
+- `scripts/git-pre-push.sh` — pre-push 훅
+
+## 사용 예시
+
+```
+> 현재 브랜치 이름이 컨벤션에 맞는지 확인해줘
+> PR 만들기 전 준비 상태 체크해줘
+> 커밋 메시지 형식 알려줘
+> git workflow 규칙이 뭐야?
+```

--- a/.cursor/skills/react-best-practices/SKILL.md
+++ b/.cursor/skills/react-best-practices/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: react-best-practices
+description: >-
+  Vercel 엔지니어링의 React/Next.js 성능 최적화 가이드라인 (45규칙/8카테고리).
+  React 컴포넌트 작성, Next.js 페이지, 데이터 페칭, 번들 최적화, 성능 개선 작업 시 적용.
+---
+
+# React Best Practices (Vercel Engineering)
+
+45개 규칙, 우선순위별 8카테고리.
+
+## 1. Waterfalls 제거 — CRITICAL
+
+- **Promise.all()** 독립 작업 병렬화
+- **await 지연**: 실제 사용 시점까지 await 미루기
+- **Suspense 경계**: 독립 데이터에 별도 Suspense boundary
+- **API route 직렬화 방지**: route handler에서 순차 fetch 금지
+
+```tsx
+// Bad: 순차 실행
+const user = await fetchUser();
+const posts = await fetchPosts();
+
+// Good: 병렬 실행
+const [user, posts] = await Promise.all([fetchUser(), fetchPosts()]);
+```
+
+## 2. Bundle 최적화 — CRITICAL
+
+- **barrel import 금지**: `import { X } from '@/lib/utils'` 대신 직접 경로
+- **dynamic import**: 무거운 컴포넌트 `next/dynamic`으로 지연 로드
+- **3rd-party 지연**: analytics, chat 위젯 등 비핵심 라이브러리 defer
+- **의도 기반 preload**: hover/focus 시 미리 로드
+
+## 3. Server 성능 — HIGH
+
+- **React.cache()**: 요청 내 데이터 중복 제거
+- **LRU 캐시**: 요청 간 공유 데이터 캐싱
+- **직렬화 최소화**: RSC → Client 전달 데이터 축소
+- **after()**: 응답 후 비차단 작업 실행
+
+## 4. Client 데이터 — MEDIUM-HIGH
+
+- **SWR 자동 중복 제거**: 동일 키 요청 deduplicate
+- **전역 이벤트 리스너**: 중복 등록 방지
+
+## 5. Re-render 최적화 — MEDIUM
+
+- **state 읽기 지연**: 사용 시점에서만 state 접근
+- **memo 추출**: 고비용 컴포넌트 분리 + React.memo
+- **effect deps 최소화**: 필요한 값만 의존성에
+- **derived state 구독**: 전체 store 대신 selector 사용
+- **functional setState**: `setCount(prev => prev + 1)`
+- **lazy initialization**: `useState(() => expensiveCompute())`
+- **useTransition**: 비긴급 업데이트 분리
+
+## 6. Rendering 성능 — MEDIUM
+
+- **content-visibility**: 긴 목록 CSS `content-visibility: auto`
+- **static JSX hoist**: 변하지 않는 JSX 컴포넌트 외부로
+- **SVG 정밀도**: 소수점 2자리로 제한
+- **Activity 컴포넌트**: show/hide에 React.Activity 사용
+- **명시적 조건부 렌더링**: `&&` 대신 삼항 연산자
+
+## 7. JS 성능 — LOW-MEDIUM
+
+- **Map/Set O(1) 조회**: 배열 대신 Map/Set
+- **early return**: 조기 반환으로 불필요 연산 방지
+- **loop 내 프로퍼티 캐시**: 반복 접근 변수 캐싱
+- **배열 순회 합치기**: 여러 map/filter → 한 번의 reduce
+- **toSorted()**: 불변 정렬 (원본 배열 유지)
+
+## 8. Advanced — LOW
+
+- **event handler refs**: 이벤트 핸들러를 ref에 저장
+- **useLatest**: 안정적 콜백 ref 패턴
+
+## decoded 프로젝트 적용 포인트
+
+- GSAP/Three.js/Spline → **dynamic import 필수** (큰 번들)
+- Zustand store → **selector 사용** (`useStore(s => s.field)`)
+- Supabase 쿼리 → **React.cache()** 또는 React Query 활용
+- 이미지 그리드 → **content-visibility** + Intersection Observer
+- `'use client'` → 가능한 한 아래로 밀어내기
+
+## 사용 예시
+
+```
+> 이 컴포넌트 성능 최적화해줘
+> 번들 크기 줄이는 방법 알려줘
+> waterfall 패턴 찾아서 수정해줘
+> 리렌더링 최적화 해줘
+```

--- a/.cursor/skills/security-auditor/SKILL.md
+++ b/.cursor/skills/security-auditor/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: security-auditor
+description: >-
+  보안 감사 및 취약점 분석. OWASP Top 10 + 프로젝트 특화 점검.
+  "보안 검토", "취약점 분석", "보안 점검", "이 코드 안전해?" 요청 시 적용.
+---
+
+# Security Auditor
+
+## 점검 항목
+
+### OWASP Top 10
+
+| # | 항목 | 주요 확인 |
+|---|------|----------|
+| A01 | 접근 제어 | 권한 검증, IDOR, CORS |
+| A02 | 암호화 | 평문 저장, 약한 해시, 하드코딩 키 |
+| A03 | 인젝션 | SQL/NoSQL/Command Injection |
+| A04 | 설계 | 비즈니스 로직 취약점, Rate limiting |
+| A05 | 설정 오류 | 디버그 모드, 기본 자격증명, 에러 노출 |
+| A06 | 취약 구성요소 | 알려진 CVE, 오래된 의존성 |
+| A07 | 인증 | 세션 관리, 토큰 저장 |
+| A08 | 데이터 무결성 | 역직렬화, 무결성 검증 |
+| A09 | 로깅 | 민감 정보 로깅, 로그 인젝션 |
+| A10 | SSRF | URL 검증, 내부 네트워크 접근 |
+
+### 추가 점검
+
+- 입력 검증 (화이트리스트, 파일 업로드)
+- 출력 인코딩 (HTML/JS/URL)
+- 민감 정보 (API 키 하드코딩, 주석 내 자격증명, 로그 내 PII)
+
+### decoded 특화 점검
+
+- Supabase RLS 정책 확인
+- API route 인증 체크 (`supabase.auth.getUser()`)
+- `dangerouslySetInnerHTML` 사용 시 sanitize 확인
+- `.env.local` 외부 하드코딩 키 탐지
+
+## 출력 형식
+
+```markdown
+## 보안 감사 보고서
+
+### 요약: Critical N / High N / Medium N / Low N
+
+#### [Critical] 취약점명
+- **위치**: 파일:라인
+- **영향**: 어떤 피해 가능
+- **조치**: 수정 방법
+```
+
+### 심각도 레벨
+
+| 레벨 | 설명 |
+|------|------|
+| Critical | 즉시 악용 가능 (RCE, SQLi) |
+| High | 중요 데이터 노출 (IDOR, 권한 상승) |
+| Medium | 제한적 영향 (XSS, CSRF) |
+| Low | 정보 노출 |
+
+## 사용 예시
+
+```
+> 이 PR의 보안 점검 해줘
+> API 라우트 보안 감사해줘
+> 이 코드에 취약점 있어?
+```

--- a/.cursor/skills/testing-specialist/SKILL.md
+++ b/.cursor/skills/testing-specialist/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: testing-specialist
+description: >-
+  테스트 케이스 작성 가이드. 단위/통합/E2E 테스트 작성.
+  "테스트 작성", "단위 테스트", "테스트 케이스", "이 함수 테스트" 요청 시 적용.
+---
+
+# Testing Specialist
+
+## AAA 패턴
+
+```javascript
+describe('대상', () => {
+  it('should [기대] when [조건]', () => {
+    // Arrange
+    const input = 'test';
+    // Act
+    const result = fn(input);
+    // Assert
+    expect(result).toBe('expected');
+  });
+});
+```
+
+## 테스트 케이스 체크리스트
+
+- **Happy Path:** 기본 입력 → 예상 출력, 다양한 유효 입력
+- **Edge Cases:** null/undefined/''/[], 경계값(0, -1, MAX), 특수 문자, 매우 긴 입력
+- **Error Cases:** 잘못된 타입, 필수 파라미터 누락, 권한 없음, 네트워크 실패
+
+## 모킹 원칙
+
+**언제:** 외부 API, DB, 파일시스템, Date/setTimeout, 랜덤
+**원칙:** 필요한 것만, 실제 동작과 유사하게, 범위 최소화
+
+## decoded 프로젝트 테스트 패턴
+
+### Playwright (E2E/Visual)
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('페이지 로딩', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading')).toBeVisible();
+});
+```
+
+### API Route 테스트
+
+```typescript
+// API route handler를 직접 호출
+import { GET } from '@/app/api/v1/posts/route';
+
+it('should return posts', async () => {
+  const request = new Request('http://localhost/api/v1/posts');
+  const response = await GET(request);
+  expect(response.status).toBe(200);
+});
+```
+
+### Hook 테스트
+
+```typescript
+import { renderHook, waitFor } from '@testing-library/react';
+
+it('should fetch data', async () => {
+  const { result } = renderHook(() => useImages());
+  await waitFor(() => expect(result.current.data).toBeDefined());
+});
+```
+
+## 테스트 파일 위치
+
+```
+packages/web/__tests__/          # 테스트 루트
+packages/web/__tests__/api/      # API route 테스트
+packages/web/__tests__/hooks/    # Hook 테스트
+packages/web/__tests__/e2e/      # E2E 테스트 (Playwright)
+```
+
+## 사용 예시
+
+```
+> usePostLike 훅 테스트 작성해줘
+> /api/v1/posts API 테스트 만들어줘
+> 이 컴포넌트의 에지 케이스 테스트 추가해줘
+```


### PR DESCRIPTION
## Summary
- Cursor 사용자 도구 격차 해소: 1 rule + 1 skill → **4 rules + 8 skills**
- Claude Code 에이전트/스킬 + 로컬 스킬에서 핵심을 포팅
- SKILL.md 포맷 동일 (Agent Skills 표준) — `allowed-tools`, `model` 제거만 적용

## Changes

**Rules (.mdc) — 파일 열면 자동 활성화:**
- `monorepo.mdc` 확장 (디자인 시스템, 훅, 네이밍 컨벤션 추가)
- `react-components.mdc` — `packages/web/**/*.tsx` 대상
- `api-routes.mdc` — `packages/web/app/api/**/*.ts` 대상
- `rust-api.mdc` — `packages/api-server/**/*.rs` 대상

**Skills (SKILL.md) — `/skill-name`으로 호출:**
- `code-reviewer` — Two-pass 리뷰, Fix-First, decoded 전용 규칙
- `git-workflow` — 브랜치/커밋/PR 컨벤션
- `component-template` — React 컴포넌트 스캐폴딩
- `api-contract` — OpenAPI 스타일 API 문서
- `security-auditor` — OWASP Top 10 보안 감사
- `testing-specialist` — AAA 패턴 테스트 가이드
- `react-best-practices` — 45개 React/Next.js 성능 규칙

## Test plan
- [ ] Cursor에서 `.tsx` 파일 열기 → react-components 룰 자동 로드 확인
- [ ] Cursor에서 `/code-reviewer` 입력 → 스킬 인식 확인
- [ ] 기존 `/commit` 스킬 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)