### PR TITLE
feat(8): admin content management — post ops, report queue, metadata edit

### DIFF
--- a/docs/agent/api-v1-routes.md
+++ b/docs/agent/api-v1-routes.md
@@ -69,6 +69,12 @@
 | `/api/v1/admin/audit/[requestId]`     | GET     | Single audit entry       |
 | `/api/v1/admin/pipeline`              | GET     | Pipeline status          |
 | `/api/v1/admin/pipeline/[pipelineId]` | GET     | Single pipeline          |
+| `/api/v1/reports`                     | POST    | Submit content report (proxy → Rust) |
+| `/api/v1/admin/posts`                 | GET     | Admin post list (proxy → Rust) |
+| `/api/v1/admin/posts/[postId]`        | PATCH   | Admin post metadata edit (proxy → Rust) |
+| `/api/v1/admin/posts/[postId]/status` | PATCH   | Update post status (proxy → Rust) |
+| `/api/v1/admin/reports`               | GET     | Admin report list (proxy → Rust) |
+| `/api/v1/admin/reports/[reportId]`    | PATCH   | Update report status (proxy → Rust) |
 | `/api/v1/admin/server-logs`           | GET     | Server logs              |
 | `/api/v1/admin/server-logs/stream`    | GET     | Server logs (SSE stream) |
 

--- a/docs/agent/web-routes-and-features.md
+++ b/docs/agent/web-routes-and-features.md
@@ -15,7 +15,8 @@ App Router 기준 (`packages/web/app/`). 작업 시 이 표와 실제 `app/` 트
 | `/profile`           | User profile with activity, badges, tries, stats, rankings, style DNA, collections |
 | `/editorial`         | Daily editorial page with curated content                                          |
 | `/magazine/personal` | Personal magazine issue viewer with decoding ritual                                |
-| `/admin`             | Admin dashboard (AI cost, audit, pipeline, server logs)                            |
+| `/admin`             | Admin dashboard (AI cost, audit, content, pipeline, server logs)                   |
+| `/admin/content`     | Content management — post visibility, status control                               |
 | `/request/upload`    | Image upload with DropZone                                                         |
 | `/request/detect`    | AI detection results with item spotting                                            |
 | `/login`             | OAuth authentication (Kakao, Google, Apple)                                        |

--- a/packages/api-server/README.md
+++ b/packages/api-server/README.md
@@ -37,7 +37,7 @@ just dev    # pre-push 훅 + .env.dev 준비 + docker/dev (API :8000, Meilisearc
 
 ## 프로젝트 통계
 
-- **총 라인 수**: ~26,968 lines (Rust)
+- **총 라인 수**: ~28,170 lines (Rust)
 - **파일 수**: 182 files
 - **도메인**: 16 domains (users, categories, posts, spots, solutions, comments, votes, feed, rankings, badges, earnings, search, admin, post_magazines, post_likes, saved_posts)
 - **마지막 업데이트**: 2026.03.26

--- a/packages/api-server/migration/sql/06_content_reports.sql
+++ b/packages/api-server/migration/sql/06_content_reports.sql
@@ -1,0 +1,47 @@
+-- content_reports 테이블
+-- 이 파일은 Supabase Dashboard SQL Editor에서 수동으로 실행해야 합니다.
+
+-- 1. Table
+CREATE TABLE IF NOT EXISTS public.content_reports (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    target_type VARCHAR(32) NOT NULL DEFAULT 'post',
+    target_id   UUID NOT NULL,
+    reporter_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    reason      VARCHAR(64) NOT NULL,
+    details     TEXT,
+    status      VARCHAR(32) NOT NULL DEFAULT 'pending',
+    resolution  TEXT,
+    reviewed_by UUID REFERENCES auth.users(id),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 2. Indexes
+CREATE INDEX IF NOT EXISTS idx_content_reports_target
+    ON public.content_reports (target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_content_reports_status
+    ON public.content_reports (status);
+CREATE INDEX IF NOT EXISTS idx_content_reports_reporter
+    ON public.content_reports (reporter_id);
+
+-- 3. Unique constraint: one report per user per target
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_reports_unique_per_user
+    ON public.content_reports (target_type, target_id, reporter_id);
+
+-- 4. RLS
+ALTER TABLE public.content_reports ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can insert their own reports
+CREATE POLICY "content_reports_insert_own"
+    ON public.content_reports
+    FOR INSERT
+    WITH CHECK (auth.uid() = reporter_id);
+
+-- Users can read their own reports
+CREATE POLICY "content_reports_select_own"
+    ON public.content_reports
+    FOR SELECT
+    USING (auth.uid() = reporter_id);
+
+-- Admin can read all reports (via service role key from Rust API)
+-- Note: Rust API uses service role, so RLS is bypassed for admin operations

--- a/packages/api-server/src/domains/admin/handlers.rs
+++ b/packages/api-server/src/domains/admin/handlers.rs
@@ -10,6 +10,7 @@ use super::{
     badges, categories, curations, dashboard, editorial_candidates, magazine_sessions, posts,
     solutions, spots, synonyms,
 };
+use crate::domains::reports;
 
 /// Admin 라우터
 pub fn router(state: AppState, app_config: AppConfig) -> Router<AppState> {
@@ -29,6 +30,10 @@ pub fn router(state: AppState, app_config: AppConfig) -> Router<AppState> {
             dashboard::router(state.clone(), app_config.clone()),
         )
         .nest("/badges", badges::router(app_config.clone()))
+        .nest(
+            "/reports",
+            reports::admin_router(app_config.clone()),
+        )
         .nest(
             "/magazine-sessions",
             magazine_sessions::router(state, app_config),

--- a/packages/api-server/src/domains/admin/posts.rs
+++ b/packages/api-server/src/domains/admin/posts.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::{
     config::{AppConfig, AppState},
     domains::posts::{
-        dto::{PostListItem, PostListQuery},
+        dto::{PostListItem, PostListQuery, UpdatePostDto},
         service,
     },
     error::AppResult,
@@ -110,7 +110,32 @@ pub async fn update_post_status(
         )));
     }
 
-    let post = service::admin_update_post_status(&state.db, post_id, &dto.status).await?;
+    let post = service::admin_update_post_status(&state.search_client, &state.db, post_id, &dto.status).await?;
+    Ok(Json(post))
+}
+
+/// PATCH /api/v1/admin/posts/{id} - Admin용 Post 메타데이터 수정
+#[utoipa::path(
+    patch,
+    path = "/api/v1/admin/posts/{id}",
+    tag = "admin",
+    security(("bearer_auth" = [])),
+    params(("id" = Uuid, Path, description = "Post ID")),
+    request_body = UpdatePostDto,
+    responses(
+        (status = 200, description = "수정 성공", body = crate::domains::posts::dto::PostResponse),
+        (status = 401, description = "인증 필요"),
+        (status = 403, description = "Admin 권한 필요"),
+        (status = 404, description = "Post를 찾을 수 없음")
+    )
+)]
+pub async fn admin_update_post(
+    State(state): State<AppState>,
+    _extension: axum::Extension<User>,
+    Path(post_id): Path<Uuid>,
+    Json(dto): Json<UpdatePostDto>,
+) -> AppResult<Json<crate::domains::posts::dto::PostResponse>> {
+    let post = service::admin_update_post(&state, post_id, dto).await?;
     Ok(Json(post))
 }
 
