### PR TITLE
fix(web): unblock local pre-push (Orval, TS, Prettier) (#216)

### DIFF
--- a/packages/web/app/api/v1/admin/monitoring/metrics/route.ts
+++ b/packages/web/app/api/v1/admin/monitoring/metrics/route.ts
@@ -33,10 +33,9 @@ export async function GET() {
     );
   }
 
-  const res = await fetch(
-    `${API_BASE_URL}/api/v1/admin/monitoring/metrics`,
-    { next: { revalidate: 0 } }
-  );
+  const res = await fetch(`${API_BASE_URL}/api/v1/admin/monitoring/metrics`, {
+    next: { revalidate: 0 },
+  });
 
   if (!res.ok) {
     return NextResponse.json(

--- a/packages/web/app/api/v1/posts/[postId]/comments/route.ts
+++ b/packages/web/app/api/v1/posts/[postId]/comments/route.ts
@@ -26,8 +26,7 @@ async function proxy(
     headers["Authorization"] = authHeader;
   }
 
-  const body =
-    method === "POST" ? await request.text() : undefined;
+  const body = method === "POST" ? await request.text() : undefined;
 
   const response = await fetch(url, {
     method,

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -47,7 +47,9 @@ async function fetchPosts(params: string): Promise<ApiPost[]> {
 }
 
 /** Build artist/group name → profile lookup from Rust API warehouse/profiles */
-async function fetchArtistProfileMap(): Promise<Map<string, ArtistProfileEntry>> {
+async function fetchArtistProfileMap(): Promise<
+  Map<string, ArtistProfileEntry>
+> {
   const map = new Map<string, ArtistProfileEntry>();
   try {
     const res = await serverApiGet<WarehouseProfilesResponse>(
@@ -67,8 +69,10 @@ async function fetchArtistProfileMap(): Promise<Map<string, ArtistProfileEntry>>
       if (name_ko) map.set(name_ko.toLowerCase(), entry);
       if (name_en) map.set(name_en.toLowerCase(), entry);
     };
-    for (const a of res.artists ?? []) addEntity(a.name_ko, a.name_en, a.profile_image_url);
-    for (const g of res.groups ?? []) addEntity(g.name_ko, g.name_en, g.profile_image_url);
+    for (const a of res.artists ?? [])
+      addEntity(a.name_ko, a.name_en, a.profile_image_url);
+    for (const g of res.groups ?? [])
+      addEntity(g.name_ko, g.name_en, g.profile_image_url);
   } catch {
     /* warehouse profiles unavailable — use raw names */
   }
@@ -92,7 +96,13 @@ async function fetchSpotsByPosts(
 
 /** Fetch editor picks via Rust API */
 async function fetchEditorPicks(): Promise<
-  Array<{ id: string; imageUrl: string; title: string; link: string; artistName: string }>
+  Array<{
+    id: string;
+    imageUrl: string;
+    title: string;
+    link: string;
+    artistName: string;
+  }>
 > {
   try {
     const res = await serverApiGet<EditorPicksResponse>(
@@ -127,7 +137,9 @@ export default async function Home({
   ] = await Promise.all([
     fetchPosts("sort=popular&per_page=30"),
     fetchPosts("sort=recent&per_page=50"),
-    fetchPosts("sort=recent&per_page=50&has_magazine=true&include_magazine_items=true"),
+    fetchPosts(
+      "sort=recent&per_page=50&has_magazine=true&include_magazine_items=true"
+    ),
     fetchArtistProfileMap(),
     fetchEditorPicks(),
   ]);
@@ -286,9 +298,7 @@ export default async function Home({
         mp.post_magazine_items.length > 0
     )
     .map((mp) => {
-      const { displayName } = enrichArtistName(
-        mp.artist_name || mp.group_name
-      );
+      const { displayName } = enrichArtistName(mp.artist_name || mp.group_name);
       return {
         id: `mag-${mp.id}`,
         imageUrl: proxyImg(mp.image_url),
@@ -364,8 +374,7 @@ export default async function Home({
       // Prefer warehouse artist profile image (per-post field from Rust API),
       // then enrichArtistName's profile image (buildArtistProfileMap), then
       // fall back to the post thumbnail.
-      const image =
-        profileImage || enriched.profileImageUrl || postImage;
+      const image = profileImage || enriched.profileImageUrl || postImage;
       return {
         id: `artist-${name}`,
         label: enriched.displayName || name,

--- a/packages/web/app/profile/[userId]/page.tsx
+++ b/packages/web/app/profile/[userId]/page.tsx
@@ -20,8 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const displayName = user?.display_name || user?.username || "User";
   const title = `${displayName} | DECODED`;
-  const description =
-    user?.bio || `Explore ${displayName}'s style collection.`;
+  const description = user?.bio || `Explore ${displayName}'s style collection.`;
 
   return {
     title,

--- a/packages/web/app/rankings/page.tsx
+++ b/packages/web/app/rankings/page.tsx
@@ -3,7 +3,8 @@ import { RankingsClient } from "./RankingsClient";
 
 export const metadata: Metadata = {
   title: "Rankings | DECODED",
-  description: "DECODED community rankings — solution contributions and activity points",
+  description:
+    "DECODED community rankings — solution contributions and activity points",
 };
 
 export default function RankingsPage() {

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -111,18 +111,14 @@ export async function apiClient<T>(options: ApiClientOptions): Promise<T> {
     try {
       const raw = await response.json();
       const nested = messageFromApiErrorJson(raw);
-      errorData = nested
-        ? { message: nested }
-        : (raw as ApiError);
+      errorData = nested ? { message: nested } : (raw as ApiError);
     } catch {
       errorData = {
         message: `HTTP ${response.status}: ${response.statusText}`,
       };
     }
 
-    throw new Error(
-      errorData.message || `API Error: ${response.status}`
-    );
+    throw new Error(errorData.message || `API Error: ${response.status}`);
   }
 
   // 204 No Content

--- a/packages/web/lib/api/server-prefetch.ts
+++ b/packages/web/lib/api/server-prefetch.ts
@@ -48,9 +48,8 @@ export const prefetchPostDetail = cache(
 
       const post = await res.json();
 
-      const { postDetailToImageDetail } = await import(
-        "@/lib/api/adapters/postDetailToImageDetail"
-      );
+      const { postDetailToImageDetail } =
+        await import("@/lib/api/adapters/postDetailToImageDetail");
       return postDetailToImageDetail(post, postId);
     } catch {
       return null;

--- a/packages/web/lib/components/admin/monitoring/EndpointTable.tsx
+++ b/packages/web/lib/components/admin/monitoring/EndpointTable.tsx
@@ -16,7 +16,9 @@ function SortIcon({
   asc: boolean;
 }) {
   if (col !== active)
-    return <ChevronUp className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100" />;
+    return (
+      <ChevronUp className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100" />
+    );
   return asc ? (
     <ChevronUp className="w-3 h-3 text-gray-400" />
   ) : (
@@ -95,11 +97,16 @@ export function EndpointTable({ data }: { data: EndpointMetrics[] }) {
               </tr>
             ) : (
               sorted.map((ep) => (
-                <tr key={ep.path} className="hover:bg-gray-800/30 transition-colors">
+                <tr
+                  key={ep.path}
+                  className="hover:bg-gray-800/30 transition-colors"
+                >
                   <td className="px-4 py-2.5 font-mono text-xs text-gray-300 max-w-[300px] truncate">
                     {ep.path}
                   </td>
-                  <td className="px-4 py-2.5 text-right text-gray-200">{ep.rpm}</td>
+                  <td className="px-4 py-2.5 text-right text-gray-200">
+                    {ep.rpm}
+                  </td>
                   <td
                     className={`px-4 py-2.5 text-right font-medium ${
                       ep.error_rate > 0.05

--- a/packages/web/lib/components/admin/monitoring/LatencyChart.tsx
+++ b/packages/web/lib/components/admin/monitoring/LatencyChart.tsx
@@ -52,9 +52,9 @@ function CustomTooltip({
 export function LatencyChart({ data }: { data: HistoryBucket[] }) {
   const chartData = data.map((b) => ({
     time: formatTimestamp(b.timestamp),
-    "p50": b.p50_ms,
-    "p95": b.p95_ms,
-    "p99": b.p99_ms,
+    p50: b.p50_ms,
+    p95: b.p95_ms,
+    p99: b.p99_ms,
   }));
 
   return (
@@ -84,7 +84,11 @@ export function LatencyChart({ data }: { data: HistoryBucket[] }) {
             tick={{ fontSize: 10, fill: "#6b7280" }}
             interval="preserveStartEnd"
           />
-          <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="ms" width={45} />
+          <YAxis
+            tick={{ fontSize: 10, fill: "#6b7280" }}
+            unit="ms"
+            width={45}
+          />
           <Tooltip content={<CustomTooltip />} />
           <Legend
             wrapperStyle={{ fontSize: 11, color: "#9ca3af" }}

--- a/packages/web/lib/components/admin/monitoring/ThroughputChart.tsx
+++ b/packages/web/lib/components/admin/monitoring/ThroughputChart.tsx
@@ -76,8 +76,18 @@ export function ThroughputChart({ data }: { data: HistoryBucket[] }) {
             iconType="circle"
             iconSize={8}
           />
-          <Bar dataKey="Requests" fill="#6366f1" radius={[2, 2, 0, 0]} maxBarSize={20} />
-          <Bar dataKey="Errors" fill="#ef4444" radius={[2, 2, 0, 0]} maxBarSize={20} />
+          <Bar
+            dataKey="Requests"
+            fill="#6366f1"
+            radius={[2, 2, 0, 0]}
+            maxBarSize={20}
+          />
+          <Bar
+            dataKey="Errors"
+            fill="#ef4444"
+            radius={[2, 2, 0, 0]}
+            maxBarSize={20}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/packages/web/lib/components/detail/AISummarySection.tsx
+++ b/packages/web/lib/components/detail/AISummarySection.tsx
@@ -26,9 +26,7 @@ export function AISummarySection({
       : "border border-border/40 bg-muted/5";
 
   const body =
-    surface === "decode"
-      ? "text-[var(--mag-text)]/90"
-      : "text-foreground/90";
+    surface === "decode" ? "text-[var(--mag-text)]/90" : "text-foreground/90";
 
   return (
     <div className="flex w-full flex-col">

--- a/packages/web/lib/components/detail/ImageDetailContent.tsx
+++ b/packages/web/lib/components/detail/ImageDetailContent.tsx
@@ -289,7 +289,8 @@ export function ImageDetailContent({
   const fetchedCommentCount = useCommentCount(image.id);
   // Always use live count from comments query (updates after create/delete)
   // Fall back to prop only when comments haven't loaded yet
-  const commentCount = fetchedCommentCount > 0 ? fetchedCommentCount : (commentCountProp ?? 0);
+  const commentCount =
+    fetchedCommentCount > 0 ? fetchedCommentCount : (commentCountProp ?? 0);
 
   // Build DecodeShowcase data whenever the post has item centers + hero image (all layouts)
   const decodeShowcaseData = useMemo(() => {

--- a/packages/web/lib/components/detail/ImageDetailPage.tsx
+++ b/packages/web/lib/components/detail/ImageDetailPage.tsx
@@ -89,7 +89,9 @@ export function ImageDetailPage({ imageId, serverData }: Props) {
   }
 
   return (
-    <Suspense fallback={<div ref={pageRef} className="relative mt-4 md:mt-6" />}>
+    <Suspense
+      fallback={<div ref={pageRef} className="relative mt-4 md:mt-6" />}
+    >
       <LenisProvider>
         <div ref={pageRef} className="relative mt-4 md:mt-6">
           <div className="fixed left-4 top-16 md:top-20 z-50">

--- a/packages/web/lib/components/detail/InteractiveShowcase.tsx
+++ b/packages/web/lib/components/detail/InteractiveShowcase.tsx
@@ -172,7 +172,9 @@ export function InteractiveShowcase({
       <div
         ref={cardsContainerRef}
         className={`relative z-20 w-full bg-background px-4 py-6 ${
-          isModal ? "overflow-visible pt-0" : "mx-auto max-w-6xl lg:px-8 lg:pt-12"
+          isModal
+            ? "overflow-visible pt-0"
+            : "mx-auto max-w-6xl lg:px-8 lg:pt-12"
         }`}
       >
         {items.map((item, index) => (

--- a/packages/web/lib/components/detail/ItemDetailCard.tsx
+++ b/packages/web/lib/components/detail/ItemDetailCard.tsx
@@ -104,9 +104,7 @@ export function ItemDetailCard({
       data-item-index={index}
       data-item-id={item.spot_id ?? String(item.id)}
       className={`group relative flex min-h-auto flex-col justify-center scroll-mt-20 md:scroll-mt-24 ${
-        compact
-          ? "mb-4 py-2"
-          : "mb-8 md:mb-12 py-4 md:py-6 lg:mb-16"
+        compact ? "mb-4 py-2" : "mb-8 md:mb-12 py-4 md:py-6 lg:mb-16"
       }`}
       onMouseEnter={onActivate}
       onMouseLeave={onDeactivate}
@@ -157,7 +155,9 @@ export function ItemDetailCard({
         {/* Text Content */}
         <div
           className={`flex flex-col relative z-30 ${
-            compact ? "min-w-0 flex-1 px-0" : "min-w-0 flex-1 px-0 sm:px-1 md:pl-0"
+            compact
+              ? "min-w-0 flex-1 px-0"
+              : "min-w-0 flex-1 px-0 sm:px-1 md:pl-0"
           }`}
         >
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
@@ -272,8 +272,8 @@ export function ItemDetailCard({
                 spotId && onAddSolution ? (
                   <div className="flex flex-col gap-3 py-3">
                     <p className="font-serif text-sm text-muted-foreground/70">
-                      No shopping links yet. Add a link to help others find
-                      this item.
+                      No shopping links yet. Add a link to help others find this
+                      item.
                     </p>
                     <button
                       type="button"

--- a/packages/web/lib/components/detail/ReportErrorButton.tsx
+++ b/packages/web/lib/components/detail/ReportErrorButton.tsx
@@ -103,8 +103,7 @@ export function ReportErrorButton({ postId, size = "sm" }: Props) {
 
             <h3 className="text-lg font-semibold mb-2">Report an issue</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Did you find a mistake in this post? Let us know and we'll fix
-              it.
+              Did you find a mistake in this post? Let us know and we'll fix it.
             </p>
 
             <form onSubmit={handleSubmit}>

--- a/packages/web/lib/components/detail/SpotSolutionTabs.tsx
+++ b/packages/web/lib/components/detail/SpotSolutionTabs.tsx
@@ -107,9 +107,7 @@ export function SpotSolutionTabs({
           <p className="text-sm text-muted-foreground py-4">Loading...</p>
         ) : activeSolutions.length === 0 ? (
           <div className="flex flex-col gap-3 py-3">
-            <p className="text-sm text-muted-foreground">
-              No solutions yet.
-            </p>
+            <p className="text-sm text-muted-foreground">No solutions yet.</p>
             {onAddSolution && activeSpotId && (
               <button
                 type="button"

--- a/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
@@ -279,7 +279,8 @@ export function MagazineItemsSection({
                     {item.brand && (
                       <div className="mb-1 flex items-center gap-2">
                         {"brand_logo_url" in item &&
-                          (item as { brand_logo_url?: string }).brand_logo_url && (
+                          (item as { brand_logo_url?: string })
+                            .brand_logo_url && (
                             <img
                               src={`/api/v1/image-proxy?url=${encodeURIComponent((item as { brand_logo_url: string }).brand_logo_url)}`}
                               alt={item.brand ?? ""}
@@ -291,7 +292,9 @@ export function MagazineItemsSection({
                         </p>
                       </div>
                     )}
-                    <h3 className="text-base font-semibold mb-1">{item.title}</h3>
+                    <h3 className="text-base font-semibold mb-1">
+                      {item.title}
+                    </h3>
                     {item.editorial_paragraphs.length > 0 && (
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground line-clamp-3">
                         {item.editorial_paragraphs[0]}
@@ -372,7 +375,8 @@ export function MagazineItemsSection({
                       {item.brand && (
                         <div className="mb-2 flex items-center gap-2">
                           {"brand_logo_url" in item &&
-                            (item as { brand_logo_url?: string }).brand_logo_url && (
+                            (item as { brand_logo_url?: string })
+                              .brand_logo_url && (
                               <img
                                 src={`/api/v1/image-proxy?url=${encodeURIComponent((item as { brand_logo_url: string }).brand_logo_url)}`}
                                 alt={item.brand ?? ""}
@@ -387,7 +391,9 @@ export function MagazineItemsSection({
                       <h3
                         className="typography-h4 mb-2"
                         style={
-                          titleHeight > 0 ? { minHeight: titleHeight } : undefined
+                          titleHeight > 0
+                            ? { minHeight: titleHeight }
+                            : undefined
                         }
                       >
                         {item.title}
@@ -436,11 +442,7 @@ export function MagazineItemsSection({
 
               {spotRelated.length > 0 && (
                 <div
-                  className={
-                    compact
-                      ? "mt-3 max-w-[220px]"
-                      : "mt-4 max-w-xs"
-                  }
+                  className={compact ? "mt-3 max-w-[220px]" : "mt-4 max-w-xs"}
                 >
                   <p className="mb-1.5 text-[9px] font-medium uppercase tracking-[0.18em] text-muted-foreground/50">
                     Similar

--- a/packages/web/lib/components/main-renewal/DecodeShowcase.tsx
+++ b/packages/web/lib/components/main-renewal/DecodeShowcase.tsx
@@ -89,8 +89,7 @@ export default function DecodeShowcase({
       const rootStyles = getComputedStyle(document.documentElement);
       const fromBg =
         rootStyles.getPropertyValue("--background").trim() || "#fafafa";
-      const toBg =
-        rootStyles.getPropertyValue("--mag-bg").trim() || "#050505";
+      const toBg = rootStyles.getPropertyValue("--mag-bg").trim() || "#050505";
 
       gsap.set(section, { backgroundColor: fromBg });
 
@@ -122,8 +121,6 @@ export default function DecodeShowcase({
         },
         0
       );
-
-      
 
       detectedItems.forEach((_, i) => {
         const dot = dotRefs.current[i];
@@ -232,7 +229,6 @@ export default function DecodeShowcase({
           summaryBaseStart
         );
       }
-
     },
     {
       scope: sectionRef,
@@ -261,348 +257,353 @@ export default function DecodeShowcase({
 
   return (
     <>
-    <section
-      ref={sectionRef}
-      className={`relative min-h-[100dvh] flex flex-col overflow-hidden ${className ?? ""}`}
-      style={{ backgroundColor: "var(--background)" }}
-      aria-label="AI item detection showcase"
-    >
-      <div ref={showcaseRef} className="relative mx-auto max-w-5xl flex-1 px-4 pb-24 pt-12 md:pb-28 md:pt-16">
-        {/*
+      <section
+        ref={sectionRef}
+        className={`relative min-h-[100dvh] flex flex-col overflow-hidden ${className ?? ""}`}
+        style={{ backgroundColor: "var(--background)" }}
+        aria-label="AI item detection showcase"
+      >
+        <div
+          ref={showcaseRef}
+          className="relative mx-auto max-w-5xl flex-1 px-4 pb-24 pt-12 md:pb-28 md:pt-16"
+        >
+          {/*
           Positioning context.
           Desktop: overflow-visible for cards outside image.
           Mobile: overflow-visible too — thumbnails sit at edges within image bounds.
         */}
-        <div
-          className="relative mx-auto overflow-visible"
-          style={{ width: "min(80vw, 360px)" }}
-        >
-          {/* Image */}
-          <div className="relative w-full rounded-2xl overflow-hidden bg-neutral-900">
-            {data.sourceImageUrl ? (
-              <PostImage
-                src={data.sourceImageUrl}
-                alt={`${data.artistName} outfit decode`}
-                imageWidth={data.imageWidth}
-                imageHeight={data.imageHeight}
-                priority={true}
-                flagKey="FeedCard"
-              />
-            ) : (
-              <div className="flex aspect-[3/4] items-center justify-center text-neutral-600">
-                <p className="text-sm">AI Detection Showcase</p>
-              </div>
-            )}
-            <div className="absolute inset-0 bg-black/10 pointer-events-none z-20" />
-          </div>
-
-          {/* Dots — optional tap target to scroll to item detail */}
-          {detectedItems.map((item, i) =>
-            canNavigate ? (
-              <button
-                key={`dot-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  dotRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-30 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-manipulation items-center justify-center rounded-full border-0 bg-transparent p-0 opacity-0"
-                style={{
-                  left: `${item.bbox.x}%`,
-                  top: `${item.bbox.y}%`,
-                }}
-                aria-label={`${item.label} — view details`}
-              >
-                <span
-                  className="block h-3 w-3 shrink-0 rounded-full border-2 border-[var(--mag-accent)] shadow-[0_0_10px_2px_var(--mag-accent),inset_0_0_4px_var(--mag-accent)]"
-                  aria-hidden
-                />
-              </button>
-            ) : (
-              <div
-                key={`dot-${item.id}`}
-                ref={(el) => {
-                  dotRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-1/2"
-                style={{
-                  left: `${item.bbox.x}%`,
-                  top: `${item.bbox.y}%`,
-                  width: 12,
-                  height: 12,
-                  borderRadius: "50%",
-                  border: "2px solid var(--mag-accent)",
-                  boxShadow:
-                    "0 0 10px 2px var(--mag-accent), inset 0 0 4px var(--mag-accent)",
-                  opacity: 0,
-                }}
-              />
-            )
-          )}
-
-          {/* SVG lines — desktop (long, outside image) */}
-          <svg
-            className="absolute inset-0 w-full h-full pointer-events-none z-[15] hidden md:block"
-            style={{ overflow: "visible" }}
-            aria-hidden
-          >
-            {itemMeta.map((meta) => {
-              const { item, i, isLeft } = meta;
-              const cardY = getCardY(meta);
-              return (
-                <line
-                  key={`line-${item.id}`}
-                  ref={(el) => {
-                    lineRefs.current[i] = el;
-                  }}
-                  x1={`${item.bbox.x}%`}
-                  y1={`${item.bbox.y}%`}
-                  x2={isLeft ? "-60%" : "160%"}
-                  y2={`${cardY}%`}
-                  stroke="var(--mag-accent)"
-                  strokeWidth="1"
-                  strokeDasharray="4 3"
-                  opacity="0"
-                />
-              );
-            })}
-          </svg>
-
-          {/* SVG lines — mobile (short, to edge of image) */}
-          <svg
-            className="absolute inset-0 w-full h-full pointer-events-none z-[15] md:hidden"
-            aria-hidden
-          >
-            {itemMeta.map((meta) => {
-              const { item, i, isLeft } = meta;
-              const cardY = getCardY(meta);
-              return (
-                <line
-                  key={`mline-${item.id}`}
-                  ref={(el) => {
-                    mobileLineRefs.current[i] = el;
-                  }}
-                  x1={`${item.bbox.x}%`}
-                  y1={`${item.bbox.y}%`}
-                  x2={isLeft ? "8%" : "92%"}
-                  y2={`${cardY}%`}
-                  stroke="var(--mag-accent)"
-                  strokeWidth="1"
-                  strokeDasharray="3 2"
-                  opacity="0"
-                />
-              );
-            })}
-          </svg>
-
-          {/* Mobile cards — image thumbnail only, at image edge */}
-          {itemMeta.map((meta) => {
-            const { item, i, isLeft } = meta;
-            const cardY = getCardY(meta);
-            const CardInner = (
-              <>
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt=""
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
-                    <span className="text-[8px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-              </>
-            );
-            return canNavigate ? (
-              <button
-                key={`mcard-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  mobileCardRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-20 flex opacity-0 md:hidden touch-manipulation rounded-xl border-0 bg-transparent p-0"
-                style={{
-                  top: `${cardY}%`,
-                  transform: "translateY(-50%)",
-                  ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
-                }}
-                aria-label={`${item.label} — view details`}
-              >
-                {CardInner}
-              </button>
-            ) : (
-              <div
-                key={`mcard-${item.id}`}
-                ref={(el) => {
-                  mobileCardRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-20 md:hidden"
-                style={{
-                  top: `${cardY}%`,
-                  transform: "translateY(-50%)",
-                  ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
-                  opacity: 0,
-                }}
-              >
-                {item.imageUrl ? (
-                  <div className="w-14 h-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt={item.label}
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
-                    <span className="text-[8px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-
-          {/* Desktop cards — full card outside image */}
-          {itemMeta.map((meta) => {
-            const { item, i, isLeft } = meta;
-            const cardY = getCardY(meta);
-            const cardStyle = {
-              top: `${cardY}%`,
-              transform: "translateY(-50%)",
-              ...(isLeft
-                ? { right: "calc(100% + 24px)" }
-                : { left: "calc(100% + 24px)" }),
-              opacity: 0,
-            } as const;
-            const cardBody = (
-              <>
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 flex-none rounded-lg">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt=""
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
-                    <span className="text-[10px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-                <div className="min-w-0 text-left">
-                  <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
-                    {item.label}
-                  </p>
-                  {item.brand && (
-                    <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
-                      {item.brand}
-                    </p>
-                  )}
-                </div>
-              </>
-            );
-            return canNavigate ? (
-              <button
-                key={`card-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  cardRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-20 hidden w-[200px] cursor-pointer touch-manipulation items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 text-left backdrop-blur-sm md:flex"
-                style={cardStyle}
-                aria-label={`${item.label} — view details`}
-              >
-                {cardBody}
-              </button>
-            ) : (
-              <div
-                key={`card-${item.id}`}
-                ref={(el) => {
-                  cardRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-20 hidden w-[200px] items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 backdrop-blur-sm md:flex"
-                style={cardStyle}
-              >
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 flex-none rounded-lg">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt={item.label}
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
-                    <span className="text-[10px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-                <div className="min-w-0">
-                  <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
-                    {item.label}
-                  </p>
-                  {item.brand && (
-                    <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
-                      {item.brand}
-                    </p>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {artist?.displayName ? (
           <div
-            ref={artistRevealRef}
-            className="mx-auto mt-8 max-w-md px-2 text-center md:mt-10"
+            className="relative mx-auto overflow-visible"
+            style={{ width: "min(80vw, 360px)" }}
           >
-            <div className="flex flex-col items-center gap-2">
-              {artist.profileImageUrl ? (
-                <img
-                  src={`/api/v1/image-proxy?url=${encodeURIComponent(artist.profileImageUrl)}`}
-                  alt=""
-                  className="h-12 w-12 rounded-full border border-white/15 object-cover"
+            {/* Image */}
+            <div className="relative w-full rounded-2xl overflow-hidden bg-neutral-900">
+              {data.sourceImageUrl ? (
+                <PostImage
+                  src={data.sourceImageUrl}
+                  alt={`${data.artistName} outfit decode`}
+                  imageWidth={data.imageWidth}
+                  imageHeight={data.imageHeight}
+                  priority={true}
+                  flagKey="FeedCard"
                 />
               ) : (
-                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5 text-base font-bold text-[var(--mag-text)]/50">
-                  {artist.displayName.charAt(0).toUpperCase()}
+                <div className="flex aspect-[3/4] items-center justify-center text-neutral-600">
+                  <p className="text-sm">AI Detection Showcase</p>
                 </div>
               )}
-              <div className="text-center">
-                <Link
-                  href={`/explore?q=${encodeURIComponent(artist.displayName)}`}
-                  className="text-lg font-semibold text-[var(--mag-text)] transition-colors hover:text-[var(--mag-accent)]"
+              <div className="absolute inset-0 bg-black/10 pointer-events-none z-20" />
+            </div>
+
+            {/* Dots — optional tap target to scroll to item detail */}
+            {detectedItems.map((item, i) =>
+              canNavigate ? (
+                <button
+                  key={`dot-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    dotRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-30 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-manipulation items-center justify-center rounded-full border-0 bg-transparent p-0 opacity-0"
+                  style={{
+                    left: `${item.bbox.x}%`,
+                    top: `${item.bbox.y}%`,
+                  }}
+                  aria-label={`${item.label} — view details`}
                 >
-                  {artist.displayName}
-                </Link>
-                <p className="text-[11px] uppercase tracking-wider text-neutral-500">
-                  Artist
-                </p>
+                  <span
+                    className="block h-3 w-3 shrink-0 rounded-full border-2 border-[var(--mag-accent)] shadow-[0_0_10px_2px_var(--mag-accent),inset_0_0_4px_var(--mag-accent)]"
+                    aria-hidden
+                  />
+                </button>
+              ) : (
+                <div
+                  key={`dot-${item.id}`}
+                  ref={(el) => {
+                    dotRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-1/2"
+                  style={{
+                    left: `${item.bbox.x}%`,
+                    top: `${item.bbox.y}%`,
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    border: "2px solid var(--mag-accent)",
+                    boxShadow:
+                      "0 0 10px 2px var(--mag-accent), inset 0 0 4px var(--mag-accent)",
+                    opacity: 0,
+                  }}
+                />
+              )
+            )}
+
+            {/* SVG lines — desktop (long, outside image) */}
+            <svg
+              className="absolute inset-0 w-full h-full pointer-events-none z-[15] hidden md:block"
+              style={{ overflow: "visible" }}
+              aria-hidden
+            >
+              {itemMeta.map((meta) => {
+                const { item, i, isLeft } = meta;
+                const cardY = getCardY(meta);
+                return (
+                  <line
+                    key={`line-${item.id}`}
+                    ref={(el) => {
+                      lineRefs.current[i] = el;
+                    }}
+                    x1={`${item.bbox.x}%`}
+                    y1={`${item.bbox.y}%`}
+                    x2={isLeft ? "-60%" : "160%"}
+                    y2={`${cardY}%`}
+                    stroke="var(--mag-accent)"
+                    strokeWidth="1"
+                    strokeDasharray="4 3"
+                    opacity="0"
+                  />
+                );
+              })}
+            </svg>
+
+            {/* SVG lines — mobile (short, to edge of image) */}
+            <svg
+              className="absolute inset-0 w-full h-full pointer-events-none z-[15] md:hidden"
+              aria-hidden
+            >
+              {itemMeta.map((meta) => {
+                const { item, i, isLeft } = meta;
+                const cardY = getCardY(meta);
+                return (
+                  <line
+                    key={`mline-${item.id}`}
+                    ref={(el) => {
+                      mobileLineRefs.current[i] = el;
+                    }}
+                    x1={`${item.bbox.x}%`}
+                    y1={`${item.bbox.y}%`}
+                    x2={isLeft ? "8%" : "92%"}
+                    y2={`${cardY}%`}
+                    stroke="var(--mag-accent)"
+                    strokeWidth="1"
+                    strokeDasharray="3 2"
+                    opacity="0"
+                  />
+                );
+              })}
+            </svg>
+
+            {/* Mobile cards — image thumbnail only, at image edge */}
+            {itemMeta.map((meta) => {
+              const { item, i, isLeft } = meta;
+              const cardY = getCardY(meta);
+              const CardInner = (
+                <>
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt=""
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
+                      <span className="text-[8px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                </>
+              );
+              return canNavigate ? (
+                <button
+                  key={`mcard-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    mobileCardRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-20 flex opacity-0 md:hidden touch-manipulation rounded-xl border-0 bg-transparent p-0"
+                  style={{
+                    top: `${cardY}%`,
+                    transform: "translateY(-50%)",
+                    ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
+                  }}
+                  aria-label={`${item.label} — view details`}
+                >
+                  {CardInner}
+                </button>
+              ) : (
+                <div
+                  key={`mcard-${item.id}`}
+                  ref={(el) => {
+                    mobileCardRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-20 md:hidden"
+                  style={{
+                    top: `${cardY}%`,
+                    transform: "translateY(-50%)",
+                    ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
+                    opacity: 0,
+                  }}
+                >
+                  {item.imageUrl ? (
+                    <div className="w-14 h-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt={item.label}
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
+                      <span className="text-[8px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Desktop cards — full card outside image */}
+            {itemMeta.map((meta) => {
+              const { item, i, isLeft } = meta;
+              const cardY = getCardY(meta);
+              const cardStyle = {
+                top: `${cardY}%`,
+                transform: "translateY(-50%)",
+                ...(isLeft
+                  ? { right: "calc(100% + 24px)" }
+                  : { left: "calc(100% + 24px)" }),
+                opacity: 0,
+              } as const;
+              const cardBody = (
+                <>
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 flex-none rounded-lg">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt=""
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
+                      <span className="text-[10px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                  <div className="min-w-0 text-left">
+                    <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
+                      {item.label}
+                    </p>
+                    {item.brand && (
+                      <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
+                        {item.brand}
+                      </p>
+                    )}
+                  </div>
+                </>
+              );
+              return canNavigate ? (
+                <button
+                  key={`card-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    cardRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-20 hidden w-[200px] cursor-pointer touch-manipulation items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 text-left backdrop-blur-sm md:flex"
+                  style={cardStyle}
+                  aria-label={`${item.label} — view details`}
+                >
+                  {cardBody}
+                </button>
+              ) : (
+                <div
+                  key={`card-${item.id}`}
+                  ref={(el) => {
+                    cardRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-20 hidden w-[200px] items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 backdrop-blur-sm md:flex"
+                  style={cardStyle}
+                >
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 flex-none rounded-lg">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt={item.label}
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
+                      <span className="text-[10px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
+                      {item.label}
+                    </p>
+                    {item.brand && (
+                      <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
+                        {item.brand}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {artist?.displayName ? (
+            <div
+              ref={artistRevealRef}
+              className="mx-auto mt-8 max-w-md px-2 text-center md:mt-10"
+            >
+              <div className="flex flex-col items-center gap-2">
+                {artist.profileImageUrl ? (
+                  <img
+                    src={`/api/v1/image-proxy?url=${encodeURIComponent(artist.profileImageUrl)}`}
+                    alt=""
+                    className="h-12 w-12 rounded-full border border-white/15 object-cover"
+                  />
+                ) : (
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5 text-base font-bold text-[var(--mag-text)]/50">
+                    {artist.displayName.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="text-center">
+                  <Link
+                    href={`/explore?q=${encodeURIComponent(artist.displayName)}`}
+                    className="text-lg font-semibold text-[var(--mag-text)] transition-colors hover:text-[var(--mag-accent)]"
+                  >
+                    {artist.displayName}
+                  </Link>
+                  <p className="text-[11px] uppercase tracking-wider text-neutral-500">
+                    Artist
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
 
-        {aiSummary?.trim() ? (
-          <div ref={summaryRevealRef} className="mx-auto mt-6 w-full max-w-3xl px-2">
-            <AISummarySection
-              summary={aiSummary.trim()}
-              isModal={isModal}
-              surface="decode"
-            />
-          </div>
-        ) : null}
-      </div>
-
-    </section>
+          {aiSummary?.trim() ? (
+            <div
+              ref={summaryRevealRef}
+              className="mx-auto mt-6 w-full max-w-3xl px-2"
+            >
+              <AISummarySection
+                summary={aiSummary.trim()}
+                isModal={isModal}
+                surface="decode"
+              />
+            </div>
+          ) : null}
+        </div>
+      </section>
 
       {/* Scroll hint — portal to body so GSAP pin transforms don't break fixed positioning */}
       {portalTarget &&
@@ -632,10 +633,15 @@ export default function DecodeShowcase({
                 strokeWidth="1.5"
                 className="text-white/30"
               />
-              <circle cx="10" cy="9" r="2" className="fill-white/60 animate-scroll-dot" />
+              <circle
+                cx="10"
+                cy="9"
+                r="2"
+                className="fill-white/60 animate-scroll-dot"
+              />
             </svg>
           </div>,
-          portalTarget,
+          portalTarget
         )}
     </>
   );

--- a/packages/web/lib/components/main/LatestPostsScroll.tsx
+++ b/packages/web/lib/components/main/LatestPostsScroll.tsx
@@ -59,9 +59,7 @@ export function LatestPostsScroll({ posts }: LatestPostsScrollProps) {
                       : "bg-white/15 text-white/90"
                   }`}
                 >
-                  {post.createdWithSolutions
-                    ? "Sharing items"
-                    : "Curious"}
+                  {post.createdWithSolutions ? "Sharing items" : "Curious"}
                 </span>
               )}
             </div>

--- a/packages/web/lib/components/main/WhatsNewSection.tsx
+++ b/packages/web/lib/components/main/WhatsNewSection.tsx
@@ -19,8 +19,7 @@ const sampleStyles: StyleCardData[] = [
   {
     id: "wn-s2",
     title: "aespa Karina Streetwear",
-    description:
-      "aespa Karina's street style — standout color combinations.",
+    description: "aespa Karina's street style — standout color combinations.",
     artistName: "aespa Karina",
     link: "/feed",
     imageUrl: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800",

--- a/packages/web/lib/components/profile/ActivityTabs.tsx
+++ b/packages/web/lib/components/profile/ActivityTabs.tsx
@@ -2,7 +2,13 @@
 
 import { cn } from "@/lib/utils";
 
-export type ActivityTab = "posts" | "spots" | "solutions" | "tries" | "saved" | "likes";
+export type ActivityTab =
+  | "posts"
+  | "spots"
+  | "solutions"
+  | "tries"
+  | "saved"
+  | "likes";
 
 interface ActivityTabsProps {
   activeTab: ActivityTab;

--- a/packages/web/lib/components/profile/EmptyState.tsx
+++ b/packages/web/lib/components/profile/EmptyState.tsx
@@ -2,7 +2,14 @@
 
 import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { FileText, MapPin, Lightbulb, Bookmark, Sparkles, Heart } from "lucide-react";
+import {
+  FileText,
+  MapPin,
+  Lightbulb,
+  Bookmark,
+  Sparkles,
+  Heart,
+} from "lucide-react";
 import type { ActivityTab } from "./ActivityTabs";
 
 interface EmptyStateProps {

--- a/packages/web/lib/components/profile/LikesGrid.tsx
+++ b/packages/web/lib/components/profile/LikesGrid.tsx
@@ -170,7 +170,9 @@ export function LikesGrid({ className }: LikesGridProps) {
     return (
       <div className="py-12 text-center">
         <Heart className="h-10 w-10 mx-auto text-muted-foreground/50 mb-3" />
-        <p className="text-sm text-muted-foreground">좋아요한 포스트가 없습니다</p>
+        <p className="text-sm text-muted-foreground">
+          좋아요한 포스트가 없습니다
+        </p>
         <p className="mt-1 text-xs text-muted-foreground/60">
           마음에 드는 포스트에 좋아요를 눌러보세요
         </p>

--- a/packages/web/lib/components/request/SolutionInputForm.tsx
+++ b/packages/web/lib/components/request/SolutionInputForm.tsx
@@ -109,7 +109,9 @@ export const SolutionInputForm = memo(
 
         {/* Product name */}
         <div className="space-y-1">
-          <label className="text-xs text-muted-foreground">Product name *</label>
+          <label className="text-xs text-muted-foreground">
+            Product name *
+          </label>
           <input
             type="text"
             value={title}

--- a/packages/web/lib/components/shared/CommentSection.tsx
+++ b/packages/web/lib/components/shared/CommentSection.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  Send,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-  Trash2,
-} from "lucide-react";
+import { Send, ChevronDown, ChevronUp, Loader2, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { AccountAvatar } from "./AccountAvatar";
@@ -132,11 +126,7 @@ function CommentItem({
 function CommentListSkeleton({ rows = 3 }: { rows?: number }) {
   const widths = ["w-[92%]", "w-[78%]", "w-[85%]", "w-[70%]", "w-[88%]"];
   return (
-    <div
-      className="space-y-5 py-2"
-      role="status"
-      aria-label="Loading comments"
-    >
+    <div className="space-y-5 py-2" role="status" aria-label="Loading comments">
       <span className="sr-only">Loading comments</span>
       {Array.from({ length: rows }).map((_, i) => (
         <div key={i} className="flex gap-3">

--- a/packages/web/lib/hooks/admin/useMonitoring.ts
+++ b/packages/web/lib/hooks/admin/useMonitoring.ts
@@ -8,7 +8,9 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import type { MonitoringMetrics } from "@/lib/api/admin/monitoring";
 
-async function fetchMonitoringMetrics(signal?: AbortSignal): Promise<MonitoringMetrics> {
+async function fetchMonitoringMetrics(
+  signal?: AbortSignal
+): Promise<MonitoringMetrics> {
   const res = await fetch("/api/v1/admin/monitoring/metrics", { signal });
   if (!res.ok) {
     throw new Error(`Monitoring API error: ${res.status}`);

--- a/packages/web/lib/hooks/useImages.ts
+++ b/packages/web/lib/hooks/useImages.ts
@@ -214,8 +214,7 @@ export function useInfinitePosts(params: {
     queryFn: async ({ pageParam }) => {
       const page = (pageParam as number) ?? 1;
       const tp = totalPagesRef.current;
-      const actualPage =
-        loop && tp > 0 ? ((page - 1) % tp) + 1 : page;
+      const actualPage = loop && tp > 0 ? ((page - 1) % tp) + 1 : page;
 
       const response = await listPosts({
         page: actualPage,

--- a/packages/web/lib/stores/authStore.ts
+++ b/packages/web/lib/stores/authStore.ts
@@ -159,8 +159,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // OAuth는 리다이렉트되므로 여기서 loading 상태는 유지됨
       // 실제 로그인 완료는 onAuthStateChange에서 처리
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Login failed.";
+      const message = error instanceof Error ? error.message : "Login failed.";
       set({
         error: message,
         isLoading: false,
@@ -199,8 +198,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         sessionExpired: false,
       });
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Logout failed.";
+      const message = error instanceof Error ? error.message : "Logout failed.";
       set({
         error: message,
         isLoading: false,

--- a/packages/web/orval.config.ts
+++ b/packages/web/orval.config.ts
@@ -1,4 +1,19 @@
 import { defineConfig } from "orval";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = join(packageRoot, "..", "..");
+
+/** Bun/npm often hoist binaries to the repo root — `./node_modules/.bin/prettier` under `packages/web` may not exist. */
+function prettierWriteHook(): string {
+  const local = join(packageRoot, "node_modules", ".bin", "prettier");
+  const hoisted = join(monorepoRoot, "node_modules", ".bin", "prettier");
+  if (existsSync(local)) return `${local} --write`;
+  if (existsSync(hoisted)) return `${hoisted} --write`;
+  return "bun x prettier --write";
+}
 
 export default defineConfig({
   decodedApi: {
@@ -56,7 +71,7 @@ export default defineConfig({
       },
     },
     hooks: {
-      afterAllFilesWrite: "./node_modules/.bin/prettier --write",
+      afterAllFilesWrite: prettierWriteHook(),
     },
   },
   decodedApiZod: {

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -3,6 +3,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": false,
     "strict": true,
     "noEmit": true,
     "incremental": true,


### PR DESCRIPTION
## Summary
- **Orval**: resolve `prettier` for `afterAllFilesWrite` when the binary is hoisted to the monorepo root (fixes ENOENT).
- **TypeScript**: set `forceConsistentCasingInFileNames: false` in `packages/web` to avoid GSAP TS1149 (`Flip.d.ts` vs `flip.d.ts` triple-slash refs).
- **Prettier**: format `packages/web` `app/` + `lib/` so `eslint-plugin-prettier` stops failing `bun run lint`.

## Test plan
- [ ] `cd packages/web && bun run generate:api && bun run lint && bun run format:check && bun run typecheck`
- [ ] `bash packages/web/scripts/pre-push.sh` (or full `bash scripts/git-pre-push.sh` with env as usual)

Fixes #216

Made with [Cursor](https://cursor.com)