### PR TITLE
release: dev → main (포스트 상세 응답 속도 드라마틱 개선)

### DIFF
--- a/packages/api-server/src/domains/posts/handlers.rs
+++ b/packages/api-server/src/domains/posts/handlers.rs
@@ -243,21 +243,23 @@ pub async fn get_post(
     Path(post_id): Path<Uuid>,
     user: Option<Extension<User>>,
 ) -> AppResult<Json<PostDetailResponse>> {
-    // 조회수 증가
-    let _ = service::increment_view_count(state.db.as_ref(), post_id).await;
-
     let user_id = user.as_ref().map(|Extension(u)| u.id);
 
-    // 로그인한 사용자의 경우 view_logs 기록
-    if let Some(Extension(ref user)) = user {
-        let _ = crate::domains::views::service::create_view_log(
-            state.db.as_ref(),
-            user.id,
-            "post",
-            post_id,
-        )
-        .await;
-    }
+    // 조회수 증가 + view_log를 백그라운드 태스크로 분리하여 응답 지연 제거
+    let db_bg = state.db.clone();
+    tokio::spawn(async move {
+        let _ = service::increment_view_count(db_bg.as_ref(), post_id).await;
+        if let Some(uid) = user_id {
+            let _ = crate::domains::views::service::create_view_log(
+                db_bg.as_ref(),
+                uid,
+                "post",
+                post_id,
+            )
+            .await;
+        }
+    });
+
     let post_detail = service::get_post_detail(state.db.as_ref(), post_id, user_id).await?;
     Ok(Json(post_detail))
 }

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -629,29 +629,41 @@ pub async fn get_post_detail(
     };
     let saved_fut = async {
         match user_id {
-            Some(uid) => Ok(crate::domains::saved_posts::service::user_has_saved(db, post_id, uid)
-                .await
-                .unwrap_or(false)),
+            Some(uid) => Ok(
+                crate::domains::saved_posts::service::user_has_saved(db, post_id, uid)
+                    .await
+                    .unwrap_or(false),
+            ),
             None => Ok::<bool, crate::error::AppError>(false),
         }
     };
 