@@ -118,6 +143,7 @@ pub async fn update_post_status(
 pub fn router(app_config: AppConfig) -> Router<AppState> {
     Router::new()
         .route("/", get(list_posts))
+        .route("/{id}", patch(admin_update_post))
         .route("/{id}/status", patch(update_post_status))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),

--- a/packages/api-server/src/domains/mod.rs
+++ b/packages/api-server/src/domains/mod.rs
@@ -12,6 +12,7 @@ pub mod post_likes;
 pub mod post_magazines;
 pub mod posts;
 pub mod rankings;
+pub mod reports;
 pub mod saved_posts;
 pub mod search;
 pub mod solutions;

--- a/packages/api-server/src/domains/posts/dto.rs
+++ b/packages/api-server/src/domains/posts/dto.rs
@@ -282,6 +282,9 @@ pub struct PostListItem {
     /// 댓글 개수
     pub comment_count: i64,
 
+    /// 상태 (active, hidden, deleted)
+    pub status: String,
+
     /// 생성일시
     pub created_at: DateTime<Utc>,
 

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -829,6 +829,7 @@ pub async fn list_posts(
                 spot_count,
                 view_count: post.view_count,
                 comment_count,
+                status: post.status.clone(),
                 created_at: post.created_at.with_timezone(&chrono::Utc),
                 post_magazine_title,
             }
@@ -1112,6 +1113,7 @@ pub async fn admin_list_posts(
                 spot_count,
                 view_count: post.view_count,
                 comment_count,
+                status: post.status.clone(),
                 created_at: post.created_at.with_timezone(&chrono::Utc),
                 post_magazine_title,
             }
@@ -1123,6 +1125,7 @@ pub async fn admin_list_posts(
 
 /// Admin용 Post 상태 변경
 pub async fn admin_update_post_status(
+    search_client: &std::sync::Arc<dyn crate::services::search::SearchClient>,
     db: &DatabaseConnection,
     post_id: Uuid,
     status: &str,
@@ -1140,7 +1143,97 @@ pub async fn admin_update_post_status(
         .await
         .map_err(AppError::DatabaseError)?;
 
+    // Meilisearch 동기화 (비동기, 실패해도 상태 변경은 성공)
+    match status {
+        "hidden" | "deleted" => {
+            if let Err(e) = search_client.delete("posts", &post_id.to_string()).await {
+                tracing::warn!(
+                    "Failed to delete post {} from Meilisearch: {}",
+                    post_id,
+                    e
+                );
+            }
+        }
+        "active" => {
+            let doc = serde_json::json!({
+                "id": post_id.to_string(),
+                "status": "active"
+            });
+            if let Err(e) = search_client
+                .update_document("posts", &post_id.to_string(), doc)
+                .await
+            {
+                tracing::warn!(
+                    "Failed to update post {} in Meilisearch: {}",
+                    post_id,
+                    e
+                );
+            }
+        }
+        _ => {}
+    }
+
     Ok(updated_post.into())
+}
+
+/// Admin용 Post 메타데이터 수정 (소유권 검사 없음)
+pub async fn admin_update_post(
+    state: &AppState,
+    post_id: Uuid,
+    dto: UpdatePostDto,
+) -> AppResult<PostResponse> {
+    let post = get_post_by_id(&state.db, post_id).await?;
+
+    let mut active_post: ActiveModel = post.into();
+
+    if let Some(media_source) = dto.media_source {
+        active_post.media_type = Set(media_source.media_type().to_string());
+    }
+    if let Some(group_name) = dto.group_name {
+        active_post.group_name = Set(Some(group_name));
+    }
+    if let Some(artist_name) = dto.artist_name {
+        active_post.artist_name = Set(Some(artist_name));
+    }
+    if let Some(context) = dto.context {
+        active_post.context = Set(Some(context));
+    }
+    if let Some(status) = dto.status {
+        active_post.status = Set(status);
+    }
+
+    let updated_post = active_post
+        .update(&state.db)
+        .await
+        .map_err(AppError::DatabaseError)?;
+
+    let updated_response: PostResponse = updated_post.into();
+
+    // Meilisearch 재인덱싱
+    let search_fields = match load_post_related_data(&state.db, post_id).await {
+        Ok(data) => compute_search_fields(&data),
+        Err(e) => {
+            tracing::warn!("Failed to load search fields for post {}: {}", post_id, e);
+            PostSearchFields {
+                category_codes: vec![],
+                has_adopted_solution: false,
+                solution_count: 0,
+                spot_count: 0,
+            }
+        }
+    };
+    if let Err(e) = index_post_to_meilisearch(
+        &state.search_client,
+        &updated_response,
+        &updated_response.image_url,
+        &search_fields,
+    )
+    .await
+    {
+        tracing::warn!("Failed to update post {} in Meilisearch: {}", post_id, e);
+    }
+
+    Ok(updated_response)
 }
 
 /// 조회수 증가

--- a/packages/api-server/src/domains/reports/dto.rs
+++ b/packages/api-server/src/domains/reports/dto.rs
@@ -1,0 +1,76 @@
+//! Reports DTOs
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// 신고 생성 요청
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateReportDto {
+    /// 대상 타입 (post, comment, solution)
+    pub target_type: String,
+    /// 대상 ID
+    pub target_id: Uuid,
+    /// 신고 사유 (spam, inappropriate, copyright, incorrect, other)
+    pub reason: String,
+    /// 상세 설명 (선택)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+}
+
+/// 신고 상태 업데이트 요청 (admin)
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct UpdateReportStatusDto {
+    /// 새 상태 (pending, reviewed, dismissed, actioned)
+    pub status: String,
+    /// 처리 결과 메모 (선택)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<String>,
+}
+
+/// Admin용 신고 목록 쿼리
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct AdminReportListQuery {
+    /// 상태 필터
+    pub status: Option<String>,
+    /// 대상 타입 필터
+    pub target_type: Option<String>,
+    /// 페이지 번호
+    pub page: Option<u64>,
+    /// 페이지당 개수
+    pub per_page: Option<u64>,
+}
+
+/// 신고자 정보 (간소화)
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReporterInfo {
+    pub id: Uuid,
+    pub username: String,
+}
+
+/// 신고 목록 아이템
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportListItem {
+    pub id: Uuid,
+    pub target_type: String,
+    pub target_id: Uuid,
+    pub reporter: ReporterInfo,
+    pub reason: String,
+    pub details: Option<String>,
+    pub status: String,
+    pub resolution: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// 신고 생성 응답
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ReportResponse {
+    pub id: Uuid,
+    pub target_type: String,
+    pub target_id: Uuid,
+    pub reason: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}

--- a/packages/api-server/src/domains/reports/handlers.rs
+++ b/packages/api-server/src/domains/reports/handlers.rs
@@ -1,0 +1,157 @@
+//! Reports HTTP handlers
+//!
+//! POST /api/v1/reports — 인증 사용자 신고 생성
+//! GET /api/v1/admin/reports — Admin 신고 목록
+//! PATCH /api/v1/admin/reports/{id} — Admin 신고 상태 변경
+
+use axum::{
+    extract::{Path, Query, State},
+    routing::{get, patch, post},
+    Json, Router,
+};
+use uuid::Uuid;
+
+use crate::{
+    config::{AppConfig, AppState},
+    error::AppResult,
+    middleware::auth::User,
+    utils::pagination::PaginatedResponse,
+};
+
+use super::{
+    dto::{
+        AdminReportListQuery, CreateReportDto, ReportListItem, ReportResponse,
+        UpdateReportStatusDto,
+    },
+    service,
+};
+
+// ─── Public (authenticated) ──────────────────────────────────────────────────
+
+/// POST /api/v1/reports
+#[utoipa::path(
+    post,
+    path = "/api/v1/reports",
+    tag = "reports",
+    security(("bearer_auth" = [])),
+    request_body = CreateReportDto,
+    responses(
+        (status = 201, description = "Report created", body = ReportResponse),
+        (status = 400, description = "Duplicate report or invalid input"),
+        (status = 401, description = "Authentication required")
+    )
+)]
+async fn create_report(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<User>,
+    Json(dto): Json<CreateReportDto>,
+) -> AppResult<Json<ReportResponse>> {
+    let valid_types = ["post", "comment", "solution"];
+    if !valid_types.contains(&dto.target_type.as_str()) {
+        return Err(crate::error::AppError::BadRequest(format!(
+            "Invalid target_type. Must be one of: {}",
+            valid_types.join(", ")
+        )));
+    }
+
+    let valid_reasons = ["spam", "inappropriate", "copyright", "incorrect", "other"];
+    if !valid_reasons.contains(&dto.reason.as_str()) {
+        return Err(crate::error::AppError::BadRequest(format!(
+            "Invalid reason. Must be one of: {}",
+            valid_reasons.join(", ")
+        )));
+    }
+
+    let report = service::create_report(
+        &state.db,
+        user.id,
+        &dto.target_type,
+        dto.target_id,
+        &dto.reason,
+        dto.details.as_deref(),
+    )
+    .await?;
+
+    Ok(Json(report))
+}
+
+/// Public reports router (authenticated)
+pub fn public_router(app_config: AppConfig) -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_report))
+        .layer(axum::middleware::from_fn_with_state(
+            app_config,
+            crate::middleware::auth_middleware,
+        ))
+}
+
+// ─── Admin ───────────────────────────────────────────────────────────────────
+
+/// GET /api/v1/admin/reports
+#[utoipa::path(
+    get,
+    path = "/api/v1/admin/reports",
+    tag = "admin",
+    security(("bearer_auth" = [])),
+    params(
+        ("status" = Option<String>, Query, description = "상태 필터 (pending, reviewed, dismissed, actioned)"),
+        ("target_type" = Option<String>, Query, description = "대상 타입 필터"),
+        ("page" = Option<u64>, Query, description = "페이지 번호"),
+        ("per_page" = Option<u64>, Query, description = "페이지당 개수")
+    ),
+    responses(
+        (status = 200, description = "Report list", body = PaginatedResponse<ReportListItem>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden")
+    )
+)]
+async fn admin_list_reports(
+    State(state): State<AppState>,
+    _extension: axum::Extension<User>,
+    Query(query): Query<AdminReportListQuery>,
+) -> AppResult<Json<PaginatedResponse<ReportListItem>>> {
+    let reports = service::admin_list_reports(&state.db, query).await?;
+    Ok(Json(reports))
+}
+
+/// PATCH /api/v1/admin/reports/{id}
+#[utoipa::path(
+    patch,
+    path = "/api/v1/admin/reports/{id}",
+    tag = "admin",
+    security(("bearer_auth" = [])),
+    params(
+        ("id" = Uuid, Path, description = "Report ID")
+    ),
+    request_body = UpdateReportStatusDto,
+    responses(
+        (status = 200, description = "Report updated", body = ReportListItem),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Report not found")
+    )
+)]
+async fn admin_update_report(
+    State(state): State<AppState>,
+    axum::Extension(user): axum::Extension<User>,
+    Path(report_id): Path<Uuid>,
+    Json(dto): Json<UpdateReportStatusDto>,
+) -> AppResult<Json<ReportListItem>> {
+    let report =
+        service::admin_update_report_status(&state.db, report_id, user.id, dto).await?;
+    Ok(Json(report))
+}
+
+/// Admin reports router
+pub fn admin_router(app_config: AppConfig) -> Router<AppState> {
+    Router::new()
+        .route("/", get(admin_list_reports))
+        .route("/{id}", patch(admin_update_report))
+        .layer(axum::middleware::from_fn_with_state(
+            app_config.clone(),
+            crate::middleware::auth_middleware,
+        ))
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
+}

