### PR TITLE
perf(api): optimize list_posts latency

### DIFF
--- a/packages/api-server/migration/src/lib.rs
+++ b/packages/api-server/migration/src/lib.rs
@@ -50,6 +50,7 @@ mod m20260406_000001_drop_post_magazines_thread_id;
 mod m20260406_000002_add_style_tags_to_posts;
 mod m20260407_000001_create_post_magazine_news_references;
 mod m20260409_add_image_dimensions;
+mod m20260412_000001_add_posts_performance_indexes;
 
 pub struct Migrator;
 
@@ -107,6 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260406_000002_add_style_tags_to_posts::Migration),
             Box::new(m20260407_000001_create_post_magazine_news_references::Migration),
             Box::new(m20260409_add_image_dimensions::Migration),
+            Box::new(m20260412_000001_add_posts_performance_indexes::Migration),
         ]
     }
 }

--- a/packages/api-server/migration/src/m20260412_000001_add_posts_performance_indexes.rs
+++ b/packages/api-server/migration/src/m20260412_000001_add_posts_performance_indexes.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // 1. trending 정렬 최적화: partial index (active posts only)
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX IF NOT EXISTS idx_posts_trending_active \
+                 ON posts (trending_score DESC NULLS LAST, created_at DESC) \
+                 WHERE status = 'active' AND (post_type IS NULL OR post_type != 'try')",
+            )
+            .await?;
+
+        // 2. solutions status + spot_id: has_solutions 서브쿼리 최적화
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX IF NOT EXISTS idx_solutions_active_spot_id \
+                 ON solutions (spot_id) \
+                 WHERE status = 'active'",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS idx_posts_trending_active")
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared("DROP INDEX IF EXISTS idx_solutions_active_spot_id")
+            .await?;
+        Ok(())
+    }
+}

--- a/packages/api-server/src/config.rs
+++ b/packages/api-server/src/config.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::domains::categories::CategoryCache;
+use crate::domains::posts::cache::PostListCache;
 use crate::services::{
     AffiliateClient, CloudflareR2Client, DecodedAIGrpcClient, DummyEmbeddingClient,
     EmbeddingClient, MeilisearchClient, OpenAIEmbeddingClient, RakutenAffiliateClient,
@@ -227,8 +228,9 @@ pub struct AppState {
     pub db: Arc<DatabaseConnection>,
     pub config: AppConfig,
 
-    // Category Cache
+    // Caches
     pub category_cache: Arc<CategoryCache>,
+    pub post_list_cache: Arc<PostListCache>,
 
     // Trait 기반 클라이언트
     pub storage_client: Arc<dyn StorageClient>,
@@ -315,9 +317,10 @@ impl AppState {
                 }
             };
 
-        // CategoryCache 초기화
+        // Cache 초기화
         let category_cache = Arc::new(CategoryCache::new());
-        tracing::info!("CategoryCache initialized successfully");
+        let post_list_cache = Arc::new(PostListCache::new());
+        tracing::info!("CategoryCache, PostListCache initialized successfully");
 
         // DecodedAIGrpcClient 초기화 (lazy connect - 실제 연결은 첫 RPC 시점에 수행)
         let grpc_url = config.ai_service.url.trim().to_string();
@@ -346,6 +349,7 @@ impl AppState {
             db,
             config,
             category_cache,
+            post_list_cache,
             storage_client,
             search_client,
             affiliate_client,

--- a/packages/api-server/src/domains/posts/cache.rs
+++ b/packages/api-server/src/domains/posts/cache.rs
@@ -1,0 +1,80 @@
+//! Post list cache service
+//!
+//! 피드 목록 응답을 단기 캐싱하여 반복 요청의 DB 부하를 제거한다.
+
+use moka::future::Cache;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::domains::posts::dto::PostListItem;
+use crate::utils::pagination::PaginatedResponse;
+
+/// 캐시 TTL (30초 — 피드는 자주 변경되므로 짧게)
+const CACHE_TTL_SECS: u64 = 30;
+
+/// 최대 캐시 엔트리 수 (쿼리 조합별)
+const CACHE_MAX_CAPACITY: u64 = 200;
+
+/// Post 목록 캐시
+pub struct PostListCache {
+    cache: Cache<String, Arc<PaginatedResponse<PostListItem>>>,
+}
+
+impl PostListCache {
+    pub fn new() -> Self {
+        let cache = Cache::builder()
+            .time_to_live(Duration::from_secs(CACHE_TTL_SECS))
+            .max_capacity(CACHE_MAX_CAPACITY)
+            .build();
+
+        Self { cache }
+    }
+
+    /// 캐시 키 생성: query params를 정렬된 문자열로 직렬화
+    fn cache_key(query: &super::dto::PostListQuery) -> String {
+        // serde_json은 struct 필드 순서가 고정이므로 deterministic
+        serde_json::to_string(query).unwrap_or_default()
+    }
+
+    /// 캐시에서 조회
+    pub async fn get(
+        &self,
+        query: &super::dto::PostListQuery,
+    ) -> Option<Arc<PaginatedResponse<PostListItem>>> {
+        self.cache.get(&Self::cache_key(query)).await
+    }
+
+    /// 캐시에 저장
+    pub async fn insert(
+        &self,
+        query: &super::dto::PostListQuery,
+        response: PaginatedResponse<PostListItem>,
+    ) {
+        self.cache
+            .insert(Self::cache_key(query), Arc::new(response))
+            .await;
+    }
+
+    /// 캐시 전체 무효화 (post 생성/수정/삭제 시)
+    pub async fn invalidate_all(&self) {
+        self.cache.invalidate_all();
+    }
+}
+
+impl Default for PostListCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_post_list_cache_default() {
+        let cache = PostListCache::default();
+        assert_eq!(cache.cache.entry_count(), 0);
+    }
+}

--- a/packages/api-server/src/domains/posts/dto.rs
+++ b/packages/api-server/src/domains/posts/dto.rs
@@ -227,7 +227,7 @@ pub struct UpdatePostDto {
 }
 
 /// Post 목록 조회 쿼리 파라미터
-#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PostListQuery {
     /// 아티스트명 필터
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/packages/api-server/src/domains/posts/handlers.rs
+++ b/packages/api-server/src/domains/posts/handlers.rs
@@ -110,6 +110,7 @@ pub async fn create_post_without_solutions(
         dto,
     )
     .await?;
+    state.post_list_cache.invalidate_all().await;
     Ok(Json(post))
 }
 
