### PR TITLE
feat(web): SEO infrastructure — sitemap, robots, metadata, structured data

### DIFF
--- a/packages/web/app/api/og/route.tsx
+++ b/packages/web/app/api/og/route.tsx
@@ -1,0 +1,114 @@
+import { ImageResponse } from "next/og";
+import type { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const title = searchParams.get("title") || "Decoded";
+  const artist = searchParams.get("artist") || "";
+  const image = searchParams.get("image") || "";
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        position: "relative",
+        backgroundColor: "#050505",
+        fontFamily: "sans-serif",
+      }}
+    >
+      {/* Background image with overlay */}
+      {image && (
+        <img
+          src={image}
+          alt=""
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            objectFit: "cover",
+            opacity: 0.4,
+          }}
+        />
+      )}
+
+      {/* Gradient overlay */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          background:
+            "linear-gradient(180deg, rgba(5,5,5,0.3) 0%, rgba(5,5,5,0.8) 100%)",
+        }}
+      />
+
+      {/* Content */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          padding: "60px",
+          width: "100%",
+          height: "100%",
+          position: "relative",
+        }}
+      >
+        {/* Logo / Brand */}
+        <div
+          style={{
+            display: "flex",
+            fontSize: 24,
+            color: "rgba(255,255,255,0.6)",
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            marginBottom: 16,
+          }}
+        >
+          DECODED
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            display: "flex",
+            fontSize: title.length > 40 ? 42 : 56,
+            fontWeight: 700,
+            color: "#ffffff",
+            lineHeight: 1.2,
+            marginBottom: artist ? 16 : 0,
+            maxWidth: "80%",
+          }}
+        >
+          {title.length > 80 ? title.slice(0, 77) + "..." : title}
+        </div>
+
+        {/* Artist */}
+        {artist && (
+          <div
+            style={{
+              display: "flex",
+              fontSize: 28,
+              color: "rgba(255,255,255,0.7)",
+            }}
+          >
+            {artist}
+          </div>
+        )}
+      </div>
+    </div>,
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+}