--- a/packages/api-server/src/domains/reports/mod.rs
+++ b/packages/api-server/src/domains/reports/mod.rs
@@ -1,0 +1,9 @@
+//! Reports domain module
+//!
+//! 콘텐츠 신고 관련 API 핸들러 및 비즈니스 로직
+
+pub mod dto;
+pub mod handlers;
+pub mod service;
+
+pub use handlers::{admin_router, public_router};

--- a/packages/api-server/src/domains/reports/service.rs
+++ b/packages/api-server/src/domains/reports/service.rs
@@ -1,0 +1,208 @@
+//! Reports service
+//!
+//! 콘텐츠 신고 비즈니스 로직
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
+};
+use uuid::Uuid;
+
+use crate::{
+    entities::content_reports::{ActiveModel, Column, Entity as ContentReports},
+    error::{AppError, AppResult},
+    utils::pagination::{PaginatedResponse, Pagination},
+};
+
+use super::dto::{
+    AdminReportListQuery, ReportListItem, ReportResponse, ReporterInfo, UpdateReportStatusDto,
+};
+
+/// 신고 생성
+pub async fn create_report(
+    db: &DatabaseConnection,
+    reporter_id: Uuid,
+    target_type: &str,
+    target_id: Uuid,
+    reason: &str,
+    details: Option<&str>,
+) -> AppResult<ReportResponse> {
+    // 중복 신고 방지
+    let existing = ContentReports::find()
+        .filter(Column::TargetType.eq(target_type))
+        .filter(Column::TargetId.eq(target_id))
+        .filter(Column::ReporterId.eq(reporter_id))
+        .one(db)
+        .await
+        .map_err(AppError::DatabaseError)?;
+
+    if existing.is_some() {
+        return Err(AppError::BadRequest(
+            "You have already reported this content".to_string(),
+        ));
+    }
+
+    let id = Uuid::new_v4();
+    let now = chrono::Utc::now().fixed_offset();
+
+    let report = ActiveModel {
+        id: Set(id),
+        target_type: Set(target_type.to_string()),
+        target_id: Set(target_id),
+        reporter_id: Set(reporter_id),
+        reason: Set(reason.to_string()),
+        details: Set(details.map(|d| d.to_string())),
+        status: Set("pending".to_string()),
+        resolution: Set(None),
+        reviewed_by: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    };
+
+    let inserted = report.insert(db).await.map_err(AppError::DatabaseError)?;
+
+    Ok(ReportResponse {
+        id: inserted.id,
+        target_type: inserted.target_type,
+        target_id: inserted.target_id,
+        reason: inserted.reason,
+        status: inserted.status,
+        created_at: inserted.created_at.with_timezone(&chrono::Utc),
+    })
+}
+
+/// Admin: 신고 목록 조회
+pub async fn admin_list_reports(
+    db: &DatabaseConnection,
+    query: AdminReportListQuery,
+) -> AppResult<PaginatedResponse<ReportListItem>> {
+    let pagination = Pagination {
+        page: query.page.unwrap_or(1),
+        per_page: query.per_page.unwrap_or(20),
+    };
+
+    let mut q = ContentReports::find();
+
+    if let Some(ref status) = query.status {
+        q = q.filter(Column::Status.eq(status.as_str()));
+    }
+    if let Some(ref target_type) = query.target_type {
+        q = q.filter(Column::TargetType.eq(target_type.as_str()));
+    }
+
+    q = q.order_by_desc(Column::CreatedAt);
+
+    let total = q
+        .clone()
+        .count(db)
+        .await
+        .map_err(AppError::DatabaseError)?;
+
+    let reports = q
+        .offset((pagination.page - 1) * pagination.per_page)
+        .limit(pagination.per_page)
+        .all(db)
+        .await
+        .map_err(AppError::DatabaseError)?;
+
+    // 신고자 정보 배치 로딩
+    let reporter_ids: Vec<Uuid> = reports.iter().map(|r| r.reporter_id).collect();
+    let users = crate::entities::users::Entity::find()
+        .filter(crate::entities::users::Column::Id.is_in(reporter_ids))
+        .all(db)
+        .await
+        .map_err(AppError::DatabaseError)?;
+
+    let users_map: std::collections::HashMap<Uuid, _> =
+        users.into_iter().map(|u| (u.id, u)).collect();
+
+    let items: Vec<ReportListItem> = reports
+        .into_iter()
+        .map(|r| {
+            let reporter = users_map
+                .get(&r.reporter_id)
+                .map(|u| ReporterInfo {
+                    id: u.id,
+                    username: u.username.clone(),
+                })
+                .unwrap_or_else(|| ReporterInfo {
+                    id: r.reporter_id,
+                    username: "Unknown".to_string(),
+                });
+
+            ReportListItem {
+                id: r.id,
+                target_type: r.target_type,
+                target_id: r.target_id,
+                reporter,
+                reason: r.reason,
+                details: r.details,
+                status: r.status,
+                resolution: r.resolution,
+                created_at: r.created_at.with_timezone(&chrono::Utc),
+                updated_at: r.updated_at.with_timezone(&chrono::Utc),
+            }
+        })
+        .collect();
+
+    Ok(PaginatedResponse::new(items, pagination, total))
+}
+
+/// Admin: 신고 상태 업데이트
+pub async fn admin_update_report_status(
+    db: &DatabaseConnection,
+    report_id: Uuid,
+    admin_id: Uuid,
+    dto: UpdateReportStatusDto,
+) -> AppResult<ReportListItem> {
+    let valid_statuses = ["pending", "reviewed", "dismissed", "actioned"];
+    if !valid_statuses.contains(&dto.status.as_str()) {
+        return Err(AppError::BadRequest(format!(
+            "Invalid status. Must be one of: {}",
+            valid_statuses.join(", ")
+        )));
+    }
+
+    let report = ContentReports::find_by_id(report_id)
+        .one(db)
+        .await
+        .map_err(AppError::DatabaseError)?
+        .ok_or(AppError::NotFound("Report not found".to_string()))?;
+
+    let mut active: ActiveModel = report.into();
+    active.status = Set(dto.status);
+    active.reviewed_by = Set(Some(admin_id));
+    active.updated_at = Set(chrono::Utc::now().fixed_offset());
+    if let Some(resolution) = dto.resolution {
+        active.resolution = Set(Some(resolution));
+    }
+
+    let updated = active.update(db).await.map_err(AppError::DatabaseError)?;
+
+    // 신고자 정보 로딩
+    let reporter = crate::entities::users::Entity::find_by_id(updated.reporter_id)
+        .one(db)
+        .await
+        .map_err(AppError::DatabaseError)?
+        .map(|u| ReporterInfo {
+            id: u.id,
+            username: u.username.clone(),
+        })
+        .unwrap_or_else(|| ReporterInfo {
+            id: updated.reporter_id,
+            username: "Unknown".to_string(),
+        });
+
+    Ok(ReportListItem {
+        id: updated.id,
+        target_type: updated.target_type,
+        target_id: updated.target_id,
+        reporter,
+        reason: updated.reason,
+        details: updated.details,
+        status: updated.status,
+        resolution: updated.resolution,
+        created_at: updated.created_at.with_timezone(&chrono::Utc),
+        updated_at: updated.updated_at.with_timezone(&chrono::Utc),
+    })
+}