@@ -191,6 +192,7 @@ pub async fn create_post_with_solutions(
     let result =
         service::create_post_with_solutions(&state, user.id, image_file, &image_content_type, dto)
             .await?;
+    state.post_list_cache.invalidate_all().await;
     Ok(Json(result))
 }
 
@@ -221,7 +223,16 @@ pub async fn list_posts(
     State(state): State<AppState>,
     Query(query): Query<PostListQuery>,
 ) -> AppResult<Json<PaginatedResponse<crate::domains::posts::dto::PostListItem>>> {
-    let posts = service::list_posts(state.db.as_ref(), query).await?;
+    // 캐시 히트 시 즉시 반환
+    if let Some(cached) = state.post_list_cache.get(&query).await {
+        return Ok(Json((*cached).clone()));
+    }
+
+    let posts = service::list_posts(state.db.as_ref(), query.clone()).await?;
+
+    // 캐시에 저장 (30초 TTL)
+    state.post_list_cache.insert(&query, posts.clone()).await;
+
     Ok(Json(posts))
 }
 
@@ -290,6 +301,7 @@ pub async fn update_post(
     Json(dto): Json<UpdatePostDto>,
 ) -> AppResult<Json<PostResponse>> {
     let updated_post = service::update_post(&state, post_id, user.id, dto).await?;
+    state.post_list_cache.invalidate_all().await;
     Ok(Json(updated_post))
 }
 