-    let (user, related_data, like_count, user_has_liked_val, user_has_saved, (artist_img, group_img)) =
-        tokio::try_join!(
-            user_fut,
-            related_fut,
-            like_count_fut,
-            user_liked_fut,
-            saved_fut,
-            async { Ok(profile_fut.await) },
-        )?;
+    let (
+        user,
+        related_data,
+        like_count,
+        user_has_liked_val,
+        user_has_saved,
+        (artist_img, group_img),
+    ) = tokio::try_join!(
+        user_fut,
+        related_fut,
+        like_count_fut,
+        user_liked_fut,
+        saved_fut,
+        async { Ok(profile_fut.await) },
+    )?;
 
     // 3. Spots이 없으면 빈 응답 반환
     if related_data.spots.is_empty() {
         let media_source = build_media_source_from_post(&post);
         let try_count = if post.post_type.as_deref() != Some(POST_TYPE_TRY) {
             let c = count_tries(db, post_id).await?;
-            if c.count > 0 { Some(c.count) } else { None }
+            if c.count > 0 {
+                Some(c.count)
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -677,12 +689,18 @@ pub async fn get_post_detail(
 
     let is_try = post.post_type.as_deref() == Some(POST_TYPE_TRY);
     let (comment_count, try_count_result) = tokio::try_join!(
-        async { count_comments_by_post_id(db, post_id).await.map(|c| c as i64) },
+        async {
+            count_comments_by_post_id(db, post_id)
+                .await
+                .map(|c| c as i64)
+        },
         async {
             if is_try {
                 return Ok(None);
             }
-            count_tries(db, post_id).await.map(|c| if c.count > 0 { Some(c.count) } else { None })
+            count_tries(db, post_id)
+                .await
+                .map(|c| if c.count > 0 { Some(c.count) } else { None })
         },
     )?;
 
@@ -3405,13 +3423,16 @@ mod tests {
     }
 
     // ── get_post_detail success path: empty spots branch ──
-    // Query order in get_post_detail when spots are empty:
+    // Query order in get_post_detail (parallelized with tokio::try_join!):
     //   1. get_post_by_id            → posts
-    //   2. get_user_by_id            → users
-    //   3. load_post_related_data    → spots (empty → early return inside)
-    //   4. get_like_stats            → posts find_by_id, then post_likes count
-    //   5. (user_has_saved if user)  → saved_posts find
-    //   6. count_tries               → posts count
+    //   2. tokio::try_join! (poll order: user, related, likes, liked, saved, profile):
+    //      a) get_user_by_id         → users
+    //      b) load_post_related_data → spots (empty → early return)
+    //      c) count_likes_by_post_id → post_likes count
+    //      d) user_has_liked (None)  → no query
+    //      e) user_has_saved (None)  → no query
+    //      f) profile images (None)  → no query
+    //   3. count_tries               → posts count
 
     #[tokio::test]
     async fn get_post_detail_empty_spots_no_user_success() {
@@ -3420,17 +3441,15 @@ mod tests {
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]]) // 1) get_post_by_id
-            .append_query_results([[fixtures::user_model()]]) // 2) get_user_by_id
-            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // 3) spots
-            .append_query_results([[fixtures::post_model()]]) // 4a) like_stats: post find
-            .append_query_results([vec![fixtures::count_row(0)]]) // 4b) like count
-            .append_query_results([vec![fixtures::count_row(0)]]) // 6) count_tries
+            .append_query_results([[fixtures::user_model()]]) // 2a) get_user_by_id
+            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // 2b) spots (empty)
+            .append_query_results([vec![fixtures::count_row(0)]]) // 2c) count_likes_by_post_id
+            .append_query_results([vec![fixtures::count_row(0)]]) // 3) count_tries
             .into_connection();
         let result = get_post_detail(&db, fixtures::test_uuid(1), None).await;
         assert!(result.is_ok(), "unexpected err: {:?}", result.err());
         let resp = result.unwrap();
         assert_eq!(resp.id, fixtures::test_uuid(1));
-        // try_count is None when count == 0
         assert!(resp.try_count.is_none());
     }
 
@@ -3441,24 +3460,24 @@ mod tests {
         use crate::tests::fixtures;
         use sea_orm::{DatabaseBackend, MockDatabase};
 
-        // Query order when spots populated:
+        // Query order (parallelized with tokio::try_join!):
         //  1) get_post_by_id
-        //  2) get_user_by_id
-        //  3) load_post_related_data: spots → solutions → subcategories → categories
-        //  4) get_like_stats: post find + count
-        //  5) count_comments_by_post_id
-        //  6) count_tries
+        //  2) tokio::try_join! poll order:
+        //     a) get_user_by_id
+        //     b) load_post_related_data: spots → solutions → subcategories → categories
+        //     c) count_likes_by_post_id
+        //     d-f) no query (no user_id, no artist/group_id)
+        //  3) tokio::try_join! for comment_count + count_tries
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]]) // 1
-            .append_query_results([[fixtures::user_model()]]) // 2
-            .append_query_results([[fixtures::spot_model()]]) // 3a spots
-            .append_query_results([[fixtures::solution_model()]]) // 3b solutions
-            .append_query_results([[fixtures::subcategory_model()]]) // 3c subcategories
-            .append_query_results([[fixtures::category_model()]]) // 3d categories
-            .append_query_results([[fixtures::post_model()]]) // 4a like: post find
-            .append_query_results([vec![fixtures::count_row(0)]]) // 4b like count
-            .append_query_results([vec![fixtures::count_row(2)]]) // 5 comment count
-            .append_query_results([vec![fixtures::count_row(0)]]) // 6 count_tries
+            .append_query_results([[fixtures::user_model()]]) // 2a
+            .append_query_results([[fixtures::spot_model()]]) // 2b-i spots
+            .append_query_results([[fixtures::solution_model()]]) // 2b-ii solutions
+            .append_query_results([[fixtures::subcategory_model()]]) // 2b-iii subcategories
+            .append_query_results([[fixtures::category_model()]]) // 2b-iv categories
+            .append_query_results([vec![fixtures::count_row(0)]]) // 2c like count
+            .append_query_results([vec![fixtures::count_row(2)]]) // 3a comment count
+            .append_query_results([vec![fixtures::count_row(0)]]) // 3b count_tries
             .into_connection();
         let result = get_post_detail(&db, fixtures::test_uuid(1), None).await;
         assert!(result.is_ok(), "unexpected err: {:?}", result.err());
@@ -3898,15 +3917,15 @@ mod tests {
         use crate::tests::fixtures;
         use sea_orm::{DatabaseBackend, MockDatabase};
 
+        // With user_id: user_has_liked + user_has_saved queries fire
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]]) // 1) get_post_by_id
-            .append_query_results([[fixtures::user_model()]]) // 2) get_user_by_id
-            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // 3) spots
-            .append_query_results([[fixtures::post_model()]]) // 4a) like_stats: post find
-            .append_query_results([vec![fixtures::count_row(2)]]) // 4b) like count
-            .append_query_results([Vec::<crate::entities::post_likes::Model>::new()]) // 4c) user_has_liked check
-            .append_query_results([Vec::<crate::entities::saved_posts::Model>::new()]) // 5) user_has_saved
-            .append_query_results([vec![fixtures::count_row(3)]]) // 6) count_tries
+            .append_query_results([[fixtures::user_model()]]) // 2a) get_user_by_id
+            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // 2b) spots (empty)
+            .append_query_results([vec![fixtures::count_row(2)]]) // 2c) count_likes_by_post_id
+            .append_query_results([Vec::<crate::entities::post_likes::Model>::new()]) // 2d) user_has_liked
+            .append_query_results([Vec::<crate::entities::saved_posts::Model>::new()]) // 2e) user_has_saved
+            .append_query_results([vec![fixtures::count_row(3)]]) // 3) count_tries
             .into_connection();
         let result =
             get_post_detail(&db, fixtures::test_uuid(1), Some(fixtures::test_uuid(10))).await;

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -565,74 +565,93 @@ fn build_spots_response(related_data: &PostRelatedData) -> AppResult<Vec<SpotWit
     Ok(spots_with_solutions)
 }
 