--- a/packages/api-server/src/entities/content_reports.rs
+++ b/packages/api-server/src/entities/content_reports.rs
@@ -1,0 +1,38 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// ContentReports entity
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "content_reports")]
+pub struct Model {
+    #[sea_orm(primary_key, column_type = "Uuid")]
+    pub id: Uuid,
+
+    pub target_type: String,
+
+    pub target_id: Uuid,
+
+    pub reporter_id: Uuid,
+
+    pub reason: String,
+
+    #[sea_orm(nullable)]
+    pub details: Option<String>,
+
+    pub status: String,
+
+    #[sea_orm(nullable)]
+    pub resolution: Option<String>,
+
+    #[sea_orm(nullable)]
+    pub reviewed_by: Option<Uuid>,
+
+    pub created_at: DateTimeWithTimeZone,
+
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/packages/api-server/src/entities/mod.rs
+++ b/packages/api-server/src/entities/mod.rs
@@ -11,6 +11,7 @@ pub mod badges;
 pub mod categories;
 pub mod click_logs;
 pub mod comments;
+pub mod content_reports;
 pub mod curation_posts;
 pub mod curations;
 pub mod earnings;
@@ -96,6 +97,10 @@ pub use user_badges::Model as UserBadgesModel;
 pub use click_logs::ActiveModel as ClickLogsActiveModel;
 pub use click_logs::Entity as ClickLogs;
 pub use click_logs::Model as ClickLogsModel;
+
+pub use content_reports::ActiveModel as ContentReportsActiveModel;
+pub use content_reports::Entity as ContentReports;
+pub use content_reports::Model as ContentReportsModel;
 
 pub use earnings::ActiveModel as EarningsActiveModel;
 pub use earnings::Entity as Earnings;

--- a/packages/api-server/src/router.rs
+++ b/packages/api-server/src/router.rs
@@ -22,6 +22,7 @@ pub fn build_api_router(state: AppState) -> Router<AppState> {
         .nest("/rankings", domains::rankings::router(config.clone()))
         .nest("/badges", domains::badges::router(config.clone()))
         .nest("/earnings", domains::earnings::router(config.clone()))
+        .nest("/reports", domains::reports::public_router(config.clone()))
         .nest(
             "/admin",
             domains::admin::router(state.clone(), config.clone()),

--- a/packages/web/app/admin/content/page.tsx
+++ b/packages/web/app/admin/content/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useAdminPostList } from "@/lib/hooks/admin/useAdminPosts";
+import { useAdminReportList } from "@/lib/hooks/admin/useAdminReports";
+import { AdminPostTable } from "@/lib/components/admin/content/AdminPostTable";
+import { AdminPostTableSkeleton } from "@/lib/components/admin/content/AdminPostTableSkeleton";
+import { PostStatusFilter } from "@/lib/components/admin/content/PostStatusFilter";
+import { ReportTable } from "@/lib/components/admin/content/ReportTable";
+import { Pagination } from "@/lib/components/admin/audit/Pagination";
+import type { PostStatus } from "@/lib/api/admin/posts";
+import type { ReportStatus } from "@/lib/api/admin/reports";
+
+// ─── Tab types ───────────────────────────────────────────────────────────────
+
+type ContentTab = "posts" | "reports";
+
+const TAB_OPTIONS: { label: string; value: ContentTab }[] = [
+  { label: "Posts", value: "posts" },
+  { label: "Reports", value: "reports" },
+];
+
+const REPORT_STATUS_OPTIONS: {
+  label: string;
+  value: ReportStatus | undefined;
+  dotColor: string | null;
+}[] = [
+  { label: "All", value: undefined, dotColor: null },
+  { label: "Pending", value: "pending", dotColor: "bg-yellow-400" },
+  { label: "Reviewed", value: "reviewed", dotColor: "bg-blue-400" },
+  { label: "Actioned", value: "actioned", dotColor: "bg-emerald-400" },
+  { label: "Dismissed", value: "dismissed", dotColor: "bg-gray-400" },
+];
+
+// ─── Inner content ───────────────────────────────────────────────────────────
+
+function ContentManagementContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const currentTab = (searchParams.get("tab") as ContentTab) || "posts";
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const statusParam = searchParams.get("status");
+
+  // Posts state
+  const postStatus =
+    currentTab === "posts" && statusParam
+      ? (statusParam as PostStatus)
+      : undefined;
+
+  // Reports state
+  const reportStatus =
+    currentTab === "reports" && statusParam
+      ? (statusParam as ReportStatus)
+      : undefined;
+
+  const postListQuery = useAdminPostList({
+    page: currentTab === "posts" ? currentPage : 1,
+    perPage: 20,
+    status: postStatus,
+  });
+
+  const reportListQuery = useAdminReportList({
+    page: currentTab === "reports" ? currentPage : 1,
+    perPage: 20,
+    status: reportStatus,
+  });
+
+  const updateUrl = useCallback(
+    (params: Record<string, string | undefined>) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      Object.entries(params).forEach(([key, value]) => {
+        if (value === undefined || value === "") {
+          newParams.delete(key);
+        } else {
+          newParams.set(key, value);
+        }
+      });
+      router.replace(`/admin/content?${newParams.toString()}`);
+    },
+    [searchParams, router]
+  );
+
+  const handleTabChange = useCallback(
+    (tab: ContentTab) => {
+      updateUrl({ tab: tab === "posts" ? undefined : tab, status: undefined, page: "1" });
+    },
+    [updateUrl]
+  );
+
+  const handlePostStatusChange = useCallback(
+    (status: PostStatus | undefined) => {
+      updateUrl({ status, page: "1" });
+    },
+    [updateUrl]
+  );
+
+  const handleReportStatusChange = useCallback(
+    (status: ReportStatus | undefined) => {
+      updateUrl({ status, page: "1" });
+    },
+    [updateUrl]
+  );
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      updateUrl({ page: page.toString() });
+    },
+    [updateUrl]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+          Content Management
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Manage post visibility, status, and reports
+        </p>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-gray-200 dark:border-gray-800">
+        {TAB_OPTIONS.map(({ label, value }) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => handleTabChange(value)}
+            className={[
+              "px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px",
+              currentTab === value
+                ? "border-gray-900 dark:border-gray-100 text-gray-900 dark:text-gray-100"
+                : "border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300",
+            ].join(" ")}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Posts tab */}
+      {currentTab === "posts" && (
+        <>
+          <PostStatusFilter
+            currentStatus={postStatus}
+            onStatusChange={handlePostStatusChange}
+          />
+
+          {postListQuery.isLoading ? (
+            <AdminPostTableSkeleton />
+          ) : postListQuery.data ? (
+            <>
+              <AdminPostTable data={postListQuery.data.data} />
+              {postListQuery.data.pagination.total_pages > 1 && (
+                <Pagination
+                  currentPage={postListQuery.data.pagination.current_page}
+                  totalPages={postListQuery.data.pagination.total_pages}
+                  onPageChange={handlePageChange}
+                />
+              )}
+            </>
+          ) : (
+            <AdminPostTableSkeleton />
+          )}
+        </>
+      )}
+
+      {/* Reports tab */}
+      {currentTab === "reports" && (
+        <>
+          {/* Report status filter */}
+          <div
+            className="flex gap-2 flex-wrap"
+            role="group"
+            aria-label="Filter by report status"
+          >
+            {REPORT_STATUS_OPTIONS.map(({ label, value, dotColor }) => {
+              const isActive = reportStatus === value;
+              return (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => handleReportStatusChange(value)}
+                  aria-pressed={isActive}
+                  className={[
+                    "px-3 py-1.5 rounded-full text-sm transition-colors flex items-center gap-1.5",
+                    isActive
+                      ? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-medium"
+                      : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700",
+                  ].join(" ")}
+                >
+                  {dotColor && (
+                    <span
+                      className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`}
+                      aria-hidden="true"
+                    />
+                  )}
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+
+          {reportListQuery.isLoading ? (
+            <AdminPostTableSkeleton />
+          ) : reportListQuery.data ? (
+            <>
+              <ReportTable data={reportListQuery.data.data} />
+              {reportListQuery.data.pagination.total_pages > 1 && (
+                <Pagination
+                  currentPage={reportListQuery.data.pagination.current_page}
+                  totalPages={reportListQuery.data.pagination.total_pages}
+                  onPageChange={handlePageChange}
+                />
+              )}
+            </>
+          ) : (
+            <AdminPostTableSkeleton />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function ContentManagementPage() {
+  return (
+    <Suspense fallback={<AdminPostTableSkeleton />}>
+      <ContentManagementContent />
+    </Suspense>
+  );
+}

--- a/packages/web/app/api/v1/admin/posts/[postId]/route.ts
+++ b/packages/web/app/api/v1/admin/posts/[postId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+type RouteParams = {
+  params: Promise<{ postId: string }>;
+};
+
+/**
+ * PATCH /api/v1/admin/posts/[postId]
+ *
+ * Proxies admin post metadata update to Rust backend.
+ * Requires admin privileges.
+ *
+ * Body: { group_name?, artist_name?, context?, media_source?, status? }
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  const { postId } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/admin/posts/${postId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Admin post update proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/admin/posts/[postId]/status/route.ts
+++ b/packages/web/app/api/v1/admin/posts/[postId]/status/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+type RouteParams = {
+  params: Promise<{ postId: string }>;
+};
+
+/**
+ * PATCH /api/v1/admin/posts/[postId]/status
+ *
+ * Proxies to Rust backend admin post status update.
+ * Requires admin privileges.
+ *
+ * Body: { status: "active" | "hidden" | "deleted" }
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  const { postId } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/admin/posts/${postId}/status`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Admin post status proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/admin/posts/route.ts
+++ b/packages/web/app/api/v1/admin/posts/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+/**
+ * GET /api/v1/admin/posts
+ *
+ * Proxies to Rust backend admin posts list.
+ * Requires admin privileges.
+ *
+ * Query params forwarded: status, artist_name, group_name, context, user_id, sort, page, per_page
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  try {
+    const queryString = request.nextUrl.searchParams.toString();
+    const url = queryString
+      ? `${API_BASE_URL}/api/v1/admin/posts?${queryString}`
+      : `${API_BASE_URL}/api/v1/admin/posts`;
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Admin posts proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/admin/reports/[reportId]/route.ts
+++ b/packages/web/app/api/v1/admin/reports/[reportId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+type RouteParams = {
+  params: Promise<{ reportId: string }>;
+};
+
+/**
+ * PATCH /api/v1/admin/reports/[reportId]
+ *
+ * Proxies admin report status update to Rust backend.
+ * Requires admin privileges.
+ *
+ * Body: { status: "pending" | "reviewed" | "dismissed" | "actioned", resolution? }
+ */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  const { reportId } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/admin/reports/${reportId}`,
+      {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Admin report update proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/admin/reports/route.ts
+++ b/packages/web/app/api/v1/admin/reports/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+/**
+ * GET /api/v1/admin/reports
+ *
+ * Proxies admin report list to Rust backend.
+ * Requires admin privileges.
+ *
+ * Query params forwarded: status, target_type, page, per_page
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  try {
+    const queryString = request.nextUrl.searchParams.toString();
+    const url = queryString
+      ? `${API_BASE_URL}/api/v1/admin/reports?${queryString}`
+      : `${API_BASE_URL}/api/v1/admin/reports`;
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Admin reports proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/v1/reports/route.ts
+++ b/packages/web/app/api/v1/reports/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { API_BASE_URL } from "@/lib/server-env";
+
+/**
+ * POST /api/v1/reports
+ *
+ * Proxies report creation to Rust backend.
+ * Requires authentication (not admin).
+ *
+ * Body: { target_type, target_id, reason, details? }
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+
+    const response = await fetch(`${API_BASE_URL}/api/v1/reports`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${session.access_token}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const responseText = await response.text();
+    let data;
+    try {
+      data = JSON.parse(responseText);
+    } catch {
+      data = {
+        message: `Backend error: ${response.status} ${response.statusText}`,
+      };
+    }
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Report proxy error:", error);
+    }
+    return NextResponse.json(
+      { message: error instanceof Error ? error.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/lib/api/admin/posts.ts
+++ b/packages/web/lib/api/admin/posts.ts
@@ -1,0 +1,46 @@
+/**
+ * Admin Posts types — matches Rust API response shapes.
+ */
+
+export type PostStatus = "active" | "hidden" | "deleted";
+
+export interface PostUserInfo {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  rank: string;
+}
+
+export interface MediaSourceDto {
+  type: string;
+  description?: string;
+}
+
+export interface AdminPostListItem {
+  id: string;
+  user: PostUserInfo;
+  image_url: string;
+  media_source: MediaSourceDto;
+  title?: string;
+  artist_name?: string;
+  group_name?: string;
+  context?: string;
+  spot_count: number;
+  view_count: number;
+  comment_count: number;
+  status: PostStatus;
+  created_at: string;
+  post_magazine_title?: string;
+}
+
+export interface PaginationMeta {
+  current_page: number;
+  per_page: number;
+  total_items: number;
+  total_pages: number;
+}
+
+export interface AdminPostListResponse {
+  data: AdminPostListItem[];
+  pagination: PaginationMeta;
+}

--- a/packages/web/lib/api/admin/reports.ts
+++ b/packages/web/lib/api/admin/reports.ts
@@ -1,0 +1,35 @@
+/**
+ * Admin Reports types — matches Rust API response shapes.
+ */
+
+export type ReportStatus = "pending" | "reviewed" | "dismissed" | "actioned";
+
+export interface ReporterInfo {
+  id: string;
+  username: string;
+}
+
+export interface ReportListItem {
+  id: string;
+  target_type: string;
+  target_id: string;
+  reporter: ReporterInfo;
+  reason: string;
+  details: string | null;
+  status: ReportStatus;
+  resolution: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaginationMeta {
+  current_page: number;
+  per_page: number;
+  total_items: number;
+  total_pages: number;
+}
+
+export interface AdminReportListResponse {
+  data: ReportListItem[];
+  pagination: PaginationMeta;
+}

--- a/packages/web/lib/components/admin/AdminSidebar.tsx
+++ b/packages/web/lib/components/admin/AdminSidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import {
   ArrowLeft,
   LayoutDashboard,
+  FileText,
   ScanSearch,
   DollarSign,
   GitBranch,
@@ -24,6 +25,7 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
+  { href: "/admin/content", label: "Content", icon: FileText },
   { href: "/admin/editorial-candidates", label: "Editorial", icon: Sparkles },
   { href: "/admin/ai-audit", label: "AI Audit", icon: ScanSearch },
   { href: "/admin/ai-cost", label: "AI Cost", icon: DollarSign },

--- a/packages/web/lib/components/admin/content/AdminPostTable.tsx
+++ b/packages/web/lib/components/admin/content/AdminPostTable.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { MoreVertical, Pencil } from "lucide-react";
+import type { AdminPostListItem, PostStatus } from "@/lib/api/admin/posts";
+import { useUpdatePostStatus } from "@/lib/hooks/admin/useAdminPosts";
+import { PostEditModal } from "./PostEditModal";
+
+// ─── Status badge ────────────────────────────────────────────────────────────
+
+const STATUS_STYLES: Record<PostStatus, string> = {
+  active:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+  hidden:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  deleted: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+};
+
+function StatusBadge({ status }: { status: PostStatus }) {
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_STYLES[status] ?? ""}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// ─── Relative time ───────────────────────────────────────────────────────────
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ─── Action dropdown ─────────────────────────────────────────────────────────
+
+function ActionDropdown({
+  post,
+  onStatusChange,
+}: {
+  post: AdminPostListItem;
+  onStatusChange: (postId: string, status: PostStatus) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const actions: { label: string; status: PostStatus; color: string }[] = [];
+  if (post.status !== "active")
+    actions.push({
+      label: "Activate",
+      status: "active",
+      color: "text-emerald-600 dark:text-emerald-400",
+    });
+  if (post.status !== "hidden")
+    actions.push({
+      label: "Hide",
+      status: "hidden",
+      color: "text-yellow-600 dark:text-yellow-400",
+    });
+  if (post.status !== "deleted")
+    actions.push({
+      label: "Delete",
+      status: "deleted",
+      color: "text-red-600 dark:text-red-400",
+    });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        aria-label="Actions"
+      >
+        <MoreVertical className="w-4 h-4 text-gray-500" />
+      </button>
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute right-0 top-8 z-20 w-32 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1">
+            {actions.map(({ label, status, color }) => (
+              <button
+                key={status}
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  onStatusChange(post.id, status);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 ${color}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Table ───────────────────────────────────────────────────────────────────
+
+interface AdminPostTableProps {
+  data: AdminPostListItem[];
+}
+
+export function AdminPostTable({ data }: AdminPostTableProps) {
+  const mutation = useUpdatePostStatus();
+  const [editingPost, setEditingPost] = useState<AdminPostListItem | null>(null);
+
+  function handleStatusChange(postId: string, status: PostStatus) {
+    if (
+      status === "deleted" &&
+      !window.confirm("Are you sure you want to delete this post?")
+    ) {
+      return;
+    }
+    mutation.mutate({ postId, status });
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        No posts found
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+      <table className="w-full table-fixed">
+        <colgroup>
+          <col className="w-14" />
+          <col />
+          <col className="w-28" />
+          <col className="w-20" />
+          <col className="w-16" />
+          <col className="w-16" />
+          <col className="w-24" />
+          <col className="w-10" />
+        </colgroup>
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-800">
+            {["", "Title / Artist", "User", "Status", "Views", "Spots", "Date", ""].map(
+              (h) => (
+                <th
+                  key={h || "spacer"}
+                  className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((post) => (
+            <tr
+              key={post.id}
+              className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+            >
+              {/* Thumbnail */}
+              <td className="px-3 py-2">
+                <Image
+                  src={post.image_url}
+                  alt=""
+                  width={40}
+                  height={40}
+                  className="rounded-md object-cover w-10 h-10"
+                />
+              </td>
+
+              {/* Title / Artist */}
+              <td className="px-3 py-2 truncate">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  {post.title || post.artist_name || "Untitled"}
+                </p>
+                {post.group_name && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {post.group_name}
+                  </p>
+                )}
+              </td>
+
+              {/* User */}
+              <td className="px-3 py-2">
+                <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
+                  {post.user.username}
+                </p>
+              </td>
+
+              {/* Status */}
+              <td className="px-3 py-2">
+                <StatusBadge status={post.status} />
+              </td>
+
+              {/* Views */}
+              <td className="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 tabular-nums">
+                {post.view_count.toLocaleString()}
+              </td>
+
+              {/* Spots */}
+              <td className="px-3 py-2 text-xs text-gray-600 dark:text-gray-400 tabular-nums">
+                {post.spot_count}
+              </td>
+
+              {/* Date */}
+              <td
+                className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400"
+                title={new Date(post.created_at).toLocaleString()}
+              >
+                {relativeTime(post.created_at)}
+              </td>
+
+              {/* Actions */}
+              <td className="px-3 py-2">
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => setEditingPost(post)}
+                    className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                    aria-label="Edit post"
+                  >
+                    <Pencil className="w-3.5 h-3.5 text-gray-500" />
+                  </button>
+                  <ActionDropdown
+                    post={post}
+                    onStatusChange={handleStatusChange}
+                  />
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {editingPost && (
+        <PostEditModal
+          post={editingPost}
+          onClose={() => setEditingPost(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/content/AdminPostTableSkeleton.tsx
+++ b/packages/web/lib/components/admin/content/AdminPostTableSkeleton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+const SKELETON_ROWS = 10;
+
+export function AdminPostTableSkeleton() {
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+      <table className="w-full table-fixed">
+        <colgroup>
+          <col className="w-14" />
+          <col />
+          <col className="w-28" />
+          <col className="w-20" />
+          <col className="w-16" />
+          <col className="w-16" />
+          <col className="w-24" />
+          <col className="w-10" />
+        </colgroup>
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-800">
+            {["", "Title / Artist", "User", "Status", "Views", "Spots", "Date", ""].map(
+              (h) => (
+                <th
+                  key={h || "spacer"}
+                  className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: SKELETON_ROWS }, (_, i) => (
+            <tr
+              key={i}
+              className="border-b border-gray-50 dark:border-gray-800/50"
+            >
+              <td className="px-3 py-2">
+                <div className="w-10 h-10 rounded-md animate-pulse bg-gray-200 dark:bg-gray-800" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-3 w-32 animate-pulse bg-gray-200 dark:bg-gray-800 rounded mb-1" />
+                <div className="h-2.5 w-20 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-3 w-16 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-5 w-14 animate-pulse bg-gray-200 dark:bg-gray-800 rounded-full" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-3 w-8 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-3 w-6 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-3 w-14 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+              <td className="px-3 py-2">
+                <div className="h-4 w-4 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/content/PostEditModal.tsx
+++ b/packages/web/lib/components/admin/content/PostEditModal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { useAdminUpdatePost } from "@/lib/hooks/admin/useAdminPostEdit";
+import type { AdminPostListItem } from "@/lib/api/admin/posts";
+
+interface PostEditModalProps {
+  post: AdminPostListItem;
+  onClose: () => void;
+}
+
+export function PostEditModal({ post, onClose }: PostEditModalProps) {
+  const [artistName, setArtistName] = useState(post.artist_name ?? "");
+  const [groupName, setGroupName] = useState(post.group_name ?? "");
+  const [context, setContext] = useState(post.context ?? "");
+
+  const mutation = useAdminUpdatePost();
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, [onClose]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    mutation.mutate(
+      {
+        postId: post.id,
+        artist_name: artistName || undefined,
+        group_name: groupName || undefined,
+        context: context || undefined,
+      },
+      { onSuccess: onClose }
+    );
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div className="absolute inset-0 bg-black/60" />
+      <div
+        className="relative w-full max-w-lg bg-white dark:bg-gray-900 rounded-xl shadow-xl p-6 space-y-5"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label="Edit post"
+      >
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Edit Post
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+              Artist Name
+            </label>
+            <input
+              type="text"
+              value={artistName}
+              onChange={(e) => setArtistName(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              maxLength={256}
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+              Group Name
+            </label>
+            <input
+              type="text"
+              value={groupName}
+              onChange={(e) => setGroupName(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              maxLength={256}
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1">
+              Context
+            </label>
+            <textarea
+              value={context}
+              onChange={(e) => setContext(e.target.value)}
+              rows={3}
+              className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+              maxLength={512}
+            />
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="flex-1 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+            >
+              {mutation.isPending ? "Saving..." : "Save Changes"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/content/PostStatusFilter.tsx
+++ b/packages/web/lib/components/admin/content/PostStatusFilter.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { PostStatus } from "@/lib/api/admin/posts";
+
+interface PostStatusFilterProps {
+  currentStatus: PostStatus | undefined;
+  onStatusChange: (status: PostStatus | undefined) => void;
+}
+
+const STATUS_OPTIONS: {
+  label: string;
+  value: PostStatus | undefined;
+  dotColor: string | null;
+}[] = [
+  { label: "All", value: undefined, dotColor: null },
+  { label: "Active", value: "active", dotColor: "bg-emerald-400" },
+  { label: "Hidden", value: "hidden", dotColor: "bg-yellow-400" },
+  { label: "Deleted", value: "deleted", dotColor: "bg-red-400" },
+];
+
+export function PostStatusFilter({
+  currentStatus,
+  onStatusChange,
+}: PostStatusFilterProps) {
+  return (
+    <div
+      className="flex gap-2 flex-wrap"
+      role="group"
+      aria-label="Filter by status"
+    >
+      {STATUS_OPTIONS.map(({ label, value, dotColor }) => {
+        const isActive = currentStatus === value;
+
+        return (
+          <button
+            key={label}
+            type="button"
+            onClick={() => onStatusChange(value)}
+            aria-pressed={isActive}
+            className={[
+              "px-3 py-1.5 rounded-full text-sm transition-colors flex items-center gap-1.5",
+              isActive
+                ? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-medium"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700",
+            ].join(" ")}
+          >
+            {dotColor && (
+              <span
+                className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`}
+                aria-hidden="true"
+              />
+            )}
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/content/ReportTable.tsx
+++ b/packages/web/lib/components/admin/content/ReportTable.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { MoreVertical } from "lucide-react";
+import type { ReportListItem, ReportStatus } from "@/lib/api/admin/reports";
+import { useUpdateReportStatus } from "@/lib/hooks/admin/useAdminReports";
+
+const STATUS_STYLES: Record<ReportStatus, string> = {
+  pending:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  reviewed:
+    "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  dismissed:
+    "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  actioned:
+    "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+};
+
+function StatusBadge({ status }: { status: ReportStatus }) {
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_STYLES[status] ?? ""}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function ActionDropdown({
+  report,
+  onStatusChange,
+}: {
+  report: ReportListItem;
+  onStatusChange: (reportId: string, status: ReportStatus) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const actions: { label: string; status: ReportStatus; color: string }[] = [];
+  if (report.status !== "reviewed")
+    actions.push({
+      label: "Mark Reviewed",
+      status: "reviewed",
+      color: "text-blue-600 dark:text-blue-400",
+    });
+  if (report.status !== "actioned")
+    actions.push({
+      label: "Mark Actioned",
+      status: "actioned",
+      color: "text-emerald-600 dark:text-emerald-400",
+    });
+  if (report.status !== "dismissed")
+    actions.push({
+      label: "Dismiss",
+      status: "dismissed",
+      color: "text-gray-600 dark:text-gray-400",
+    });
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        aria-label="Actions"
+      >
+        <MoreVertical className="w-4 h-4 text-gray-500" />
+      </button>
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute right-0 top-8 z-20 w-36 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1">
+            {actions.map(({ label, status, color }) => (
+              <button
+                key={status}
+                type="button"
+                onClick={() => {
+                  setOpen(false);
+                  onStatusChange(report.id, status);
+                }}
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-800 ${color}`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface ReportTableProps {
+  data: ReportListItem[];
+}
+
+export function ReportTable({ data }: ReportTableProps) {
+  const mutation = useUpdateReportStatus();
+
+  function handleStatusChange(reportId: string, status: ReportStatus) {
+    mutation.mutate({ reportId, status });
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+        No reports found
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-xl overflow-hidden">
+      <table className="w-full table-fixed">
+        <colgroup>
+          <col className="w-20" />
+          <col />
+          <col className="w-28" />
+          <col className="w-32" />
+          <col className="w-20" />
+          <col className="w-24" />
+          <col className="w-10" />
+        </colgroup>
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-800">
+            {["Type", "Reason / Details", "Reporter", "Target ID", "Status", "Date", ""].map(
+              (h) => (
+                <th
+                  key={h || "spacer"}
+                  className="px-3 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider"
+                >
+                  {h}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((report) => (
+            <tr
+              key={report.id}
+              className="border-b border-gray-50 dark:border-gray-800/50 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors"
+            >
+              <td className="px-3 py-2">
+                <span className="text-xs font-medium text-gray-700 dark:text-gray-300 uppercase">
+                  {report.target_type}
+                </span>
+              </td>
+
+              <td className="px-3 py-2 truncate">
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  {report.reason}
+                </p>
+                {report.details && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    {report.details}
+                  </p>
+                )}
+              </td>
+
+              <td className="px-3 py-2">
+                <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
+                  {report.reporter.username}
+                </p>
+              </td>
+
+              <td className="px-3 py-2">
+                <p
+                  className="text-xs text-gray-500 dark:text-gray-400 truncate font-mono"
+                  title={report.target_id}
+                >
+                  {report.target_id.slice(0, 8)}...
+                </p>
+              </td>
+
+              <td className="px-3 py-2">
+                <StatusBadge status={report.status} />
+              </td>
+
+              <td
+                className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400"
+                title={new Date(report.created_at).toLocaleString()}
+              >
+                {relativeTime(report.created_at)}
+              </td>
+
+              <td className="px-3 py-2">
+                <ActionDropdown
+                  report={report}
+                  onStatusChange={handleStatusChange}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/web/lib/components/detail/ReportErrorButton.tsx
+++ b/packages/web/lib/components/detail/ReportErrorButton.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { AlertCircle, X, Send } from "lucide-react";
+import { useSubmitReport } from "@/lib/hooks/useReport";
+import { toast } from "sonner";
 
 type Props = {
   postId?: string; // Made optional as per new usage in floating controls
@@ -11,7 +13,8 @@ type Props = {
 export function ReportErrorButton({ postId, size = "sm" }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [suggestion, setSuggestion] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submitReport = useSubmitReport();
+  const isSubmitting = submitReport.isPending;
   const modalRef = useRef<HTMLDivElement>(null);
 
   // Close modal when clicking outside
@@ -35,21 +38,36 @@ export function ReportErrorButton({ postId, size = "sm" }: Props) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setIsSubmitting(true);
 
-    // Simulate API call
-    console.log("Report Error Submitted:", {
-      postId: postId || "unknown-post",
-      suggest: suggestion,
-    });
-
-    // Reset and close after a short delay to simulate network request
-    setTimeout(() => {
+    if (!postId) {
+      toast.success("소중한 의견 감사합니다! 빠르게 확인해보겠습니다.");
       setSuggestion("");
-      setIsSubmitting(false);
       setIsOpen(false);
-      alert("소중한 의견 감사합니다! 빠르게 확인해보겠습니다.");
-    }, 500);
+      return;
+    }
+
+    submitReport.mutate(
+      {
+        target_type: "post",
+        target_id: postId,
+        reason: "incorrect",
+        details: suggestion,
+      },
+      {
+        onSuccess: () => {
+          toast.success("소중한 의견 감사합니다! 빠르게 확인해보겠습니다.");
+          setSuggestion("");
+          setIsOpen(false);
+        },
+        onError: (error) => {
+          toast.error(
+            error.message === "You have already reported this content"
+              ? "이미 신고한 콘텐츠입니다."
+              : "신고 전송에 실패했습니다. 다시 시도해주세요."
+          );
+        },
+      }
+    );
   };
 
   const buttonClasses =

--- a/packages/web/lib/components/shared/ReportModal.tsx
+++ b/packages/web/lib/components/shared/ReportModal.tsx
@@ -4,11 +4,13 @@ import { useState } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { useSubmitReport } from "@/lib/hooks/useReport";
 
 export interface ReportModalProps {
   open: boolean;
   onClose: () => void;
   targetType?: string;
+  targetId?: string;
   className?: string;
 }
 
@@ -24,19 +26,49 @@ export function ReportModal({
   open,
   onClose,
   targetType = "content",
+  targetId,
   className,
 }: ReportModalProps) {
   const [reason, setReason] = useState<string>("");
   const [details, setDetails] = useState("");
+  const submitReport = useSubmitReport();
 
   if (!open) return null;
 
   const handleSubmit = () => {
     if (!reason) return;
-    toast.success("Report submitted. Thank you for your feedback.");
-    setReason("");
-    setDetails("");
-    onClose();
+
+    if (!targetId) {
+      toast.success("Report submitted. Thank you for your feedback.");
+      setReason("");
+      setDetails("");
+      onClose();
+      return;
+    }
+
+    submitReport.mutate(
+      {
+        target_type: targetType === "content" ? "post" : targetType,
+        target_id: targetId,
+        reason,
+        details: details || undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Report submitted. Thank you for your feedback.");
+          setReason("");
+          setDetails("");
+          onClose();
+        },
+        onError: (error) => {
+          toast.error(
+            error.message === "You have already reported this content"
+              ? "You have already reported this content."
+              : "Failed to submit report. Please try again."
+          );
+        },
+      }
+    );
   };
 
   return (
@@ -108,10 +140,10 @@ export function ReportModal({
           </button>
           <button
             onClick={handleSubmit}
-            disabled={!reason}
+            disabled={!reason || submitReport.isPending}
             className="flex-1 rounded-lg bg-destructive px-4 py-2.5 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
           >
-            Submit Report
+            {submitReport.isPending ? "Submitting..." : "Submit Report"}
           </button>
         </div>
       </div>

--- a/packages/web/lib/hooks/admin/useAdminPostEdit.ts
+++ b/packages/web/lib/hooks/admin/useAdminPostEdit.ts
@@ -1,0 +1,35 @@
+/**
+ * Hook for admin post metadata editing.
+ *
+ * PATCH /api/v1/admin/posts/:postId
+ */
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface UpdatePostParams {
+  postId: string;
+  group_name?: string;
+  artist_name?: string;
+  context?: string;
+}
+
+export function useAdminUpdatePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ postId, ...body }: UpdatePostParams) => {
+      const res = await fetch(`/api/v1/admin/posts/${postId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to update post: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
+    },
+  });
+}

--- a/packages/web/lib/hooks/admin/useAdminPosts.ts
+++ b/packages/web/lib/hooks/admin/useAdminPosts.ts
@@ -1,0 +1,95 @@
+/**
+ * React Query hooks for admin post management.
+ *
+ * - useAdminPostList → GET /api/v1/admin/posts
+ * - useUpdatePostStatus → PATCH /api/v1/admin/posts/:postId/status
+ */
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  AdminPostListResponse,
+  PostStatus,
+} from "@/lib/api/admin/posts";
+
+// ─── Shared fetcher ───────────────────────────────────────────────────────────
+
+async function adminFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`Admin API error: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+interface UseAdminPostListParams {
+  page: number;
+  perPage?: number;
+  status?: PostStatus;
+}
+
+/**
+ * Fetches a paginated, filterable list of admin posts.
+ */
+export function useAdminPostList(
+  params: UseAdminPostListParams
+): UseQueryResult<AdminPostListResponse> {
+  const { page, perPage = 20, status } = params;
+
+  return useQuery<AdminPostListResponse>({
+    queryKey: ["admin", "posts", "list", page, perPage, status],
+    queryFn: ({ signal }: { signal?: AbortSignal }) => {
+      const searchParams = new URLSearchParams({
+        page: String(page),
+        per_page: String(perPage),
+      });
+      if (status !== undefined) {
+        searchParams.set("status", status);
+      }
+      return adminFetch<AdminPostListResponse>(
+        `/api/v1/admin/posts?${searchParams.toString()}`,
+        { signal }
+      );
+    },
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Mutation to update a post's status.
+ * Invalidates the admin posts list on success.
+ */
+export function useUpdatePostStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      postId,
+      status,
+    }: {
+      postId: string;
+      status: PostStatus;
+    }) => {
+      const res = await fetch(`/api/v1/admin/posts/${postId}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to update status: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "posts"] });
+    },
+  });
+}

