### PR TITLE
fix(ci): ai health check docker exec로 변경

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Health check — ai
         run: |
           for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:10000/health; then
+            if docker exec decoded-backend-ai-prod curl -sf http://127.0.0.1:10000/health; then
               echo ""
               echo "ai healthy"
               exit 0


### PR DESCRIPTION
## Summary
- ai 컨테이너는 포트 10000을 호스트에 publish하지 않아 `curl localhost:10000` 실패
- `docker exec decoded-backend-ai-prod curl ...`로 컨테이너 내부에서 체크하도록 변경

## Test plan
- [ ] workflow_dispatch로 수동 트리거 후 ai health check 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)