-/// Warehouse에서 아티스트/그룹 프로필 이미지를 조회
+/// Warehouse에서 아티스트/그룹 프로필 이미지를 병렬 조회
 async fn load_entity_profile_images(
     db: &DatabaseConnection,
     artist_id: Option<Uuid>,
     group_id: Option<Uuid>,
 ) -> (Option<String>, Option<String>) {
-    let artist_img = if let Some(aid) = artist_id {
-        crate::entities::WarehouseArtists::find_by_id(aid)
-            .one(db)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|a| a.profile_image_url)
-    } else {
-        None
+    let artist_fut = async {
+        match artist_id {
+            Some(aid) => crate::entities::WarehouseArtists::find_by_id(aid)
+                .one(db)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|a| a.profile_image_url),
+            None => None,
+        }
     };
 
-    let group_img = if let Some(gid) = group_id {
-        crate::entities::WarehouseGroups::find_by_id(gid)
-            .one(db)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|g| g.profile_image_url)
-    } else {
-        None
+    let group_fut = async {
+        match group_id {
+            Some(gid) => crate::entities::WarehouseGroups::find_by_id(gid)
+                .one(db)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|g| g.profile_image_url),
+            None => None,
+        }
     };
 
-    (artist_img, group_img)
+    tokio::join!(artist_fut, group_fut)
 }
 
 /// Post 상세 조회 (Spots + 대표 Solution 포함)
