### PR TITLE
feat(web): home section redesign — editorial slider, Style Moods, Trending Now

### DIFF
--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -25,11 +25,11 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: {
-    default: "Decoded — AI-Powered Celebrity Fashion Discovery",
+    default: "Decoded — The Style Search Engine",
     template: "%s | Decoded",
   },
   description:
-    "Discover what your favorite celebrities are wearing. AI-powered item detection, editorial magazines, and virtual try-on.",
+    "The style search engine — AI-powered item detection, editorial magazines, and virtual try-on.",
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style"
   ),

--- a/packages/web/lib/components/main-renewal/EditorialMagazine.tsx
+++ b/packages/web/lib/components/main-renewal/EditorialMagazine.tsx
@@ -64,12 +64,12 @@ export default function EditorialMagazine({ data, className }: EditorialMagazine
       {/* Header */}
       <div
         ref={headerRef}
-        className="mx-auto max-w-7xl px-6 md:px-12 lg:px-20 pt-16 md:pt-24 pb-8 md:pb-10"
+        className="px-6 md:px-12 lg:px-20 pt-16 md:pt-24 pb-8"
         style={{ opacity: 0 }}
       >
         <div className="flex items-end justify-between gap-4">
           <div>
-            <p className="text-[10px] uppercase tracking-[0.3em] text-white/40 mb-2">Editorial</p>
+            <p className="text-[10px] uppercase tracking-[0.3em] mb-2" style={{ color: "#eafd67" }}>Editorial</p>
             <h2
               className="text-3xl md:text-5xl lg:text-6xl font-bold text-white leading-[1.1]"
               style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
@@ -272,7 +272,7 @@ export default function EditorialMagazine({ data, className }: EditorialMagazine
                 onClick={() => setActiveIdx(i)}
                 className={`rounded-full transition-all duration-300 ${
                   i === activeIdx
-                    ? "w-5 h-1.5 bg-white"
+                    ? "w-5 h-1.5 bg-[#eafd67]"
                     : "w-1.5 h-1.5 bg-white/20 hover:bg-white/40"
                 }`}
               />

--- a/packages/web/lib/components/main-renewal/StyleMoods.tsx
+++ b/packages/web/lib/components/main-renewal/StyleMoods.tsx
@@ -25,11 +25,11 @@ export default function StyleMoods({ items }: StyleMoodsProps) {
   if (items.length === 0) return null;
 
   return (
-    <section className="bg-mag-bg px-6 py-16 md:py-24 md:px-12 lg:px-20">
-      <div className="mx-auto max-w-7xl">
+    <section className="bg-mag-bg py-16 md:py-24">
+      <div className="px-6 md:px-12 lg:px-20">
         {/* Section header */}
-        <div className="mb-8">
-          <p className="text-[10px] uppercase tracking-[0.3em] text-white/40 mb-2">By Context</p>
+        <div className="mb-6">
+          <p className="text-[10px] uppercase tracking-[0.3em] mb-2" style={{ color: "#eafd67" }}>By Context</p>
           <h2
             className="text-3xl md:text-5xl font-bold text-white leading-[1.1]"
             style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
@@ -47,7 +47,7 @@ export default function StyleMoods({ items }: StyleMoodsProps) {
               onClick={() => setActiveTab(cat)}
               className={`px-4 py-1.5 rounded-full text-xs uppercase tracking-widest transition-colors ${
                 activeTab === cat
-                  ? "bg-white text-black"
+                  ? "bg-[#eafd67] text-black"
                   : "bg-white/10 text-white/60 hover:bg-white/20"
               }`}
             >

--- a/packages/web/lib/components/main/EditorialCarousel.tsx
+++ b/packages/web/lib/components/main/EditorialCarousel.tsx
@@ -54,7 +54,7 @@ export function EditorialCarousel({ items }: EditorialCarouselProps) {
       {/* Header */}
       <div className="px-6 md:px-12 lg:px-20 mb-8 flex items-end justify-between">
         <div>
-          <p className="text-[10px] uppercase tracking-[0.3em] text-white/40 mb-2">Trending</p>
+          <p className="text-[10px] uppercase tracking-[0.3em] mb-2" style={{ color: "#eafd67" }}>Trending</p>
           <h2
             className="text-3xl md:text-5xl font-bold text-white leading-[1.1]"
             style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
@@ -123,15 +123,15 @@ export function EditorialCarousel({ items }: EditorialCarouselProps) {
                 ) : (
                   <div className="absolute inset-0 bg-neutral-800" />
                 )}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent z-10" />
                 {item.description && (
-                  <div className="absolute top-3 left-3">
+                  <div className="absolute top-3 left-3 z-20">
                     <span className="text-[9px] uppercase tracking-[0.15em] text-white/70 bg-white/10 backdrop-blur-sm px-2 py-0.5 rounded-full border border-white/10">
                       {item.description}
                     </span>
                   </div>
                 )}
-                <div className="absolute bottom-3 left-3 right-3">
+                <div className="absolute bottom-3 left-3 right-3 z-20">
                   <p className="text-sm font-bold text-white uppercase tracking-wide line-clamp-1">
                     {item.artistName}
                   </p>

--- a/packages/web/lib/components/main/TrendingListSection.tsx
+++ b/packages/web/lib/components/main/TrendingListSection.tsx
@@ -206,13 +206,13 @@ export function TrendingListSection({
       {/* Section Header */}
       <div className="flex items-end justify-between px-6 md:px-12 lg:px-20 py-8 md:py-10">
         <div>
-          <p className="text-[10px] uppercase tracking-[0.3em] text-white/40 mb-2">Discover</p>
+          <p className="text-[10px] uppercase tracking-[0.3em] mb-2" style={{ color: "#eafd67" }}>Discover</p>
           <h2
             className="text-3xl md:text-5xl font-bold text-white leading-[1.1]"
             style={{ fontFamily: "'Playfair Display', Georgia, serif" }}
           >
             Trending{" "}
-            <span className="italic font-normal text-white/60">Now</span>
+            <span className="italic font-normal text-white/60">Keywords</span>
           </h2>
         </div>
         <Link

--- a/packages/web/lib/design-system/desktop-header.tsx
+++ b/packages/web/lib/design-system/desktop-header.tsx
@@ -127,7 +127,7 @@ export function DesktopHeader({
     >
       <div className="w-full flex items-center justify-between h-full px-6 md:px-8">
         {/* Left Section: Logo - flex-1 for equal width with right */}
-        <div className="flex-1 flex items-center">
+        <div className="flex-1 flex items-center gap-3">
           <Link
             href="/"
             className="relative w-48 h-16 flex items-center justify-center hover:opacity-80 transition-opacity"


### PR DESCRIPTION
## Summary

- **EditorialMagazine**: infinite slider with active card + related products panel + next cards, 5s auto-advance, mobile item strip
- **Trending Now** (EditorialCarousel): horizontal auto-scroll carousel, 10 cards, 4s interval, arrow controls
- **Style Moods**: new context-based section with tab pills, replaces MasonryGrid
- **Editor's Pick**: conditional curation section (shows only when data exists)
- **Section polish**: unified padding/alignment, `#eafd67` accent on all eyebrow labels, active dots, tab pills
- **Trending Keywords**: renamed from "Trending Now" in TrendingListSection
- **Copy**: site title → "The Style Search Engine", updated meta description
- Fix search route conflict (`route.ts` → `[[...path]]/route.ts`)

## Test plan

- [ ] Home loads without hydration errors
- [ ] Editorial slider auto-advances and wraps infinitely
- [ ] Mobile: card full-width + item strip below
- [ ] Trending Now carousel auto-scrolls, arrows work
- [ ] Style Moods tab filtering works
- [ ] Editor's Pick hidden (no curation data)
- [ ] Section eyebrow labels show in `#eafd67`
- [ ] Vercel build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)