@@ -317,6 +329,7 @@ pub async fn delete_post(
     Path(post_id): Path<Uuid>,
 ) -> AppResult<axum::http::StatusCode> {
     service::delete_post(&state.search_client, state.db.as_ref(), post_id, user.id).await?;
+    state.post_list_cache.invalidate_all().await;
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
 

--- a/packages/api-server/src/domains/posts/mod.rs
+++ b/packages/api-server/src/domains/posts/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! 게시물 관리 및 API 엔드포인트
 
+pub mod cache;
 pub mod dto;
 pub mod handlers;
 pub mod magazine_preview;

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -666,39 +666,33 @@ async fn load_warehouse_display_maps(
     let artist_ids: Vec<Uuid> = posts.iter().filter_map(|p| p.artist_id).collect();
     let group_ids: Vec<Uuid> = posts.iter().filter_map(|p| p.group_id).collect();
 
-    let artist_fut = async {
-        if artist_ids.is_empty() {
-            Ok::<_, AppError>(std::collections::HashMap::new())
-        } else {
-            let rows = WarehouseArtists::find()
-                .filter(ArtistCol::Id.is_in(artist_ids))
-                .all(db)
-                .await
-                .map_err(AppError::DatabaseError)?;
-            Ok(rows
-                .into_iter()
-                .map(|a| (a.id, (a.name_en, a.name_ko, a.profile_image_url)))
-                .collect())
-        }
-    };
-    let group_fut = async {
-        if group_ids.is_empty() {
-            Ok::<_, AppError>(std::collections::HashMap::new())
-        } else {
-            let rows = WarehouseGroups::find()
-                .filter(GroupCol::Id.is_in(group_ids))
-                .all(db)
-                .await
-                .map_err(AppError::DatabaseError)?;
-            Ok(rows
-                .into_iter()
-                .map(|g| (g.id, (g.name_en, g.name_ko, g.profile_image_url)))
-                .collect())
-        }
+    let artist_map = if artist_ids.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        WarehouseArtists::find()
+            .filter(ArtistCol::Id.is_in(artist_ids))
+            .all(db)
+            .await
+            .map_err(AppError::DatabaseError)?
+            .into_iter()
+            .map(|a| (a.id, (a.name_en, a.name_ko, a.profile_image_url)))
+            .collect()
     };
 
-    let (artists, groups) = tokio::join!(artist_fut, group_fut);
-    Ok((artists?, groups?))
+    let group_map = if group_ids.is_empty() {
+        std::collections::HashMap::new()
+    } else {
+        WarehouseGroups::find()
+            .filter(GroupCol::Id.is_in(group_ids))
+            .all(db)
+            .await
+            .map_err(AppError::DatabaseError)?
+            .into_iter()
+            .map(|g| (g.id, (g.name_en, g.name_ko, g.profile_image_url)))
+            .collect()
+    };
+
+    Ok((artist_map, group_map))
 }
 
 /// 단일 post의 artist/group display fallback: (artist_name, profile), (group_name, profile).
@@ -1009,69 +1003,38 @@ pub async fn list_posts(
     }
 
     // has_solutions 필터: true = ACTIVE 솔루션 있는 post만, false = spot은 있으나 솔루션 없는 post만
+    // 최적화: 2~3개 순차 쿼리 → 1개 JOIN 쿼리로 통합
     if let Some(has_solutions) = query.has_solutions {
-        use crate::entities::solutions::{Column as SolutionColumn, Entity as Solutions};
-        use crate::entities::spots::{Column as SpotColumn, Entity as Spots};
+        use sea_orm::sea_query::{Alias, Query as SeaQuery};
 
-        let solution_spot_ids: Vec<Uuid> = Solutions::find()
-            .filter(SolutionColumn::Status.eq(crate::constants::solution_status::ACTIVE))
-            .select_only()
-            .column(SolutionColumn::SpotId)
-            .into_tuple::<Uuid>()
-            .all(db)
-            .await
-            .map_err(AppError::DatabaseError)?;
+        // spots JOIN solutions (status='active') → DISTINCT post_id (단일 쿼리)
+        let subquery = SeaQuery::select()
+            .distinct()
+            .column((Alias::new("spots"), Alias::new("post_id")))
+            .from(Alias::new("spots"))
+            .inner_join(
+                Alias::new("solutions"),
+                sea_orm::sea_query::Expr::col((Alias::new("solutions"), Alias::new("spot_id")))
+                    .equals((Alias::new("spots"), Alias::new("id"))),
+            )
+            .and_where(
+                sea_orm::sea_query::Expr::col((Alias::new("solutions"), Alias::new("status")))
+                    .eq(crate::constants::solution_status::ACTIVE),
+            )
+            .to_owned();
 
         if has_solutions {
-            // post_id in (spots where spot_id in solution_spot_ids)
-            let post_ids_with_solutions: Vec<Uuid> = if solution_spot_ids.is_empty() {
-                vec![]
-            } else {
-                Spots::find()
-                    .filter(SpotColumn::Id.is_in(solution_spot_ids))
-                    .select_only()
-                    .column(SpotColumn::PostId)
-                    .into_tuple::<Uuid>()
-                    .all(db)
-                    .await
-                    .map_err(AppError::DatabaseError)?
-            };
-            if !post_ids_with_solutions.is_empty() {
-                select = select.filter(Column::Id.is_in(post_ids_with_solutions));
-            } else {
-                // no post has solutions -> return empty
-                select = select.filter(Column::Id.is_in([Uuid::nil()]));
-            }
+            select = select.filter(Column::Id.in_subquery(subquery));
         } else {
-            // spot은 있으나 solution 없는 post: post_id in (all spots) AND post_id not in (posts with solutions)
-            let post_ids_with_solutions: Vec<Uuid> = if solution_spot_ids.is_empty() {
-                vec![]
-            } else {
-                Spots::find()
-                    .filter(SpotColumn::Id.is_in(solution_spot_ids))
-                    .select_only()
-                    .column(SpotColumn::PostId)
-                    .into_tuple::<Uuid>()
-                    .all(db)
-                    .await
-                    .map_err(AppError::DatabaseError)?
-            };
-            let post_ids_with_any_spot: Vec<Uuid> = Spots::find()
-                .select_only()
-                .column(SpotColumn::PostId)
-                .into_tuple::<Uuid>()
-                .all(db)
-                .await
-                .map_err(AppError::DatabaseError)?;
-            let post_ids_spot_only: Vec<Uuid> = post_ids_with_any_spot
-                .into_iter()
-                .filter(|id| !post_ids_with_solutions.contains(id))
-                .collect();
-            if post_ids_spot_only.is_empty() {
-                select = select.filter(Column::Id.is_in([Uuid::nil()]));
-            } else {
-                select = select.filter(Column::Id.is_in(post_ids_spot_only));
-            }
+            // spot은 있으나 solution이 없는 post
+            let spot_subquery = SeaQuery::select()
+                .distinct()
+                .column((Alias::new("spots"), Alias::new("post_id")))
+                .from(Alias::new("spots"))
+                .to_owned();
+            select = select
+                .filter(Column::Id.in_subquery(spot_subquery))
+                .filter(Column::Id.not_in_subquery(subquery));
         }
     }
 
@@ -1094,71 +1057,66 @@ pub async fn list_posts(
         }
     }
 