--- a/packages/web/app/explore/page.tsx
+++ b/packages/web/app/explore/page.tsx
@@ -1,9 +1,39 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { ExploreClient } from "./ExploreClient";
 
 type Props = {
   searchParams: Promise<{ q?: string }>;
 };
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+export async function generateMetadata({
+  searchParams,
+}: Props): Promise<Metadata> {
+  const { q } = await searchParams;
+
+  if (q) {
+    const title = `"${q}" — Search Results`;
+    const description = `Search results for "${q}" on Decoded — discover styles, outfits, and fashion items.`;
+    return {
+      title,
+      description,
+      alternates: {
+        canonical: `${SITE_URL}/explore?q=${encodeURIComponent(q)}`,
+      },
+      openGraph: { title, description },
+      robots: { index: false, follow: true }, // Don't index search result pages
+    };
+  }
+
+  return {
+    title: "Explore Styles",
+    description:
+      "Explore trending styles, outfits, and fashion items — AI-powered style search engine.",
+    alternates: { canonical: `${SITE_URL}/explore` },
+  };
+}
 
 function ExploreSkeleton() {
   return (
@@ -31,9 +61,7 @@ export default async function ExplorePage({ searchParams }: Props) {
 
   return (
     <Suspense fallback={<ExploreSkeleton />}>
-      <ExploreClient
-        initialQuery={q ?? ""}
-      />
+      <ExploreClient initialQuery={q ?? ""} />
     </Suspense>
   );
 }

--- a/packages/web/app/layout.tsx
+++ b/packages/web/app/layout.tsx
@@ -10,6 +10,7 @@ import { LazyOnboardingSheet } from "@/lib/components/auth/LazyOnboardingSheet";
 import { LazyVtonModal } from "@/lib/components/vton/LazyVtonModal";
 import { ThemeScript } from "@/lib/theme/theme-script";
 import { EventFlushProvider } from "./EventFlushProvider";
+import { JsonLdOrganization } from "@/lib/seo/json-ld";
 
 const playfairDisplay = Playfair_Display({
   subsets: ["latin"],
@@ -23,6 +24,8 @@ const inter = Inter({
   display: "swap",
 });
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
 export const metadata: Metadata = {
   title: {
     default: "Decoded — The Style Search Engine",
@@ -30,16 +33,26 @@ export const metadata: Metadata = {
   },
   description:
     "The style search engine — AI-powered item detection, editorial magazines, and virtual try-on.",
-  metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style"
-  ),
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: SITE_URL,
+  },
   openGraph: {
     type: "website",
     siteName: "Decoded",
     locale: "en_US",
+    images: [
+      {
+        url: `${SITE_URL}/api/og`,
+        width: 1200,
+        height: 630,
+        alt: "Decoded — The Style Search Engine",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
+    images: [`${SITE_URL}/api/og`],
   },
   robots: {
     index: true,
@@ -58,6 +71,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <ThemeScript />
+        <JsonLdOrganization />
       </head>
       <body
         className={`${playfairDisplay.variable} ${inter.variable} font-sans`}

--- a/packages/web/app/posts/[id]/page.tsx
+++ b/packages/web/app/posts/[id]/page.tsx
@@ -1,9 +1,71 @@
+import type { Metadata } from "next";
 import { ImageDetailPage } from "@/lib/components/detail/ImageDetailPage";
-import { buildArtistProfileMap, buildBrandProfileMap } from "@/lib/supabase/queries/warehouse-entities.server";
+import {
+  buildArtistProfileMap,
+  buildBrandProfileMap,
+} from "@/lib/supabase/queries/warehouse-entities.server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { JsonLdArticle } from "@/lib/seo/json-ld";
 
 type Props = {
   params: Promise<{ id: string }>;
 };
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const supabase = await createSupabaseServerClient();
+
+  const { data: post } = await supabase
+    .from("posts")
+    .select(
+      "id, title, context, artist_name, group_name, image_url, created_at, ai_summary"
+    )
+    .eq("id", id)
+    .single();
+
+  if (!post) {
+    return { title: "Post Not Found" };
+  }
+
+  const artistLabel = post.artist_name || post.group_name || "Unknown";
+  const title = post.title || post.context || `${artistLabel}'s Style`;
+  const description =
+    post.ai_summary ||
+    post.context ||
+    `Discover ${artistLabel}'s style — AI-powered item detection on Decoded.`;
+  const ogImageUrl = `${SITE_URL}/api/og?title=${encodeURIComponent(title)}&artist=${encodeURIComponent(artistLabel)}&image=${encodeURIComponent(post.image_url || "")}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: `${SITE_URL}/posts/${post.id}`,
+    },
+    openGraph: {
+      type: "article",
+      title,
+      description,
+      url: `${SITE_URL}/posts/${post.id}`,
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
+      publishedTime: post.created_at,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
 
 /**
  * Full page route for /posts/[id]
@@ -16,9 +78,44 @@ export default async function PostDetailPageRoute({ params }: Props) {
     buildBrandProfileMap(),
   ]);
 
+  // Fetch post data for JSON-LD (lightweight query)
+  const supabase = await createSupabaseServerClient();
+  const { data: post } = await supabase
+    .from("posts")
+    .select(
+      "id, title, context, artist_name, group_name, image_url, created_at, ai_summary"
+    )
+    .eq("id", id)
+    .single();
+
   // TODO: filter to only relevant entries for this post to reduce RSC payload
   const artistProfiles = Object.fromEntries(artistProfileMap);
   const brandProfiles = Object.fromEntries(brandProfileMap);
 
-  return <ImageDetailPage imageId={id} artistProfiles={artistProfiles} brandProfiles={brandProfiles} />;
+  const artistLabel = post?.artist_name || post?.group_name || "Unknown";
+  const title = post?.title || post?.context || `${artistLabel}'s Style`;
+  const description =
+    post?.ai_summary ||
+    post?.context ||
+    `Discover ${artistLabel}'s style on Decoded.`;
+
+  return (
+    <>
+      {post && (
+        <JsonLdArticle
+          title={title}
+          description={description}
+          imageUrl={post.image_url}
+          publishedTime={post.created_at}
+          url={`${SITE_URL}/posts/${post.id}`}
+          artistName={artistLabel}
+        />
+      )}
+      <ImageDetailPage
+        imageId={id}
+        artistProfiles={artistProfiles}
+        brandProfiles={brandProfiles}
+      />
+    </>
+  );
 }

--- a/packages/web/app/profile/[userId]/page.tsx
+++ b/packages/web/app/profile/[userId]/page.tsx
@@ -1,14 +1,34 @@
+import type { Metadata } from "next";
 import { PublicProfileClient } from "./PublicProfileClient";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 type Props = {
   params: Promise<{ userId: string }>;
 };
 
-export async function generateMetadata({ params }: Props) {
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { userId } = await params;
+  const supabase = await createSupabaseServerClient();
+
+  const { data: user } = await supabase
+    .from("users")
+    .select("display_name, bio")
+    .eq("id", userId)
+    .single();
+
+  const displayName = user?.display_name || "User";
+  const title = `${displayName}'s Profile`;
+  const description =
+    user?.bio || `View ${displayName}'s style collection on Decoded.`;
+
   return {
-    title: `Profile | DECODED`,
-    description: `View user profile on DECODED`,
+    title,
+    description,
+    alternates: { canonical: `${SITE_URL}/profile/${userId}` },
+    openGraph: { title, description },
+    robots: { index: true, follow: true },
   };
 }
 

--- a/packages/web/app/robots.ts
+++ b/packages/web/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/posts/", "/explore", "/search"],
+        disallow: [
+          "/api/",
+          "/admin/",
+          "/lab/",
+          "/login",
+          "/profile",
+          "/request/",
+          "/debug/",
+          "/feed",
+          "/_next/",
+        ],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/packages/web/app/sitemap.ts
+++ b/packages/web/app/sitemap.ts
@@ -1,0 +1,50 @@
+import type { MetadataRoute } from "next";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const supabase = await createSupabaseServerClient();
+
+  // Fetch all active posts with image_url
+  const { data: posts } = await supabase
+    .from("posts")
+    .select("id, updated_at")
+    .eq("status", "active")
+    .not("image_url", "is", null)
+    .order("created_at", { ascending: false })
+    .limit(5000);
+
+  const postEntries: MetadataRoute.Sitemap = (posts ?? []).map(
+    (post: { id: string; updated_at: string }) => ({
+      url: `${SITE_URL}/posts/${post.id}`,
+      lastModified: new Date(post.updated_at),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    })
+  );
+
+  // Static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/explore`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/search`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+  ];
+
+  return [...staticPages, ...postEntries];
+}

--- a/packages/web/lib/api/mutation-types.ts
+++ b/packages/web/lib/api/mutation-types.ts
@@ -91,7 +91,8 @@ export type ContextType =
   | "sns"
   | "street"
   | "fan_meeting"
-  | "interview";
+  | "interview"
+  | "other";
 
 export interface MediaMetadataItem {
   key: string; // e.g., "platform", "season", "episode"

--- a/packages/web/lib/seo/json-ld.tsx
+++ b/packages/web/lib/seo/json-ld.tsx
@@ -1,0 +1,122 @@
+/**
+ * JSON-LD structured data components for SEO
+ */
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://decoded.style";
+
+function JsonLdScript({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}
+
+/**
+ * Organization + WebSite schema for the root layout
+ */
+export function JsonLdOrganization() {
+  return (
+    <JsonLdScript
+      data={{
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Organization",
+            "@id": `${SITE_URL}/#organization`,
+            name: "Decoded",
+            url: SITE_URL,
+            description:
+              "The style search engine — AI-powered item detection, editorial magazines, and virtual try-on.",
+          },
+          {
+            "@type": "WebSite",
+            "@id": `${SITE_URL}/#website`,
+            url: SITE_URL,
+            name: "Decoded",
+            publisher: { "@id": `${SITE_URL}/#organization` },
+            potentialAction: {
+              "@type": "SearchAction",
+              target: {
+                "@type": "EntryPoint",
+                urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
+              },
+              "query-input": "required name=search_term_string",
+            },
+          },
+        ],
+      }}
+    />
+  );
+}
+
+/**
+ * Article schema for individual post pages
+ */
+export function JsonLdArticle({
+  title,
+  description,
+  imageUrl,
+  publishedTime,
+  url,
+  artistName,
+}: {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  publishedTime: string;
+  url: string;
+  artistName: string;
+}) {
+  return (
+    <JsonLdScript
+      data={{
+        "@context": "https://schema.org",
+        "@type": "Article",
+        headline: title,
+        description,
+        ...(imageUrl ? { image: imageUrl } : {}),
+        datePublished: publishedTime,
+        url,
+        author: {
+          "@type": "Person",
+          name: artistName,
+        },
+        publisher: {
+          "@type": "Organization",
+          name: "Decoded",
+          url: SITE_URL,
+        },
+        mainEntityOfPage: {
+          "@type": "WebPage",
+          "@id": url,
+        },
+      }}
+    />
+  );
+}
+
+/**
+ * BreadcrumbList schema
+ */
+export function JsonLdBreadcrumb({
+  items,
+}: {
+  items: { name: string; url: string }[];
+}) {
+  return (
+    <JsonLdScript
+      data={{
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: items.map((item, i) => ({
+          "@type": "ListItem",
+          position: i + 1,
+          name: item.name,
+          item: item.url,
+        })),
+      }}
+    />
+  );
+}

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- **sitemap.ts**: 동적 sitemap 생성 (정적 페이지 + Supabase active posts, 5000개 limit)
- **robots.ts**: 크롤러 규칙 (공개 페이지 allow, api/admin/lab/login 등 disallow)
- **posts/[id] generateMetadata**: 포스트별 동적 title, description, OG article, Twitter card, canonical URL
- **JSON-LD 구조화 데이터**: Organization + WebSite + SearchAction (root), Article (posts)
- **OG Image API** (`/api/og`): Edge runtime 동적 OG 이미지 생성 (1200x630, 포스트 이미지 배경 + 제목)
- **explore, profile 페이지 metadata**: 검색어 반영 metadata, 유저 프로필 동적 metadata
- **Root layout 강화**: OG 이미지, canonical URL, JSON-LD Organization 추가

## Changed files
| File | Change |
|------|--------|
| `app/sitemap.ts` | NEW — dynamic sitemap |
| `app/robots.ts` | NEW — crawler rules |
| `app/api/og/route.tsx` | NEW — OG image generation |
| `lib/seo/json-ld.tsx` | NEW — JSON-LD components |
| `app/layout.tsx` | Enhanced metadata + JSON-LD |
| `app/posts/[id]/page.tsx` | generateMetadata + JSON-LD Article |
| `app/explore/page.tsx` | generateMetadata |
| `app/profile/[userId]/page.tsx` | Dynamic generateMetadata |
| `lib/api/mutation-types.ts` | Fix: add missing "other" to ContextType |

## Test plan
- [ ] `curl /sitemap.xml` → 200 응답, posts URL 포함 확인
- [ ] `curl /robots.txt` → 200 응답, sitemap 경로 명시 확인
- [ ] `/posts/[id]` 페이지 `<head>` 태그에 OG/Twitter meta 존재 확인
- [ ] `/api/og?title=Test&artist=Artist` → 1200x630 이미지 응답 확인
- [ ] [Rich Results Test](https://search.google.com/test/rich-results)로 JSON-LD 유효성 확인
- [ ] [opengraph.xyz](https://opengraph.xyz)에서 SNS 공유 미리보기 확인
- [ ] Lighthouse SEO 점수 90+ 확인

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)