### PR TITLE
fix(web): add missing "other" to ContextType

### DIFF
--- a/packages/web/lib/api/mutation-types.ts
+++ b/packages/web/lib/api/mutation-types.ts
@@ -91,7 +91,8 @@ export type ContextType =
   | "sns"
   | "street"
   | "fan_meeting"
-  | "interview";
+  | "interview"
+  | "other";
 
 export interface MediaMetadataItem {
   key: string; // e.g., "platform", "season", "episode"


### PR DESCRIPTION
## Summary
- `ContextType`에 `"other"` 값이 누락되어 `MetadataInputForm`에서 TypeScript 타입 에러 발생 → Vercel 빌드 실패
- union type에 `"other"` 추가하여 해결

## Test plan
- [ ] Vercel 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)