-    // 전체 개수 조회
-    let total = select
-        .clone()
-        .count(db)
-        .await
-        .map_err(AppError::DatabaseError)?;
-
     // 페이지네이션 설정
     let pagination = Pagination::new(query.page, query.per_page);
 
-    // 페이지네이션 적용
-    let posts = select
-        .offset(pagination.offset())
-        .limit(pagination.limit())
-        .all(db)
-        .await
-        .map_err(AppError::DatabaseError)?;
+    // COUNT + SELECT 병렬 실행 (동시 2 커넥션)
+    let (total_result, posts_result) = tokio::join!(
+        select.clone().count(db),
+        select
+            .offset(pagination.offset())
+            .limit(pagination.limit())
+            .all(db),
+    );
+    let total = total_result.map_err(AppError::DatabaseError)?;
+    let posts = posts_result.map_err(AppError::DatabaseError)?;
 
-    // 배치 로딩: User 정보
+    // 배치 로딩: 부가 데이터 병렬 조회
     use crate::entities::comments::{Column as CommentColumn, Entity as Comments};
+    use crate::entities::post_magazines::{Column as MagazineColumn, Entity as PostMagazines};
     use crate::entities::spots::{Column as SpotColumn, Entity as Spots};
     use crate::entities::users::{Column as UserColumn, Entity as Users};
 
     let post_ids: Vec<Uuid> = posts.iter().map(|p| p.id).collect();
     let user_ids: Vec<Uuid> = posts.iter().map(|p| p.user_id).collect();
-
-    // 1. User 배치 조회
-    let users = Users::find()
-        .filter(UserColumn::Id.is_in(user_ids))
-        .all(db)
-        .await
-        .map_err(AppError::DatabaseError)?;
-    let users_map: std::collections::HashMap<Uuid, crate::entities::users::Model> =
-        users.into_iter().map(|u| (u.id, u)).collect();
-
-    // 2. Spot 개수 배치 조회 (GROUP BY)
-    let spot_counts = Spots::find()
-        .select_only()
-        .column(SpotColumn::PostId)
-        .filter(SpotColumn::PostId.is_in(post_ids.clone()))
-        .group_by(SpotColumn::PostId)
-        .column_as(SpotColumn::Id.count(), "count")
-        .into_tuple::<(Uuid, i64)>()
-        .all(db)
-        .await
-        .map_err(AppError::DatabaseError)?;
-    let spot_count_map: std::collections::HashMap<Uuid, i64> = spot_counts.into_iter().collect();
-
-    // 3. Comment 개수 배치 조회 (GROUP BY)
-    let comment_counts = Comments::find()
-        .select_only()
-        .column(CommentColumn::PostId)
-        .filter(CommentColumn::PostId.is_in(post_ids))
-        .group_by(CommentColumn::PostId)
-        .column_as(CommentColumn::Id.count(), "count")
-        .into_tuple::<(Uuid, i64)>()
-        .all(db)
-        .await
-        .map_err(AppError::DatabaseError)?;
-    let comment_count_map: std::collections::HashMap<Uuid, i64> =
-        comment_counts.into_iter().collect();
-
-    // 4. PostMagazines 배치 조회 (post_magazine_title + optional preview items)
-    use crate::entities::post_magazines::{Column as MagazineColumn, Entity as PostMagazines};
     let magazine_ids: Vec<Uuid> = posts.iter().filter_map(|p| p.post_magazine_id).collect();