+///
+/// 독립적인 쿼리를 tokio::try_join!으로 병렬 실행하여 응답 시간을 최소화한다.
+/// Before: post → user → related_data → like_stats → saved → profile (직렬 ~6 RTT)
+/// After:  post → [user, related_data, like_count, user_liked, saved, profile] 병렬 (~2 RTT)
 pub async fn get_post_detail(
     db: &DatabaseConnection,
     post_id: Uuid,
     user_id: Option<Uuid>,
 ) -> AppResult<PostDetailResponse> {
     use crate::domains::comments::service::count_comments_by_post_id;
-    use crate::domains::post_likes::service::get_like_stats as get_post_like_stats;
+    use crate::domains::post_likes::service::{count_likes_by_post_id, user_has_liked};
     use crate::domains::users::service::get_user_by_id;
 
-    // 1. Post 및 관련 데이터 로드
+    // 1. Post 조회 (나머지 쿼리에서 post.user_id, post.artist_id 등이 필요)
     let post = get_post_by_id(db, post_id).await?;
-    let user = get_user_by_id(db, post.user_id).await?;
-    let related_data = load_post_related_data(db, post_id).await?;
 
-    // 2. Like/Saved 상태 + warehouse 프로필 이미지 조회
-    let like_stats = get_post_like_stats(db, post_id, user_id).await?;
-    let user_has_saved = if let Some(uid) = user_id {
-        crate::domains::saved_posts::service::user_has_saved(db, post_id, uid)
-            .await
-            .unwrap_or(false)
-    } else {
-        false
+    // 2. 독립적인 쿼리들을 모두 병렬 실행
+    let user_fut = get_user_by_id(db, post.user_id);
+    let related_fut = load_post_related_data(db, post_id);
+    let like_count_fut = count_likes_by_post_id(db, post_id);
+    let profile_fut = load_entity_profile_images(db, post.artist_id, post.group_id);
+
+    let user_liked_fut = async {
+        match user_id {
+            Some(uid) => user_has_liked(db, post_id, uid).await,
+            None => Ok(false),
+        }
     };
-    let (artist_profile_image_url, group_profile_image_url) =
-        load_entity_profile_images(db, post.artist_id, post.group_id).await;
+    let saved_fut = async {
+        match user_id {
+            Some(uid) => Ok(crate::domains::saved_posts::service::user_has_saved(db, post_id, uid)
+                .await
+                .unwrap_or(false)),
+            None => Ok::<bool, crate::error::AppError>(false),
+        }
+    };
+
+    let (user, related_data, like_count, user_has_liked_val, user_has_saved, (artist_img, group_img)) =
+        tokio::try_join!(
+            user_fut,
+            related_fut,
+            like_count_fut,
+            user_liked_fut,
+            saved_fut,
+            async { Ok(profile_fut.await) },
+        )?;
 
     // 3. Spots이 없으면 빈 응답 반환
     if related_data.spots.is_empty() {
         let media_source = build_media_source_from_post(&post);
         let try_count = if post.post_type.as_deref() != Some(POST_TYPE_TRY) {
             let c = count_tries(db, post_id).await?;
-            if c.count > 0 {
-                Some(c.count)
-            } else {
-                None
-            }
+            if c.count > 0 { Some(c.count) } else { None }
         } else {
             None
         };
@@ -642,49 +661,45 @@ pub async fn get_post_detail(
             media_source,
             None,
             0,
-            like_stats.like_count as i64,
-            Some(like_stats.user_has_liked),
+            like_count as i64,
+            Some(user_has_liked_val),
             user_id.map(|_| user_has_saved),
         );
         response.try_count = try_count;
-        response.artist_profile_image_url = artist_profile_image_url;
-        response.group_profile_image_url = group_profile_image_url;
+        response.artist_profile_image_url = artist_img;
+        response.group_profile_image_url = group_img;
         return Ok(response);
     }
 
-    // 4. Spot 목록 생성 (배치 로드된 데이터로부터)
+    // 4. Spot 목록 생성 + Comment/Try 카운트 병렬
     let spots = build_spots_response(&related_data)?;
-
-    // 5. Comment 개수 및 MediaSource 조회
-    let comment_count = count_comments_by_post_id(db, post_id).await? as i64;
     let media_source = build_media_source_from_post(&post);
 
-    // 6. Try 개수 조회 (원본 포스트인 경우만)
-    let try_count = if post.post_type.as_deref() != Some(POST_TYPE_TRY) {
-        let count = count_tries(db, post_id).await?;
-        if count.count > 0 {
-            Some(count.count)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    let is_try = post.post_type.as_deref() == Some(POST_TYPE_TRY);
+    let (comment_count, try_count_result) = tokio::try_join!(
+        async { count_comments_by_post_id(db, post_id).await.map(|c| c as i64) },
+        async {
+            if is_try {
+                return Ok(None);
+            }
+            count_tries(db, post_id).await.map(|c| if c.count > 0 { Some(c.count) } else { None })
+        },
+    )?;
 
-    // 7. PostDetailResponse 반환
+    // 5. PostDetailResponse 반환
     let mut response = PostDetailResponse::from_post_model(
         post,
         user,
         media_source,
         Some(spots),
         comment_count,
-        like_stats.like_count as i64,
-        Some(like_stats.user_has_liked),
+        like_count as i64,
+        Some(user_has_liked_val),
         user_id.map(|_| user_has_saved),
     );
-    response.try_count = try_count;
-    response.artist_profile_image_url = artist_profile_image_url;
-    response.group_profile_image_url = group_profile_image_url;
+    response.try_count = try_count_result;
+    response.artist_profile_image_url = artist_img;
+    response.group_profile_image_url = group_img;
 
     Ok(response)
 }

--- a/packages/api-server/src/domains/posts/tests.rs
+++ b/packages/api-server/src/domains/posts/tests.rs
@@ -628,23 +628,29 @@ mod tests {
         use axum::extract::{Path, State};
         use sea_orm::{DatabaseBackend, MockDatabase};
 
-        // increment_view_count: get_post_by_id + update → both succeed
-        // get_post_detail (empty spots path):
-        //   1) get_post_by_id → post
-        //   2) get_user_by_id → user
-        //   3) load_post_related_data → spots (empty)
-        //   4) get_like_stats: post find + count
-        //   5) count_tries
-        let updated_post = post_model();
+        // increment_view_count + view_log are now in tokio::spawn (background, not awaited).
+        // Handler only awaits get_post_detail. With a shared MockDatabase, the spawned
+        // task may consume mock rows unpredictably, so we provide enough results for both
+        // the background task and the main path.
+        //
+        // get_post_detail (parallelized, empty spots, no user):
+        //   1) get_post_by_id
+        //   2a) get_user_by_id
+        //   2b) spots (empty)
+        //   2c) count_likes_by_post_id
+        //   3) count_tries
+        //
+        // Background task (may or may not consume from same mock):
+        //   - increment_view_count: get_post_by_id + update
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![post_model()]]) // inc: find
-            .append_query_results([vec![updated_post.clone()]]) // inc: update returns model
-            .append_query_results([vec![post_model()]]) // detail: post
-            .append_query_results([vec![user_model()]]) // detail: user
+            .append_query_results([vec![post_model()]]) // detail: get_post_by_id
+            .append_query_results([vec![user_model()]]) // detail: get_user_by_id
             .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // spots
-            .append_query_results([vec![post_model()]]) // like_stats post find
-            .append_query_results([vec![count_row(0)]]) // like count
+            .append_query_results([vec![count_row(0)]]) // count_likes_by_post_id
             .append_query_results([vec![count_row(0)]]) // count_tries
+            // Extra rows for background increment_view_count (best-effort)
+            .append_query_results([vec![post_model()]]) // inc: find
+            .append_query_results([vec![post_model()]]) // inc: update
             .into_connection();
         let state = test_app_state(db);
 
@@ -1144,17 +1150,15 @@ mod tests {
         use axum::Extension;
         use sea_orm::{DatabaseBackend, MockDatabase};
 
-        // Flow:
-        //   increment_view_count: get_post_by_id + update
-        //   create_view_log: find existing view_log → Some → early return
-        //   get_post_detail (empty spots):
-        //     1) get_post_by_id
-        //     2) get_user_by_id
-        //     3) spots (empty)
-        //     4) like_stats: post find + like_count
-        //     5) user_has_liked check: post_likes find (Some(uid) branch)
-        //     6) user_has_saved: saved_posts find
-        //     7) count_tries
+        // Background tasks (tokio::spawn): increment_view_count + create_view_log
+        // Main path: get_post_detail (parallelized, empty spots, with user_id):
+        //   1) get_post_by_id
+        //   2a) get_user_by_id
+        //   2b) spots (empty)
+        //   2c) count_likes_by_post_id
+        //   2d) user_has_liked
+        //   2e) user_has_saved
+        //   3) count_tries
         let existing_view_log = crate::entities::view_logs::Model {
             id: test_uuid(111),
             user_id: Some(test_uuid(10)),
@@ -1163,17 +1167,17 @@ mod tests {
             created_at: crate::tests::fixtures::test_timestamp(),
         };
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![post_model()]]) // inc: find
-            .append_query_results([vec![post_model()]]) // inc: update
-            .append_query_results([vec![existing_view_log]]) // view_logs find → Some → skip insert
-            .append_query_results([vec![post_model()]]) // detail: post
-            .append_query_results([vec![user_model()]]) // detail: user
+            .append_query_results([vec![post_model()]]) // detail: get_post_by_id
+            .append_query_results([vec![user_model()]]) // detail: get_user_by_id
             .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // spots
-            .append_query_results([vec![post_model()]]) // like: post find
-            .append_query_results([vec![count_row(0)]]) // like count
+            .append_query_results([vec![count_row(0)]]) // count_likes_by_post_id
             .append_query_results([Vec::<crate::entities::post_likes::Model>::new()]) // user_has_liked
             .append_query_results([Vec::<crate::entities::saved_posts::Model>::new()]) // user_has_saved
             .append_query_results([vec![count_row(0)]]) // count_tries
+            // Extra rows for background tasks (best-effort)
+            .append_query_results([vec![post_model()]]) // inc: find
+            .append_query_results([vec![post_model()]]) // inc: update
+            .append_query_results([vec![existing_view_log]]) // view_logs find → skip insert
             .into_connection();
         let state = test_app_state(db);
         let result = get_post(

--- a/packages/web/app/@modal/(.)posts/[id]/page.tsx
+++ b/packages/web/app/@modal/(.)posts/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { ImageDetailModal } from "@/lib/components/detail/ImageDetailModal";
+import { prefetchPostDetail } from "@/lib/api/server-prefetch";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -12,5 +13,13 @@ export default async function ModalPostDetailPage({
   const [{ id }, { from }] = await Promise.all([params, searchParams]);
   const variant = from === "explore" ? "explore-preview" : "full";
 
-  return <ImageDetailModal imageId={id} variant={variant} />;
+  const prefetchedDetail = await prefetchPostDetail(id);
+
+  return (
+    <ImageDetailModal
+      imageId={id}
+      variant={variant}
+      serverData={prefetchedDetail}
+    />
+  );
 }

--- a/packages/web/app/posts/[id]/page.tsx
+++ b/packages/web/app/posts/[id]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { ImageDetailPage } from "@/lib/components/detail/ImageDetailPage";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { JsonLdArticle } from "@/lib/seo/json-ld";
+import { prefetchPostDetail } from "@/lib/api/server-prefetch";
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -71,7 +72,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function PostDetailPageRoute({ params }: Props) {
   const { id } = await params;
-  const post = await getCachedPost(id);
+
+  const [post, prefetchedDetail] = await Promise.all([
+    getCachedPost(id),
+    prefetchPostDetail(id),
+  ]);
 
   const artistLabel = post?.artist_name || post?.group_name || "Unknown";
   const title = post?.title || post?.context || `${artistLabel}'s Style`;
@@ -92,7 +97,7 @@ export default async function PostDetailPageRoute({ params }: Props) {
           artistName={artistLabel}
         />
       )}
-      <ImageDetailPage imageId={id} />
+      <ImageDetailPage imageId={id} serverData={prefetchedDetail} />
     </>
   );
 }

--- a/packages/web/lib/api/adapters/postDetailToImageDetail.ts
+++ b/packages/web/lib/api/adapters/postDetailToImageDetail.ts
@@ -33,6 +33,8 @@ export type ImageDetailWithPostOwner = ImageDetail & {
   artist_profile_image_url?: string | null;
   /** 그룹 프로필 이미지 URL (백엔드에서 warehouse 조회) */
   group_profile_image_url?: string | null;
+  /** 백엔드에서 제공하는 댓글 수 (별도 fetch 불필요) */
+  comment_count?: number;
 };
 
 function parsePosition(val: string): number {
@@ -105,6 +107,7 @@ export function postDetailToImageDetail(
     group_name: post.group_name ?? null,
     artist_profile_image_url: post.artist_profile_image_url ?? null,
     group_profile_image_url: post.group_profile_image_url ?? null,
+    comment_count: post.comment_count ?? 0,
     status: post.status as
       | "pending"
       | "extracted"

--- a/packages/web/lib/api/server-prefetch.ts
+++ b/packages/web/lib/api/server-prefetch.ts
@@ -1,0 +1,41 @@
+/**
+ * Server-side prefetch for post detail.
+ *
+ * Fetches PostDetailResponse from Rust backend during RSC render and transforms
+ * it to ImageDetail so the client component can render immediately without a
+ * separate client-side fetch waterfall.
+ */
+
+import { cache } from "react";
+import { API_BASE_URL } from "@/lib/server-env";
+import type { ImageDetail } from "@/lib/supabase/queries/images";
+
+/**
+ * Prefetch post detail from Rust API on the server.
+ * Returns the raw JSON or null on failure (non-blocking — client will retry).
+ */
+export const prefetchPostDetail = cache(
+  async (postId: string): Promise<ImageDetail | null> => {
+    if (!API_BASE_URL) return null;
+
+    try {
+      const url = `${API_BASE_URL}/api/v1/posts/${postId}`;
+      const res = await fetch(url, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+        next: { revalidate: 30 },
+      });
+
+      if (!res.ok) return null;
+
+      const post = await res.json();
+
+      const { postDetailToImageDetail } = await import(
+        "@/lib/api/adapters/postDetailToImageDetail"
+      );
+      return postDetailToImageDetail(post, postId);
+    } catch {
+      return null;
+    }
+  }
+);

--- a/packages/web/lib/components/detail/ImageDetailContent.tsx
+++ b/packages/web/lib/components/detail/ImageDetailContent.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { RefObject, useCallback, useMemo, useRef, useState } from "react";
+import {
+  RefObject,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  lazy,
+  Suspense,
+} from "react";
 import type { ImageDetail } from "@/lib/supabase/queries/images";
 import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
 import type {
@@ -13,7 +21,9 @@ import type { UiItem } from "./types";
 import { HeroSection } from "./HeroSection";
 import { InteractiveShowcase } from "./InteractiveShowcase";
 import { ShopGrid } from "./ShopGrid";
-import { RelatedImages } from "./RelatedImages";
+const RelatedImages = lazy(() =>
+  import("./RelatedImages").then((m) => ({ default: m.RelatedImages }))
+);
 import { SocialActions } from "@/lib/components/shared/SocialActions";
 import { ImageCommentSection } from "./ImageCommentSection";
 import { AddSolutionSheet } from "./AddSolutionSheet";
@@ -29,11 +39,18 @@ import {
   MagazineCelebSection,
   MagazineItemsSection,
   MagazineNewsSection,
-  MagazineRelatedSection,
 } from "./magazine";
 import { MagazineTitleSection } from "./magazine/MagazineTitleSection";
+// MagazineRelatedSection lazy-loaded (only rendered when related editorials exist)
+const MagazineRelatedSectionLazy = lazy(() =>
+  import("./magazine").then((m) => ({
+    default: m.MagazineRelatedSection,
+  }))
+);
 import { EditorialPreviewHeader } from "./EditorialPreviewHeader";
-import DecodeShowcase from "@/lib/components/main-renewal/DecodeShowcase";
+const DecodeShowcase = lazy(
+  () => import("@/lib/components/main-renewal/DecodeShowcase")
+);
 import { toDecodeShowcaseData } from "./adapters/toDecodeShowcaseData";
 import { SpotDot } from "./SpotDot";
 import { SpotSolutionTabs } from "./SpotSolutionTabs";
@@ -49,6 +66,8 @@ type Props = {
   hideImage?: boolean;
   onHeroClick?: () => void;
   variant?: "full" | "explore-preview";
+  /** Pre-computed comment count from PostDetailResponse (avoids separate fetch) */
+  commentCount?: number;
 };
 
 /**
@@ -71,6 +90,7 @@ export function ImageDetailContent({
   hideImage = false,
   onHeroClick,
   variant = "full",
+  commentCount: commentCountProp,
 }: Props) {
   const isExplorePreview = variant === "explore-preview";
   const hasMagazine = !!magazineLayout;
@@ -233,7 +253,10 @@ export function ImageDetailContent({
     null
   );
 
-  const commentCount = useCommentCount(image.id);
+  const fetchedCommentCount = useCommentCount(
+    commentCountProp != null ? "" : image.id
+  );
+  const commentCount = commentCountProp ?? fetchedCommentCount;
 
   // Build DecodeShowcase data from normalized items (magazine mode)
   const decodeShowcaseData = useMemo(() => {
@@ -396,7 +419,9 @@ export function ImageDetailContent({
         {/* Section 2: DecodeShowcase (magazine) or Interactive Showcase (non-magazine) */}
         {/* In modal mode, skip — the floating left panel already shows this image */}
         {decodeShowcaseData && !isModal && !isExplorePreview && (
-          <DecodeShowcase data={decodeShowcaseData} />
+          <Suspense fallback={null}>
+            <DecodeShowcase data={decodeShowcaseData} />
+          </Suspense>
         )}
         {!hasMagazine && hasItemsWithCoordinates && (
           <InteractiveShowcase
@@ -517,19 +542,34 @@ export function ImageDetailContent({
           </>
         )}
 
-        {/* Related Posts - 같은 유저가 올린 다른 포스트 */}
+        {/* Related Posts - 같은 유저가 올린 다른 포스트 (lazy loaded) */}
         {!isExplorePreview &&
           (image.postImages?.[0]?.post as Record<string, unknown>)?.account && (
-            <RelatedImages
-              currentPostId={image.id}
-              account={String(
-                (image.postImages![0].post as Record<string, unknown>).account
-              )}
-              userId={
-                (image as ImageDetailWithPostOwner).post_owner_id ?? undefined
+            <Suspense
+              fallback={
+                <div className="mx-auto max-w-6xl px-4 py-8">
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                    {Array.from({ length: 6 }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="aspect-[3/4] animate-pulse rounded-lg bg-muted"
+                      />
+                    ))}
+                  </div>
+                </div>
               }
-              isModal={isModal}
-            />
+            >
+              <RelatedImages
+                currentPostId={image.id}
+                account={String(
+                  (image.postImages![0].post as Record<string, unknown>).account
+                )}
+                userId={
+                  (image as ImageDetailWithPostOwner).post_owner_id ?? undefined
+                }
+                isModal={isModal}
+              />
+            </Suspense>
           )}
 
         {/* TODO: Try Gallery Section — temporarily disabled
@@ -564,9 +604,13 @@ export function ImageDetailContent({
           />
         </div>
 
-        {/* Magazine: Related Editorials - 맨 마지막 */}
+        {/* Magazine: Related Editorials - 맨 마지막 (lazy loaded) */}
         {hasMagazine && relatedEditorials && relatedEditorials.length > 0 && (
-          <MagazineRelatedSection relatedEditorials={relatedEditorials} />
+          <Suspense fallback={null}>
+            <MagazineRelatedSectionLazy
+              relatedEditorials={relatedEditorials}
+            />
+          </Suspense>
         )}
 
         {/* Fallback: Show basic info if no items */}

--- a/packages/web/lib/components/detail/ImageDetailModal.tsx
+++ b/packages/web/lib/components/detail/ImageDetailModal.tsx
@@ -13,20 +13,30 @@ import { useTransitionStore } from "@/lib/stores/transitionStore";
 import { useShallow } from "zustand/react/shallow";
 import { useTrackEvent } from "@/lib/hooks/useTrackEvent";
 import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
+import type { ImageDetail } from "@/lib/supabase/queries/images";
 import { useImageModalAnimation } from "@/lib/hooks/useImageModalAnimation";
 
 type Props = {
   imageId: string;
   variant?: "full" | "explore-preview";
+  serverData?: ImageDetail | null;
 };
 
 /**
  * Side Drawer version of image detail page
  * Used when navigating from grid (intercepting route)
  */
-export function ImageDetailModal({ imageId, variant = "full" }: Props) {
+export function ImageDetailModal({
+  imageId,
+  variant = "full",
+  serverData,
+}: Props) {
   const router = useRouter();
-  const { data: image, isLoading, error } = usePostDetailForImage(imageId);
+  const {
+    data: image,
+    isLoading,
+    error,
+  } = usePostDetailForImage(imageId, serverData ?? undefined);
   const magazineId = (image as ImageDetailWithPostOwner)?.post_magazine_id;
   const { data: magazine } = usePostMagazine(magazineId);
   const { originRect, reset, imgSrc } = useTransitionStore(
@@ -214,6 +224,11 @@ export function ImageDetailModal({ imageId, variant = "full" }: Props) {
         ? magazine.layout_json
         : null;
 
+    const imgWithOwner = image as ImageDetailWithPostOwner & {
+      comment_count?: number;
+    };
+    const backendCommentCount = imgWithOwner.comment_count;
+
     // Magazine posts: use same ImageDetailContent as full page (with isModal to skip GSAP)
     if (publishedMagazineLayout) {
       return (
@@ -228,6 +243,7 @@ export function ImageDetailModal({ imageId, variant = "full" }: Props) {
           }
           activeIndex={activeIndex}
           onActiveIndexChange={setActiveIndex}
+          commentCount={backendCommentCount}
         />
       );
     }
@@ -244,6 +260,7 @@ export function ImageDetailModal({ imageId, variant = "full" }: Props) {
         scrollContainerRef={scrollContainerRef as React.RefObject<HTMLElement>}
         activeIndex={activeIndex}
         onActiveIndexChange={setActiveIndex}
+        commentCount={backendCommentCount}
       />
     );
   };

--- a/packages/web/lib/components/detail/ImageDetailPage.tsx
+++ b/packages/web/lib/components/detail/ImageDetailPage.tsx
@@ -2,54 +2,54 @@
 
 import { usePostDetailForImage, usePostMagazine } from "@/lib/hooks/useImages";
 import { ImageDetailContent } from "./ImageDetailContent";
-import { LenisProvider } from "./LenisProvider";
-import { useEffect, useRef, useState } from "react";
-import { gsap } from "gsap";
+import { useEffect, useRef, lazy, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
-import { Lightbox } from "./Lightbox";
 import { ErrorState } from "@/lib/components/shared";
 import { useTrackEvent } from "@/lib/hooks/useTrackEvent";
 import type { ImageDetailWithPostOwner } from "@/lib/api/adapters/postDetailToImageDetail";
+import type { ImageDetail } from "@/lib/supabase/queries/images";
+
+const LenisProvider = lazy(() =>
+  import("./LenisProvider").then((m) => ({ default: m.LenisProvider }))
+);
 
 type Props = {
   imageId: string;
+  serverData?: ImageDetail | null;
 };
 
 /**
- * Full page version of image detail
- * Used when directly accessing URL or refreshing page
- * Now renders post data instead of old image data
+ * Full page version of image detail.
+ * Accepts optional serverData prefetched by the RSC to eliminate client waterfall.
  */
-export function ImageDetailPage({ imageId }: Props) {
+export function ImageDetailPage({ imageId, serverData }: Props) {
   const router = useRouter();
-  const { data: image, isLoading, error } = usePostDetailForImage(imageId);
+  const {
+    data: image,
+    isLoading,
+    error,
+  } = usePostDetailForImage(imageId, serverData ?? undefined);
   const magazineId = (image as ImageDetailWithPostOwner)?.post_magazine_id;
   const { data: magazine, isLoading: magazineLoading } =
     usePostMagazine(magazineId);
   const pageRef = useRef<HTMLDivElement>(null);
-  const [showLightbox, setShowLightbox] = useState(false);
   const track = useTrackEvent();
 
-  // Track post_view on page mount (once per post)
   useEffect(() => {
     if (!imageId) return;
     track({ event_type: "post_view", entity_id: imageId });
   }, [imageId]);
 
-  // Fade-in animation for direct access
   useEffect(() => {
     if (!pageRef.current) return;
-
-    gsap.fromTo(
-      pageRef.current,
-      { opacity: 0 },
-      {
-        opacity: 1,
-        duration: 0.4,
-        ease: "power2.out",
+    pageRef.current.style.opacity = "0";
+    requestAnimationFrame(() => {
+      if (pageRef.current) {
+        pageRef.current.style.transition = "opacity 0.4s ease-out";
+        pageRef.current.style.opacity = "1";
       }
-    );
+    });
   }, []);
 
   const handleBack = () => {
@@ -89,33 +89,30 @@ export function ImageDetailPage({ imageId }: Props) {
   }
 
   return (
-    <LenisProvider>
-      <div ref={pageRef} className="relative">
-        {/* Back Button */}
-        <div className="fixed left-4 top-16 md:top-20 z-50">
-          <button
-            onClick={handleBack}
-            className="flex h-11 w-11 items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-transform transition-colors hover:scale-105 hover:bg-background/90"
-            aria-label="Back"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </button>
+    <Suspense fallback={<div ref={pageRef} className="relative" />}>
+      <LenisProvider>
+        <div ref={pageRef} className="relative">
+          <div className="fixed left-4 top-16 md:top-20 z-50">
+            <button
+              onClick={handleBack}
+              className="flex h-11 w-11 items-center justify-center rounded-full bg-background/80 backdrop-blur-sm transition-transform transition-colors hover:scale-105 hover:bg-background/90"
+              aria-label="Back"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </button>
+          </div>
+
+          <ImageDetailContent
+            image={image}
+            magazineLayout={showMagazine ? magazine!.layout_json : null}
+            relatedEditorials={magazine?.related_editorials ?? []}
+            commentCount={
+              (image as ImageDetailWithPostOwner & { comment_count?: number })
+                .comment_count
+            }
+          />
         </div>
-
-        <ImageDetailContent
-          image={image}
-          magazineLayout={showMagazine ? magazine!.layout_json : null}
-          relatedEditorials={magazine?.related_editorials ?? []}
-        />
-
-        {/* Lightbox */}
-        <Lightbox
-          isOpen={showLightbox}
-          onClose={() => setShowLightbox(false)}
-          imageUrl={(image as { image_url?: string }).image_url || ""}
-          alt={`Post ${image.id}`}
-        />
-      </div>
-    </LenisProvider>
+      </LenisProvider>
+    </Suspense>
   );
 }

--- a/packages/web/lib/hooks/useImages.ts
+++ b/packages/web/lib/hooks/useImages.ts
@@ -253,9 +253,14 @@ export function useInfinitePosts(params: {
 
 /**
  * Fetch post detail and convert to ImageDetail for ImageDetailContent.
- * Tries REST API first (production), falls back to Supabase direct (dev without backend).
+ *
+ * When `serverData` is provided (prefetched by RSC), the query starts with
+ * that data immediately — no client-side fetch waterfall.
  */
-export function usePostDetailForImage(postId: string) {
+export function usePostDetailForImage(
+  postId: string,
+  serverData?: ImageDetail
+) {
   return useQuery<ImageDetail | null>({
     queryKey: ["posts", "detail", "image", postId],
     queryFn: async () => {
@@ -265,6 +270,7 @@ export function usePostDetailForImage(postId: string) {
     enabled: !!postId,
     staleTime: 1000 * 60,
     gcTime: 1000 * 60 * 5,
+    initialData: serverData ?? undefined,
   });
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release: dev → main

### 포함된 변경사항

- **PR #189**: 포스트 상세 응답 속도 드라마틱 개선
  - Rust 백엔드: `tokio::try_join!` 병렬 쿼리 (6 RTT → 2 RTT)
  - view_count/view_log 백그라운드 처리 (`tokio::spawn`)
  - 프론트엔드: RSC 서버 prefetch로 클라이언트 waterfall 제거
  - comment_count 별도 fetch 제거 (백엔드 응답 활용)
  - GSAP/Lenis/Lightbox/RelatedImages/DecodeShowcase lazy loading
  - 예상 체감 시간: ~500-700ms → ~100-200ms
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50a0f25a-0389-4351-bb43-aa1d74e62bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50a0f25a-0389-4351-bb43-aa1d74e62bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

