### PR TITLE
feat(home): Decoded Pick 큐레이션 섹션 추가

### DIFF
--- a/packages/web/app/admin/picks/page.tsx
+++ b/packages/web/app/admin/picks/page.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { useState, useCallback, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import {
+  useAdminPickList,
+  useCreatePick,
+  useUpdatePick,
+  useDeletePick,
+} from "@/lib/hooks/admin/useAdminPicks";
+import { Pagination } from "@/lib/components/admin/audit/Pagination";
+import type { DecodedPickListItem } from "@/lib/api/admin/picks";
+import { createBrowserClient } from "@supabase/ssr";
+
+// ─── Post search hook (Supabase direct for autocomplete) ────────────────────
+
+function usePostSearch(query: string) {
+  const [results, setResults] = useState<
+    { id: string; image_url: string | null; artist_name: string | null; group_name: string | null; context: string | null }[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+
+  const search = useCallback(async (q: string) => {
+    if (q.length < 2) {
+      setResults([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+      );
+      const { data } = await supabase
+        .from("posts")
+        .select("id, image_url, artist_name, group_name, context")
+        .eq("status", "active")
+        .or(`artist_name.ilike.%${q}%,group_name.ilike.%${q}%,context.ilike.%${q}%`)
+        .order("created_at", { ascending: false })
+        .limit(10);
+      setResults(data ?? []);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { results, loading, search, setResults };
+}
+
+// ─── Create Pick Modal ──────────────────────────────────────────────────────
+
+function CreatePickModal({ onClose }: { onClose: () => void }) {
+  const [postQuery, setPostQuery] = useState("");
+  const [selectedPost, setSelectedPost] = useState<{
+    id: string; image_url: string | null; artist_name: string | null; group_name: string | null;
+  } | null>(null);
+  const [pickDate, setPickDate] = useState(new Date().toISOString().slice(0, 10));
+  const [note, setNote] = useState("");
+  const [curatedBy, setCuratedBy] = useState<"editor" | "ai">("editor");
+  const { results, loading, search, setResults } = usePostSearch(postQuery);
+  const createPick = useCreatePick();
+
+  const handleSearch = (value: string) => {
+    setPostQuery(value);
+    search(value);
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedPost) return;
+    await createPick.mutateAsync({
+      post_id: selectedPost.id,
+      pick_date: pickDate,
+      note: note || undefined,
+      curated_by: curatedBy,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-full max-w-lg rounded-xl bg-gray-900 p-6 shadow-2xl">
+        <h3 className="mb-6 text-lg font-semibold text-white">Create Decoded Pick</h3>
+
+        {/* Post Search */}
+        <label className="mb-1 block text-xs font-medium text-gray-400">Post</label>
+        {selectedPost ? (
+          <div className="mb-4 flex items-center gap-3 rounded-lg bg-gray-800 p-3">
+            {selectedPost.image_url && (
+              <Image
+                src={selectedPost.image_url}
+                alt=""
+                width={48}
+                height={48}
+                className="rounded-md object-cover"
+              />
+            )}
+            <div className="flex-1 text-sm text-white">
+              {selectedPost.artist_name || selectedPost.group_name || "Unknown"}
+            </div>
+            <button
+              onClick={() => { setSelectedPost(null); setPostQuery(""); }}
+              className="text-xs text-gray-500 hover:text-white"
+            >
+              Change
+            </button>
+          </div>
+        ) : (
+          <div className="relative mb-4">
+            <input
+              type="text"
+              value={postQuery}
+              onChange={(e) => handleSearch(e.target.value)}
+              placeholder="Search by artist, group, or context..."
+              className="w-full rounded-lg bg-gray-800 px-4 py-2.5 text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            {(results.length > 0 || loading) && (
+              <div className="absolute left-0 right-0 top-full z-10 mt-1 max-h-60 overflow-y-auto rounded-lg bg-gray-800 shadow-xl">
+                {loading && <div className="px-4 py-2 text-xs text-gray-500">Searching...</div>}
+                {results.map((post) => (
+                  <button
+                    key={post.id}
+                    onClick={() => {
+                      setSelectedPost(post);
+                      setResults([]);
+                      setPostQuery("");
+                    }}
+                    className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-gray-700"
+                  >
+                    {post.image_url && (
+                      <Image
+                        src={post.image_url}
+                        alt=""
+                        width={32}
+                        height={32}
+                        className="rounded object-cover"
+                      />
+                    )}
+                    <span className="text-sm text-white">
+                      {post.artist_name || post.group_name || "Unknown"}
+                    </span>
+                    {post.context && (
+                      <span className="text-xs text-gray-500">{post.context}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Date */}
+        <label className="mb-1 block text-xs font-medium text-gray-400">Pick Date</label>
+        <input
+          type="date"
+          value={pickDate}
+          onChange={(e) => setPickDate(e.target.value)}
+          className="mb-4 w-full rounded-lg bg-gray-800 px-4 py-2.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+
+        {/* Note */}
+        <label className="mb-1 block text-xs font-medium text-gray-400">Note (optional)</label>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Why this pick?"
+          rows={2}
+          className="mb-4 w-full resize-none rounded-lg bg-gray-800 px-4 py-2.5 text-sm text-white placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+
+        {/* Curated By */}
+        <label className="mb-1 block text-xs font-medium text-gray-400">Curated By</label>
+        <div className="mb-6 flex gap-2">
+          {(["editor", "ai"] as const).map((val) => (
+            <button
+              key={val}
+              onClick={() => setCuratedBy(val)}
+              className={`rounded-lg px-4 py-2 text-xs font-medium transition ${
+                curatedBy === val
+                  ? "bg-primary text-black"
+                  : "bg-gray-800 text-gray-400 hover:text-white"
+              }`}
+            >
+              {val === "editor" ? "Editor" : "AI"}
+            </button>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="rounded-lg px-4 py-2 text-sm text-gray-400 hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!selectedPost || createPick.isPending}
+            className="rounded-lg bg-primary px-6 py-2 text-sm font-medium text-black disabled:opacity-40"
+          >
+            {createPick.isPending ? "Creating..." : "Create Pick"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Pick Row ────────────────────────────────────────────────────────────────
+
+function PickRow({
+  pick,
+  onToggleActive,
+  onDelete,
+}: {
+  pick: DecodedPickListItem;
+  onToggleActive: (id: string, active: boolean) => void;
+  onDelete: (id: string) => void;
+}) {
+  const displayName = pick.post?.artist_name || pick.post?.group_name || "Unknown";
+
+  return (
+    <tr className="border-b border-gray-800 hover:bg-gray-800/50">
+      <td className="px-4 py-3 text-sm text-white">{pick.pick_date}</td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3">
+          {pick.post?.image_url && (
+            <Image
+              src={pick.post.image_url}
+              alt=""
+              width={40}
+              height={40}
+              className="rounded-md object-cover"
+            />
+          )}
+          <span className="text-sm text-white">{displayName}</span>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <span
+          className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            pick.curated_by === "editor"
+              ? "bg-violet-500/20 text-violet-300"
+              : "bg-sky-500/20 text-sky-300"
+          }`}
+        >
+          {pick.curated_by === "editor" ? "Editor" : "AI"}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-sm text-gray-400 max-w-[200px] truncate">
+        {pick.note || "—"}
+      </td>
+      <td className="px-4 py-3">
+        <span
+          className={`inline-block h-2 w-2 rounded-full ${
+            pick.is_active ? "bg-emerald-400" : "bg-gray-600"
+          }`}
+        />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onToggleActive(pick.id, !pick.is_active)}
+            className="text-xs text-gray-400 hover:text-white"
+          >
+            {pick.is_active ? "Deactivate" : "Activate"}
+          </button>
+          <button
+            onClick={() => onDelete(pick.id)}
+            className="text-xs text-red-400 hover:text-red-300"
+          >
+            Delete
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+// ─── Main content ────────────────────────────────────────────────────────────
+
+function PickManagementContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+
+  const pickListQuery = useAdminPickList({ page: currentPage, perPage: 20 });
+  const updatePick = useUpdatePick();
+  const deletePick = useDeletePick();
+
+  const handlePageChange = (page: number) => {
+    const newParams = new URLSearchParams(searchParams.toString());
+    newParams.set("page", String(page));
+    router.replace(`/admin/picks?${newParams.toString()}`);
+  };
+
+  const handleToggleActive = (id: string, isActive: boolean) => {
+    updatePick.mutate({ pickId: id, is_active: isActive });
+  };
+
+  const handleDelete = (id: string) => {
+    if (confirm("Delete this pick?")) {
+      deletePick.mutate(id);
+    }
+  };
+
+  const picks = pickListQuery.data?.data ?? [];
+  const total = pickListQuery.data?.total ?? 0;
+  const totalPages = Math.ceil(total / 20);
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Decoded Pick</h1>
+          <p className="mt-1 text-sm text-gray-400">
+            Manage curated daily picks for the homepage
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="rounded-lg bg-primary px-5 py-2.5 text-sm font-medium text-black hover:bg-primary/90"
+        >
+          Create Pick
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-hidden rounded-xl border border-gray-800 bg-gray-900/50">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-gray-800 text-left">
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Date
+              </th>
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Post
+              </th>
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Curated By
+              </th>
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Note
+              </th>
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Active
+              </th>
+              <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {pickListQuery.isLoading ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-sm text-gray-500">
+                  Loading...
+                </td>
+              </tr>
+            ) : picks.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-12 text-center text-sm text-gray-500">
+                  No picks yet. Create your first pick!
+                </td>
+              </tr>
+            ) : (
+              picks.map((pick) => (
+                <PickRow
+                  key={pick.id}
+                  pick={pick}
+                  onToggleActive={handleToggleActive}
+                  onDelete={handleDelete}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="mt-4">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      )}
+
+      {/* Create Modal */}
+      {showCreate && <CreatePickModal onClose={() => setShowCreate(false)} />}
+    </div>
+  );
+}
+
+// ─── Page export ─────────────────────────────────────────────────────────────
+
+export default function AdminPicksPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-64 items-center justify-center text-gray-500">
+          Loading...
+        </div>
+      }
+    >
+      <PickManagementContent />
+    </Suspense>
+  );
+}

--- a/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
+++ b/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+
+/**
+ * PATCH /api/v1/admin/picks/:pickId
+ *
+ * Update a decoded pick (note, is_active, curated_by).
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ pickId: string }> }
+) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { pickId } = await params;
+  const body = await request.json();
+  const updates: Record<string, unknown> = {};
+
+  if ("note" in body) updates.note = body.note;
+  if ("is_active" in body) updates.is_active = body.is_active;
+  if ("curated_by" in body) updates.curated_by = body.curated_by;
+  if ("post_id" in body) updates.post_id = body.post_id;
+
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("decoded_picks")
+    .update(updates)
+    .eq("id", pickId)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}
+
+/**
+ * DELETE /api/v1/admin/picks/:pickId
+ *
+ * Delete a decoded pick.
+ */
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ pickId: string }> }
+) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { pickId } = await params;
+
+  const { error } = await supabase
+    .from("decoded_picks")
+    .delete()
+    .eq("id", pickId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/web/app/api/v1/admin/picks/route.ts
+++ b/packages/web/app/api/v1/admin/picks/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+
+/**
+ * GET /api/v1/admin/picks
+ *
+ * List decoded picks with joined post data.
+ * Query params: page, per_page
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const params = request.nextUrl.searchParams;
+  const page = Math.max(1, Number(params.get("page") || 1));
+  const perPage = Math.min(50, Math.max(1, Number(params.get("per_page") || 20)));
+  const from = (page - 1) * perPage;
+  const to = from + perPage - 1;
+
+  const { data, error, count } = await supabase
+    .from("decoded_picks")
+    .select(
+      "*, posts:post_id(id, image_url, artist_name, group_name, context)",
+      { count: "exact" }
+    )
+    .order("pick_date", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    data: (data ?? []).map((row: Record<string, unknown>) => ({
+      id: row.id,
+      post_id: row.post_id,
+      pick_date: row.pick_date,
+      note: row.note,
+      curated_by: row.curated_by,
+      is_active: row.is_active,
+      created_at: row.created_at,
+      post: row.posts ?? null,
+    })),
+    total: count ?? 0,
+    page,
+    per_page: perPage,
+  });
+}
+
+/**
+ * POST /api/v1/admin/picks
+ *
+ * Create or upsert a decoded pick.
+ * Body: { post_id, pick_date?, note?, curated_by? }
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const isAdmin = await checkIsAdmin(supabase, user.id);
+  if (!isAdmin) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const body = await request.json();
+  const { post_id, pick_date, note, curated_by } = body as {
+    post_id?: string;
+    pick_date?: string;
+    note?: string;
+    curated_by?: string;
+  };
+
+  if (!post_id) {
+    return NextResponse.json({ error: "post_id is required" }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("decoded_picks")
+    .upsert(
+      {
+        post_id,
+        pick_date: pick_date || new Date().toISOString().slice(0, 10),
+        note: note || null,
+        curated_by: curated_by || "editor",
+      },
+      { onConflict: "pick_date" }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -13,8 +13,11 @@ import {
   HeroItemSync,
   TrendingPostsSection,
   HelpFindSection,
+  EditorialSection,
+  TrendingListSection,
+  DecodedPickSection,
 } from "@/lib/components/main";
-import type { LatestPostCardData } from "@/lib/components/main";
+import type { LatestPostCardData, StyleCardData, ItemCardData } from "@/lib/components/main";
 import type { HeroPostEntry } from "@/lib/components/main/HeroItemSync";
 import type { PaginatedResponsePostListItem } from "@/lib/api/generated/models";
 import type { PaginatedResponsePostListItemDataItem } from "@/lib/api/generated/models";
@@ -145,22 +148,6 @@ export default async function Home({
 
   const heroPosts: HeroPostEntry[] = [];
 
-  if (decodedPick && decodedPick.post.imageUrl) {
-    heroPosts.push({
-      id: String(decodedPick.post.id),
-      heroData: buildHeroFromApiPost(
-        { id: decodedPick.post.id, image_url: decodedPick.post.imageUrl!, artist_name: decodedPick.post.artistName, group_name: decodedPick.post.groupName, context: decodedPick.post.context } as ApiPost,
-        buildSpots(decodedPick.items)
-      ),
-      items: decodedPick.items.map((item) => ({
-        id: String(item.id), brand: item.brand || "Unknown",
-        name: item.name || item.label, imageUrl: item.imageUrl || undefined,
-      })),
-      galleryImage: proxyImg(decodedPick.post.imageUrl),
-      galleryLabel: decodedPick.post.artistName || decodedPick.post.groupName || "Decoded Pick",
-    });
-  }
-
   for (const post of recentPosts) {
     if (heroPosts.some((hp) => hp.id === post.id)) continue;
     heroPosts.push({
@@ -256,6 +243,34 @@ export default async function Home({
 
   const editorialMagazineData: EditorialMagazineData = { cards: magazineCards };
 
+  // --- Decoded Pick ---
+
+  const pickStyleData: StyleCardData | undefined =
+    decodedPick && decodedPick.post.imageUrl
+      ? {
+          id: decodedPick.post.id,
+          title: enrichArtistName(decodedPick.post.artistName || decodedPick.post.groupName).displayName || "Decoded Pick",
+          description: decodedPick.post.context || "",
+          artistName: enrichArtistName(decodedPick.post.artistName || decodedPick.post.groupName).displayName || "Unknown",
+          imageUrl: proxyImg(decodedPick.post.imageUrl),
+          link: `/posts/${decodedPick.post.id}`,
+          spots: decodedPick.spots?.map((s) => ({
+            id: s.id, x: parseFloat(s.position_left) || 50, y: parseFloat(s.position_top) || 50,
+            label: s.solutions?.[0]?.title || "Item",
+          })),
+        }
+      : undefined;
+
+  const pickItems: ItemCardData[] | undefined = decodedPick
+    ? decodedPick.items.map((item) => ({
+        id: String(item.id),
+        brand: item.brand || "Unknown",
+        name: item.name || item.label,
+        imageUrl: item.imageUrl,
+        link: `/items/${item.id}`,
+      }))
+    : undefined;
+
   // --- MasonryGrid ---
 
   const gridItems: GridItemData[] = popularPosts.slice(0, 16).map((post, i) => {
@@ -285,6 +300,14 @@ export default async function Home({
       <HelpFindSection posts={helpFindCards} />
 
       <EditorialMagazine data={editorialMagazineData} />
+
+      <DecodedPickSection
+        styleData={pickStyleData}
+        items={pickItems}
+        pickDate={decodedPick?.pickDate ?? null}
+        curatedBy={decodedPick?.curatedBy ?? null}
+        note={decodedPick?.note ?? null}
+      />
 
       <section className="relative">
         <MasonryGrid items={gridItems as GridItemData[]} />

--- a/packages/web/lib/api/admin/picks.ts
+++ b/packages/web/lib/api/admin/picks.ts
@@ -1,0 +1,43 @@
+/**
+ * Types for admin decoded pick management.
+ */
+
+export interface DecodedPickPost {
+  id: string;
+  image_url: string | null;
+  artist_name: string | null;
+  group_name: string | null;
+  context: string | null;
+}
+
+export interface DecodedPickListItem {
+  id: string;
+  post_id: string;
+  pick_date: string;
+  note: string | null;
+  curated_by: string;
+  is_active: boolean;
+  created_at: string;
+  post: DecodedPickPost | null;
+}
+
+export interface DecodedPickListResponse {
+  data: DecodedPickListItem[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+export interface CreatePickPayload {
+  post_id: string;
+  pick_date?: string;
+  note?: string;
+  curated_by?: string;
+}
+
+export interface UpdatePickPayload {
+  note?: string | null;
+  is_active?: boolean;
+  curated_by?: string;
+  post_id?: string;
+}

--- a/packages/web/lib/components/admin/AdminSidebar.tsx
+++ b/packages/web/lib/components/admin/AdminSidebar.tsx
@@ -11,6 +11,7 @@ import {
   GitBranch,
   Server,
   Sparkles,
+  Star,
   LogOut,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -27,6 +28,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/admin", label: "Dashboard", icon: LayoutDashboard, exact: true },
   { href: "/admin/content", label: "Content", icon: FileText },
   { href: "/admin/editorial-candidates", label: "Editorial", icon: Sparkles },
+  { href: "/admin/picks", label: "Decoded Pick", icon: Star },
   { href: "/admin/ai-audit", label: "AI Audit", icon: ScanSearch },
   { href: "/admin/ai-cost", label: "AI Cost", icon: DollarSign },
   { href: "/admin/pipeline-logs", label: "Pipeline Logs", icon: GitBranch },

--- a/packages/web/lib/components/main/DecodedPickSection.tsx
+++ b/packages/web/lib/components/main/DecodedPickSection.tsx
@@ -69,11 +69,22 @@ const sampleStyleData: StyleCardData = {
 interface DecodedPickSectionProps {
   styleData?: StyleCardData;
   items?: ItemCardData[];
+  pickDate?: string | null;
+  curatedBy?: string | null;
+  note?: string | null;
+}
+
+function formatPickDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  return date.toLocaleDateString("en-US", { month: "long", day: "numeric" }) + " Pick";
 }
 
 export function DecodedPickSection({
   styleData = sampleStyleData,
   items,
+  pickDate,
+  curatedBy,
+  note,
 }: DecodedPickSectionProps) {
   const [activeSpotId, setActiveSpotId] = useState<string | null>(null);
 
@@ -215,13 +226,23 @@ export function DecodedPickSection({
           <div className="max-w-2xl">
             <div ref={headerRef} style={{ opacity: 0 }}>
               <span className="text-primary font-sans font-bold tracking-[0.4em] text-[10px] md:text-xs uppercase mb-6 block">
-                Editor's Choice
+                {curatedBy === "editor" ? "Editor\u2019s Choice" : "AI Curated"}
               </span>
               <h2 className="text-6xl md:text-8xl font-serif font-bold italic tracking-tighter leading-[0.85]">
-                Decoded's
+                Decoded&apos;s
                 <br />
                 Pick
               </h2>
+              {pickDate && (
+                <p className="mt-6 text-sm font-sans tracking-[0.2em] text-white/40 uppercase">
+                  {formatPickDate(pickDate)}
+                </p>
+              )}
+              {note && (
+                <p className="mt-4 text-sm md:text-base font-sans text-white/50 italic max-w-md leading-relaxed">
+                  &ldquo;{note}&rdquo;
+                </p>
+              )}
             </div>
           </div>
           <Link

--- a/packages/web/lib/hooks/admin/useAdminPicks.ts
+++ b/packages/web/lib/hooks/admin/useAdminPicks.ts
@@ -1,0 +1,120 @@
+/**
+ * React Query hooks for admin decoded pick management.
+ *
+ * - useAdminPickList → GET /api/v1/admin/picks
+ * - useCreatePick   → POST /api/v1/admin/picks
+ * - useUpdatePick   → PATCH /api/v1/admin/picks/:pickId
+ * - useDeletePick   → DELETE /api/v1/admin/picks/:pickId
+ */
+
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  DecodedPickListResponse,
+  CreatePickPayload,
+  UpdatePickPayload,
+} from "@/lib/api/admin/picks";
+
+// ─── Shared fetcher ───────────────────────────────────────────────────────────
+
+async function adminFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (!res.ok) {
+    throw new Error(`Admin API error: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Query keys ──────────────────────────────────────────────────────────────
+
+const PICKS_KEY = ["admin", "picks"] as const;
+
+// ─── Hooks ────────────────────────────────────────────────────────────────────
+
+interface UseAdminPickListParams {
+  page: number;
+  perPage?: number;
+}
+
+export function useAdminPickList(
+  params: UseAdminPickListParams
+): UseQueryResult<DecodedPickListResponse> {
+  const { page, perPage = 20 } = params;
+
+  return useQuery<DecodedPickListResponse>({
+    queryKey: [...PICKS_KEY, "list", page, perPage],
+    queryFn: ({ signal }) => {
+      const searchParams = new URLSearchParams({
+        page: String(page),
+        per_page: String(perPage),
+      });
+      return adminFetch<DecodedPickListResponse>(
+        `/api/v1/admin/picks?${searchParams.toString()}`,
+        { signal }
+      );
+    },
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCreatePick() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CreatePickPayload) => {
+      return adminFetch<Record<string, unknown>>("/api/v1/admin/picks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: PICKS_KEY });
+    },
+  });
+}
+
+export function useUpdatePick() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      pickId,
+      ...payload
+    }: UpdatePickPayload & { pickId: string }) => {
+      return adminFetch<Record<string, unknown>>(
+        `/api/v1/admin/picks/${pickId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: PICKS_KEY });
+    },
+  });
+}
+
+export function useDeletePick() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (pickId: string) => {
+      return adminFetch<{ success: boolean }>(
+        `/api/v1/admin/picks/${pickId}`,
+        { method: "DELETE" }
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: PICKS_KEY });
+    },
+  });
+}

--- a/packages/web/lib/supabase/queries/main-page.server.ts
+++ b/packages/web/lib/supabase/queries/main-page.server.ts
@@ -50,6 +50,15 @@ export interface StyleCardServerData {
 }
 
 /**
+ * Extended style data with decoded_picks curation metadata
+ */
+export interface DecodedPickServerData extends StyleCardServerData {
+  pickDate: string | null;
+  curatedBy: string | null;
+  note: string | null;
+}
+
+/**
  * Trending keyword data
  */
 export interface TrendingKeyword {
@@ -249,37 +258,60 @@ export async function fetchWhatsNewPostsServer(
 
 /**
  * Fetches data for Decoded Pick section (server-side)
- * Gets a style with its spots and solutions
  *
- * @param offset - Number of posts to skip (default: 2 to skip What's New)
- * @returns Style card data or null
+ * Queries decoded_picks table for the most recent active pick,
+ * then fetches the associated post with spots/solutions.
+ * Falls back to offset-based selection if no curated pick exists.
  */
-export async function fetchDecodedPickServer(
-  offset = 2
-): Promise<StyleCardServerData | null> {
+export async function fetchDecodedPickServer(): Promise<DecodedPickServerData | null> {
   const supabase = await createSupabaseServerClient();
 
-  const { data, error } = await supabase
-    .from("posts")
-    .select("*, spots(*, solutions(*))")
-    .eq("status", "active")
-    .not("image_url", "is", null)
-    .order("created_at", { ascending: false })
-    .range(offset, offset);
+  // 1. Try to get the most recent active curated pick
+  const { data: pickRow } = await supabase
+    .from("decoded_picks")
+    .select("post_id, pick_date, curated_by, note")
+    .eq("is_active", true)
+    .order("pick_date", { ascending: false })
+    .limit(1)
+    .single();
 
-  if (error) {
-    console.error(
-      "Error fetching decoded pick:",
-      JSON.stringify(error, null, 2)
-    );
-    return null;
+  let postId: string | null = pickRow?.post_id ?? null;
+  let pickDate: string | null = pickRow?.pick_date ?? null;
+  let curatedBy: string | null = pickRow?.curated_by ?? null;
+  let note: string | null = pickRow?.note ?? null;
+
+  // 2. Fetch the post (by pick's post_id, or fallback to offset=2)
+  let row: PostWithSpots | null = null;
+
+  if (postId) {
+    const { data } = await supabase
+      .from("posts")
+      .select("*, spots(*, solutions(*))")
+      .eq("id", postId)
+      .eq("status", "active")
+      .single();
+    row = data as PostWithSpots | null;
   }
 
-  if (!data || data.length === 0) {
-    return null;
+  // Fallback: no curated pick or post inactive — use offset-based selection
+  if (!row) {
+    pickDate = null;
+    curatedBy = null;
+    note = null;
+
+    const { data } = await supabase
+      .from("posts")
+      .select("*, spots(*, solutions(*))")
+      .eq("status", "active")
+      .not("image_url", "is", null)
+      .order("created_at", { ascending: false })
+      .range(2, 2);
+
+    row = (data?.[0] as PostWithSpots) ?? null;
   }
 
-  const row = data[0] as PostWithSpots;
+  if (!row) return null;
+
   return {
     post: toPostData(row),
     items: (row.spots || []).flatMap((spot) =>
@@ -294,6 +326,9 @@ export async function fetchDecodedPickServer(
       }))
     ),
     spots: row.spots || [],
+    pickDate,
+    curatedBy,
+    note,
   };
 }
 
@@ -672,10 +707,11 @@ export async function fetchAllBadgesServer(): Promise<BadgeRow[]> {
 }
 
 /** @deprecated Use fetchDecodedPickServer instead */
-export async function fetchDecodedPickStyleServer(
-  offset = 2
-): Promise<{ style: WhatsNewStyleData | null; items: ItemWithImage[] }> {
-  const pick = await fetchDecodedPickServer(offset);
+export async function fetchDecodedPickStyleServer(): Promise<{
+  style: WhatsNewStyleData | null;
+  items: ItemWithImage[];
+}> {
+  const pick = await fetchDecodedPickServer();
   if (!pick)
     return {
       style: null,

--- a/packages/web/lib/supabase/types.ts
+++ b/packages/web/lib/supabase/types.ts
@@ -17,6 +17,7 @@
  * - user_events - Behavioral event tracking (30-day TTL)
  * - user_tryon_history - VTON history
  * - user_social_accounts - OAuth SNS connections
+ * - decoded_picks - Editor/AI curated daily picks for homepage
  */
 
 export type Json =
@@ -41,6 +42,47 @@ export type Database = {
       // =================================================================
       // CORE CONTENT
       // =================================================================
+
+      /**
+       * Decoded Picks - Editor/AI curated daily picks for homepage
+       */
+      decoded_picks: {
+        Row: {
+          id: string;
+          post_id: string;
+          pick_date: string;
+          note: string | null;
+          curated_by: string;
+          is_active: boolean;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          post_id: string;
+          pick_date?: string;
+          note?: string | null;
+          curated_by?: string;
+          is_active?: boolean;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          post_id?: string;
+          pick_date?: string;
+          note?: string | null;
+          curated_by?: string;
+          is_active?: boolean;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "decoded_picks_post_id_fkey";
+            columns: ["post_id"];
+            referencedRelation: "posts";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
 
       /**
        * Posts - Main content with images

--- a/supabase/migrations/20260403120000_create_decoded_picks.sql
+++ b/supabase/migrations/20260403120000_create_decoded_picks.sql
@@ -1,0 +1,45 @@
+-- Decoded Picks: editor/AI curated daily pick for homepage section
+-- Issue #71: feat(home): Decoded Pick 큐레이션 섹션 추가
+
+CREATE TABLE IF NOT EXISTS public.decoded_picks (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id     UUID NOT NULL REFERENCES public.posts(id) ON DELETE CASCADE,
+  pick_date   DATE NOT NULL DEFAULT CURRENT_DATE,
+  note        TEXT,
+  curated_by  TEXT NOT NULL DEFAULT 'ai',
+  is_active   BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Only one pick per date
+CREATE UNIQUE INDEX IF NOT EXISTS decoded_picks_pick_date_unique
+  ON public.decoded_picks (pick_date);
+
+-- Quick lookup for active picks (homepage query)
+CREATE INDEX IF NOT EXISTS decoded_picks_active_date
+  ON public.decoded_picks (is_active, pick_date DESC);
+
+-- RLS
+ALTER TABLE public.decoded_picks ENABLE ROW LEVEL SECURITY;
+
+-- Public read for active picks (homepage section)
+CREATE POLICY "Public can read active picks"
+  ON public.decoded_picks
+  FOR SELECT
+  TO anon, authenticated
+  USING (is_active = true);
+
+-- Authenticated full access (admin check enforced at app layer)
+CREATE POLICY "Authenticated users can manage picks"
+  ON public.decoded_picks
+  FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- Service role full access (for future cron / backend operations)
+CREATE POLICY "Service role full access"
+  ON public.decoded_picks
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary

- `decoded_picks` 테이블 신규 생성 (날짜당 1개, RLS 적용)
- `fetchDecodedPickServer()` — decoded_picks 조회 + offset fallback
- 히어로 캐러셀에서 pick 제거, EditorialMagazine↔MasonryGrid 사이 독립 섹션으로 배치
- `DecodedPickSection`에 pickDate/curatedBy/note 동적 표시
- Admin `/admin/picks` 관리 페이지 (post 검색, 생성/수정/삭제)
- Admin API 라우트 (`/api/v1/admin/picks` GET/POST/PATCH/DELETE)

## Test plan

- [ ] `supabase db push`로 마이그레이션 적용 후 decoded_picks 테이블 확인
- [ ] Admin `/admin/picks`에서 pick 생성 (post 검색 → 선택 → note 입력 → 저장)
- [ ] 홈페이지에서 DecodedPickSection 독립 섹션 렌더 확인
- [ ] pick_date, curated_by 배지, note 표시 확인
- [ ] Pick 없을 때 offset fallback 동작 확인
- [ ] 히어로 캐러셀에서 pick 제거 확인
- [ ] Admin sidebar에 Decoded Pick 항목 표시 확인

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)