--- a/packages/web/lib/hooks/admin/useAdminReports.ts
+++ b/packages/web/lib/hooks/admin/useAdminReports.ts
@@ -1,0 +1,90 @@
+/**
+ * React Query hooks for admin report management.
+ *
+ * - useAdminReportList → GET /api/v1/admin/reports
+ * - useUpdateReportStatus → PATCH /api/v1/admin/reports/:reportId
+ */
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  AdminReportListResponse,
+  ReportStatus,
+} from "@/lib/api/admin/reports";
+
+async function adminFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`Admin API error: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+interface UseAdminReportListParams {
+  page: number;
+  perPage?: number;
+  status?: ReportStatus;
+  targetType?: string;
+}
+
+export function useAdminReportList(
+  params: UseAdminReportListParams
+): UseQueryResult<AdminReportListResponse> {
+  const { page, perPage = 20, status, targetType } = params;
+
+  return useQuery<AdminReportListResponse>({
+    queryKey: ["admin", "reports", "list", page, perPage, status, targetType],
+    queryFn: ({ signal }: { signal?: AbortSignal }) => {
+      const searchParams = new URLSearchParams({
+        page: String(page),
+        per_page: String(perPage),
+      });
+      if (status !== undefined) {
+        searchParams.set("status", status);
+      }
+      if (targetType !== undefined) {
+        searchParams.set("target_type", targetType);
+      }
+      return adminFetch<AdminReportListResponse>(
+        `/api/v1/admin/reports?${searchParams.toString()}`,
+        { signal }
+      );
+    },
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useUpdateReportStatus() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      reportId,
+      status,
+      resolution,
+    }: {
+      reportId: string;
+      status: ReportStatus;
+      resolution?: string;
+    }) => {
+      const res = await fetch(`/api/v1/admin/reports/${reportId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status, resolution }),
+      });
+      if (!res.ok) {
+        throw new Error(`Failed to update report: ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "reports"] });
+    },
+  });
+}

--- a/packages/web/lib/hooks/useReport.ts
+++ b/packages/web/lib/hooks/useReport.ts
@@ -1,0 +1,33 @@
+/**
+ * Hook for submitting content reports.
+ *
+ * POST /api/v1/reports
+ */
+
+import { useMutation } from "@tanstack/react-query";
+
+interface SubmitReportParams {
+  target_type: string;
+  target_id: string;
+  reason: string;
+  details?: string;
+}
+
+export function useSubmitReport() {
+  return useMutation({
+    mutationFn: async (params: SubmitReportParams) => {
+      const res = await fetch("/api/v1/reports", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.message || `Failed to submit report: ${res.status}`
+        );
+      }
+      return res.json();
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Closes #8 (Phase 1–3)

- **Phase 1 — Post Operations**: Admin post list with status filtering, hide/activate/delete actions with Meilisearch sync, BFF proxy routes, `/admin/content` page with sidebar link
- **Phase 2 — Report Queue**: `content_reports` DB migration + RLS, Rust reports domain (entity/DTO/service/handlers), `ReportModal`/`ReportErrorButton` real API integration, admin Reports tab with status management
- **Phase 3 — Metadata Edit**: Admin post metadata editing (artist, group, context) via inline modal, `PATCH /api/v1/admin/posts/{id}` with Meilisearch re-indexing

### Key changes (37 files, +2469 lines)

**Rust API** (`packages/api-server`)
- `PostListItem` now includes `status` field
- `admin_update_post_status()` syncs Meilisearch (delete on hidden/deleted, update on active)
- New `reports` domain: entity, DTOs, service, handlers (`POST /reports`, `GET/PATCH /admin/reports`)
- New `admin_update_post()` endpoint for metadata editing without ownership check
- `content_reports` migration SQL

**Next.js BFF** (`packages/web/app/api/v1/`)
- `GET /admin/posts` — proxy with Supabase session token
- `PATCH /admin/posts/[postId]/status` — status change proxy
- `PATCH /admin/posts/[postId]` — metadata edit proxy
- `POST /reports` — authenticated report submission proxy
- `GET /admin/reports`, `PATCH /admin/reports/[reportId]` — admin report management proxy

**Admin UI** (`packages/web`)
- `/admin/content` page with Posts / Reports tabs
- `AdminPostTable` with status badges, action dropdown, edit modal
- `PostStatusFilter`, `ReportTable`, `PostEditModal` components
- `useAdminPosts`, `useAdminReports`, `useAdminPostEdit`, `useReport` hooks
- `AdminSidebar` — added "Content" nav item

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] TypeScript type check passes for new files (verified)
- [ ] Navigate to `/admin/content` — post list loads with status column
- [ ] Filter posts by status (All/Active/Hidden/Deleted)
- [ ] Hide a post → verify Meilisearch removal
- [ ] Activate a hidden post → verify Meilisearch re-indexing
- [ ] Click Edit on a post → modify metadata → save
- [ ] Switch to Reports tab → verify report list loads
- [ ] Submit a report via ReportModal → verify it appears in admin queue
- [ ] Update report status (reviewed/actioned/dismissed)
- [ ] Run `06_content_reports.sql` migration in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)