### PR TITLE
fix(ci): CD env 파일 복사 스텝 추가

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Copy env file
+        run: cp /Users/decoded/dev/decoded/.env.backend.prod .env.backend.prod
+
       - name: Tag current images as :prev
         run: |
           for img in "$API_IMAGE" "$AI_IMAGE"; do


### PR DESCRIPTION
## Summary
- CD workflow checkout 후 Mac Mini의 `.env.backend.prod`를 작업 디렉토리로 복사
- runner 작업 디렉토리는 매번 새로 생성되어 gitignored env 파일이 없음

## Test plan
- [ ] workflow_dispatch로 수동 트리거 후 배포 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)