### PR TITLE
fix(web): Explore 한글 검색 + published 필터 수정 (#99)

### DIFF
--- a/packages/web/app/api/v1/search/route.ts
+++ b/packages/web/app/api/v1/search/route.ts
@@ -33,10 +33,17 @@ export async function GET(request: NextRequest) {
       } catch {
         data = { message: `Backend error: ${response.status}` };
       }
-      return NextResponse.json(data, { status: response.status });
+      // If backend returns empty results for a non-empty query, fall through
+      // to Supabase which has synonym expansion (한글→영문 매핑)
+      const q = searchParams.get("q")?.trim();
+      const hasResults = Array.isArray(data?.data) && data.data.length > 0;
+      if (hasResults || !q) {
+        return NextResponse.json(data, { status: response.status });
+      }
+      console.warn(`[Search GET] Backend returned empty for "${q}", trying Supabase synonyms`);
+    } else {
+      console.warn(`[Search GET] Backend returned ${response.status}, falling back to Supabase`);
     }
-
-    console.warn(`[Search GET] Backend returned ${response.status}, falling back to Supabase`);
   } catch (error) {
     if (process.env.NODE_ENV === "development") {
       console.warn("Search proxy error, falling back to Supabase:", error);
@@ -67,9 +74,11 @@ async function supabaseSearchFallback(searchParams: URLSearchParams) {
 
     let query = supabase
       .from("posts")
-      .select("*", { count: "exact" })
+      .select("*, post_magazines!inner(status)", { count: "exact" })
       .eq("status", "active")
-      .not("image_url", "is", null);
+      .not("image_url", "is", null)
+      .eq("created_with_solutions", true)
+      .eq("post_magazines.status", "published");
 
     // Text search: match against artist_name, group_name, or context
     // Expand query using synonyms table for cross-language matching (e.g. 제니 → Jennie)


### PR DESCRIPTION
## 요약

### 1. 한글 검색 불가 수정
- 백엔드가 200 + 빈 결과 반환 시 Supabase fallback으로 넘어가지 않던 문제
- 비어있는 결과 + 검색어가 있으면 Supabase fallback 트리거
- Supabase에 synonyms 테이블 (제니→Jennie) 매핑이 있어 한글 검색 가능

### 2. published 필터 누락 수정  
- search fallback에 post_magazines inner join + created_with_solutions 필터 추가
- browse 모드와 동일한 필터링으로 unpublished 포스트 노출 방지

## 테스트
- [x] tsc --noEmit 통과
- [ ] 로컬에서 한글 검색 확인 (제니, 뉴진스)
- [ ] 검색 결과에 published 포스트만 표시되는지 확인

Fixes #99