+
+    // 그룹 A: users + spot counts + comment counts (동시 3 커넥션)
+    let (users_result, spot_counts_result, comment_counts_result) = tokio::join!(
+        Users::find().filter(UserColumn::Id.is_in(user_ids)).all(db),
+        Spots::find()
+            .select_only()
+            .column(SpotColumn::PostId)
+            .filter(SpotColumn::PostId.is_in(post_ids.clone()))
+            .group_by(SpotColumn::PostId)
+            .column_as(SpotColumn::Id.count(), "count")
+            .into_tuple::<(Uuid, i64)>()
+            .all(db),
+        Comments::find()
+            .select_only()
+            .column(CommentColumn::PostId)
+            .filter(CommentColumn::PostId.is_in(post_ids))
+            .group_by(CommentColumn::PostId)
+            .column_as(CommentColumn::Id.count(), "count")
+            .into_tuple::<(Uuid, i64)>()
+            .all(db),
+    );
+
+    let users_map: std::collections::HashMap<Uuid, crate::entities::users::Model> = users_result
+        .map_err(AppError::DatabaseError)?
+        .into_iter()
+        .map(|u| (u.id, u))
+        .collect();
+    let spot_count_map: std::collections::HashMap<Uuid, i64> = spot_counts_result
+        .map_err(AppError::DatabaseError)?
+        .into_iter()
+        .collect();
+    let comment_count_map: std::collections::HashMap<Uuid, i64> = comment_counts_result
+        .map_err(AppError::DatabaseError)?
+        .into_iter()
+        .collect();
+
+    // magazines + warehouse 순차 (커넥션 1개씩)
     let include_preview = query.include_magazine_items == Some(true);
     let (magazine_titles_map, magazine_preview_map) = if magazine_ids.is_empty() {
         (
@@ -1188,8 +1146,6 @@ pub async fn list_posts(
         }
         (titles, previews)
     };
-
-    // 5. Warehouse 배치 조회 (artist/group의 name_en, name_ko, profile_image_url)
     let (artist_display_map, group_display_map) = load_warehouse_display_maps(db, &posts).await?;
 
     // PostListItem으로 변환 (배치 로딩 데이터 사용)


### PR DESCRIPTION
## Summary
- **병렬 쿼리**: COUNT+SELECT, users/spots/comments 배치를 `tokio::join!`으로 병렬 실행 (동시 최대 3 커넥션, Supabase Session mode 호환)
- **응답 캐시**: `PostListCache` (moka, 30초 TTL) — 캐시 히트 시 ~2ms 응답
- **has_solutions 서브쿼리 최적화**: 2~3개 순차 쿼리 → `spots INNER JOIN solutions` 서브쿼리 1개로 통합
- **DB 인덱스 추가**: `idx_posts_trending_active` (trending 정렬), `idx_solutions_active_spot_id` (has_solutions 필터)
- 캐시 무효화: post create/update/delete 시 자동 무효화

## Benchmark (로컬, 한국 → Supabase 도쿄)

| 시나리오 | Before | After (cold) | After (cache hit) |
|----------|--------|-------------|-------------------|
| recent | 1.2~1.7s | 0.8~1.3s | **~2ms** |
| trending | - | 0.7s | **~2ms** |
| has_solutions | - | 0.9s | **~2ms** |

> Cold 요청의 병목은 한국↔도쿄 네트워크 RTT (~40-100ms × 쿼리 수). DB 쿼리 자체는 3~13ms.

## Test plan
- [x] `cargo check` + `cargo fmt` 통과
- [x] 로컬 서버 기동 후 `list_posts` 전체 시나리오 200 OK 확인
- [x] 캐시 히트/미스 동작 확인
- [x] `has_solutions=true` 서브쿼리 정상 동작 확인
- [ ] dev 환경 배포 후 프로덕션 latency 측정

🤖 Generated with [Claude Code](https://claude.com/claude-code)