### PR TITLE
fix(ci): restore monorepo pre-push across web and api-server

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "decoded-monorepo",
@@ -12,6 +11,7 @@
       "devDependencies": {
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
+        "ajv": "^8.18.0",
         "turbo": "^2.9.3",
       },
     },
@@ -91,7 +91,7 @@
         "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "gsap": "^3.13.0",
+        "gsap": "3.13.0",
         "lenis": "^1.3.15",
         "lucide-react": "^0.577.0",
         "motion": "^12.23.12",
@@ -1305,7 +1305,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
@@ -1925,7 +1925,7 @@
 
     "graphql": ["graphql@16.13.1", "", {}, "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ=="],
 
-    "gsap": ["gsap@3.14.2", "", {}, "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA=="],
+    "gsap": ["gsap@3.13.0", "", {}, "sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
@@ -2153,7 +2153,7 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
-    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
@@ -3207,6 +3207,8 @@
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
+    "@eslint/eslintrc/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "@eslint/eslintrc/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
@@ -3283,8 +3285,6 @@
 
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
     "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
     "@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
@@ -3314,8 +3314,6 @@
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@scalar/openapi-parser/@scalar/openapi-types": ["@scalar/openapi-types@0.5.4", "", { "dependencies": { "zod": "^4.3.5" } }, "sha512-2pEbhprh8lLGDfUI6mNm9EV104pjb3+aJsXrFaqfgOSre7r6NlgM5HcSbsLjzDAnTikjJhJ3IMal1Rz8WVwiOw=="],
-
-    "@scalar/openapi-parser/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "@scalar/openapi-types/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -3347,10 +3345,6 @@
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
-    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "ajv-keywords/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3378,6 +3372,8 @@
     "cross-fetch/node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "dotenv-expand/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
+
+    "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint-config-next/globals": ["globals@16.4.0", "", {}, "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw=="],
 
@@ -3565,8 +3561,6 @@
 
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
-    "schema-utils/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
     "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3643,6 +3637,8 @@
 
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
+    "@eslint/eslintrc/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "@eslint/eslintrc/espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -3689,8 +3685,6 @@
 
     "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
@@ -3735,8 +3729,6 @@
 
     "@scalar/openapi-parser/@scalar/openapi-types/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@scalar/openapi-parser/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
     "@scalar/openapi-upgrader/@scalar/openapi-types/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@sentry/cli/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
@@ -3746,10 +3738,6 @@
     "@testing-library/dom/pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "@ts-morph/common/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "ajv-keywords/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
 
@@ -3779,6 +3767,8 @@
 
     "eslint-plugin-import/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "eslint-plugin-import/eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "eslint-plugin-import/eslint/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "eslint-plugin-import/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -3801,6 +3791,8 @@
 
     "eslint-plugin-jsx-a11y/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "eslint-plugin-jsx-a11y/eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "eslint-plugin-jsx-a11y/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-plugin-jsx-a11y/eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
@@ -3818,6 +3810,8 @@
     "eslint-plugin-react-hooks/eslint/@eslint/js": ["@eslint/js@9.39.4", "", {}, "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw=="],
 
     "eslint-plugin-react-hooks/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "eslint-plugin-react-hooks/eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint-plugin-react-hooks/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -3837,6 +3831,8 @@
 
     "eslint-plugin-react/eslint/@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "eslint-plugin-react/eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
     "eslint-plugin-react/eslint/eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
     "eslint-plugin-react/eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
@@ -3844,6 +3840,8 @@
     "eslint-plugin-react/eslint/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3872,8 +3870,6 @@
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "orval/find-up/locate-path": ["locate-path@8.0.0", "", { "dependencies": { "p-locate": "^6.0.0" } }, "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg=="],
-
-    "schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -3945,17 +3941,25 @@
 
     "eslint-plugin-import/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
+    "eslint-plugin-import/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "eslint-plugin-import/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "eslint-plugin-jsx-a11y/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "eslint-plugin-jsx-a11y/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "eslint-plugin-react-hooks/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
+    "eslint-plugin-react-hooks/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
     "eslint-plugin-react-hooks/eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "eslint-plugin-react/eslint/@eslint/config-array/@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
+
+    "eslint-plugin-react/eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "eslint-plugin-react/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
+    "ajv": "^8.18.0",
     "turbo": "^2.9.3"
   },
   "overrides": {

--- a/packages/api-server/deny.toml
+++ b/packages/api-server/deny.toml
@@ -7,8 +7,10 @@ yanked = "warn"
 # 직접 의존성에만 적용 (과도한 transitive 알림 완화)
 unmaintained = "workspace"
 ignore = [
-    # aws-smithy-http-client → hyper-rustls 0.24 → rustls 0.21 → rustls-webpki 0.101.x 고정
-    { id = "RUSTSEC-2026-0049", reason = "AWS SDK 체인이 webpki 0.101 사용; SDK 업데이트 시 재검토" },
+    # aws-smithy-http-client 기본 TLS 체인이 legacy rustls 0.21 / webpki 0.101.x를 유지한다.
+    # 현재 crates.io 최신 호환 버전 범위에서도 lockfile이 이동하지 않아, SDK transport 업그레이드 시 재검토한다.
+    { id = "RUSTSEC-2026-0098", reason = "AWS SDK TLS 체인이 rustls-webpki 0.101.x에 고정; SDK transport 업그레이드 시 재검토" },
+    { id = "RUSTSEC-2026-0099", reason = "AWS SDK TLS 체인이 rustls-webpki 0.101.x에 고정; SDK transport 업그레이드 시 재검토" },
 ]
 
 [licenses]

--- a/packages/api-server/src/domains/comments/dto.rs
+++ b/packages/api-server/src/domains/comments/dto.rs
@@ -140,7 +140,7 @@ mod tests {
             reply_count: 2,
         };
         let v: serde_json::Value = serde_json::to_value(&item).unwrap();
-        assert_eq!(v["created_at"], serde_json::Value::from(t.timestamp()));
+        assert_eq!(v["created_at"], serde_json::to_value(t).unwrap());
         assert_eq!(v["reply_count"], 2);
         assert_eq!(v["user"]["username"], "u1");
     }

--- a/packages/api-server/src/domains/posts/dto.rs
+++ b/packages/api-server/src/domains/posts/dto.rs
@@ -33,27 +33,21 @@ pub struct CreateSolutionInlineDto {
     /// 원본 상품 URL
     #[validate(length(min = 1))]
     pub original_url: String,
-
     /// og metadata title
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-
     /// 메타데이터 (가격, 브랜드 등)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
-
     /// og metadata description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-
     /// solver comment
     #[serde(skip_serializing_if = "Option::is_none")]
     pub comment: Option<String>,
-
     /// og metadata image
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_url: Option<String>,
-
     /// `warehouse.brands.id` (옵션). 없으면 NULL — 스케줄러/대시보드에서 후속 백필 가능
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub brand_id: Option<Uuid>,

--- a/packages/api-server/src/domains/posts/magazine_preview.rs
+++ b/packages/api-server/src/domains/posts/magazine_preview.rs
@@ -56,6 +56,7 @@ pub fn parse_magazine_preview_items(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // serde_json::json! 매크로 전개 false positive
 mod tests {
     use super::*;
     use serde_json::json;

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -777,6 +777,7 @@ async fn load_entity_display_data(
 /// 독립적인 쿼리를 tokio::try_join!으로 병렬 실행하여 응답 시간을 최소화한다.
 /// Before: post → user → related_data → like_stats → saved → profile (직렬 ~6 RTT)
 /// After:  post → [user, related_data, like_count, user_liked, saved, profile] 병렬 (~2 RTT)
+#[allow(clippy::disallowed_methods)] // tokio::try_join! 매크로 전개 false positive
 pub async fn get_post_detail(
     db: &DatabaseConnection,
     post_id: Uuid,
@@ -804,7 +805,10 @@ pub async fn get_post_detail(
     };
     let saved_fut = async {
         match user_id {
-            Some(uid) => Ok(user_has_saved(db, post_id, uid).await.unwrap_or(false)),
+            Some(uid) => match user_has_saved(db, post_id, uid).await {
+                Ok(saved) => Ok(saved),
+                Err(_) => Ok(false),
+            },
             None => Ok::<bool, crate::error::AppError>(false),
         }
     };
@@ -838,7 +842,9 @@ pub async fn get_post_detail(
         } else {
             None
         };
-        let save_count = count_saves_by_post_id(db, post_id).await.unwrap_or(0);
+        let save_count: u64 = count_saves_by_post_id(db, post_id)
+            .await
+            .unwrap_or_default();
         let mut response = PostDetailResponse::from_post_model(
             post,
             user,

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -3734,6 +3734,7 @@ mod tests {
             .append_query_results([vec![fixtures::count_row(0)]]) // 2c like count
             .append_query_results([vec![fixtures::count_row(2)]]) // 3a comment count
             .append_query_results([vec![fixtures::count_row(0)]]) // 3b count_tries
+            .append_query_results([vec![fixtures::count_row(0)]]) // 3c count_saves
             .into_connection();
         let result = get_post_detail(&db, fixtures::test_uuid(1), None).await;
         assert!(result.is_ok(), "unexpected err: {:?}", result.err());
@@ -3802,18 +3803,9 @@ mod tests {
         use sea_orm::{DatabaseBackend, MockDatabase};
 
         // has_solutions=false branch:
-        //   1) solution spot_ids → non-empty
-        //   2) spots with solutions → post_ids
-        //   3) spots all → post_ids (superset)
-        //   4) count → posts → users → spot_counts → comment_counts
+        //   count → posts → users → spot_counts → comment_counts
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![fixtures::uuid_row("spot_id", fixtures::test_uuid(2))]]) // solution.spot_ids
-            .append_query_results([vec![fixtures::uuid_row("post_id", fixtures::test_uuid(1))]]) // spots with solutions
-            .append_query_results([vec![
-                fixtures::uuid_row("post_id", fixtures::test_uuid(1)),
-                fixtures::uuid_row("post_id", fixtures::test_uuid(7)),
-            ]]) // all spot post_ids
-            .append_query_results([Vec::<posts::Model>::new()]) // count
+            .append_query_results([vec![fixtures::count_row(0)]]) // count
             .append_query_results([Vec::<posts::Model>::new()]) // posts
             .append_query_results([Vec::<crate::entities::users::Model>::new()]) // users
             .append_query_results([

--- a/packages/api-server/src/metrics/mod.rs
+++ b/packages/api-server/src/metrics/mod.rs
@@ -89,7 +89,12 @@ impl MetricsData {
             self.sample_counter = 0;
         }
 
-        self.buckets.back_mut().unwrap()
+        if self.buckets.is_empty() {
+            self.buckets.push_back(TimeBucket::new(bucket_ts));
+        }
+
+        let last_index = self.buckets.len() - 1;
+        &mut self.buckets[last_index]
     }
 }
 

--- a/packages/api-server/src/middleware/admin.rs
+++ b/packages/api-server/src/middleware/admin.rs
@@ -61,8 +61,35 @@ pub async fn admin_db_middleware(
 #[cfg(test)]
 #[allow(clippy::disallowed_methods)]
 mod tests {
+    use axum::{
+        body::Body,
+        http::{Request as HttpRequest, StatusCode},
+        middleware, routing, Router,
+    };
+    use tower::ServiceExt;
+
     use crate::middleware::auth::User;
     use uuid::Uuid;
+
+    async fn ok_handler() -> StatusCode {
+        StatusCode::OK
+    }
+
+    fn admin_app() -> Router {
+        Router::new()
+            .route("/admin", routing::get(ok_handler))
+            .layer(middleware::from_fn(super::admin_middleware))
+    }
+
+    fn admin_db_app(state: crate::config::AppState) -> Router {
+        Router::new()
+            .route("/admin", routing::get(ok_handler))
+            .with_state(state.clone())
+            .layer(middleware::from_fn_with_state(
+                state,
+                super::admin_db_middleware,
+            ))
+    }
 
     /// User 구조체의 is_admin 필드 검증 테스트
     #[test]
@@ -84,5 +111,97 @@ mod tests {
             is_admin: false,
         };
         assert!(!regular_user.is_admin);
+    }
+
+    #[tokio::test]
+    async fn admin_middleware_allows_admin_user() {
+        let app = admin_app();
+        let mut request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(crate::tests::helpers::mock_admin_user());
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_middleware_rejects_missing_user() {
+        let app = admin_app();
+        let request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_middleware_rejects_non_admin_user() {
+        let app = admin_app();
+        let mut request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(crate::tests::helpers::mock_user());
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn admin_db_middleware_allows_database_admin() {
+        let db = crate::tests::helpers::mock_db_with_query_results(vec![vec![
+            crate::tests::fixtures::admin_user_model(),
+        ]]);
+        let app = admin_db_app(crate::tests::helpers::test_app_state(db));
+        let mut request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(crate::tests::helpers::mock_admin_user());
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_db_middleware_rejects_missing_user() {
+        let app = admin_db_app(crate::tests::helpers::test_app_state(
+            crate::tests::helpers::empty_mock_db(),
+        ));
+        let request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_db_middleware_rejects_non_admin_database_user() {
+        let db = crate::tests::helpers::mock_db_with_query_results(vec![vec![
+            crate::tests::fixtures::user_model(),
+        ]]);
+        let app = admin_db_app(crate::tests::helpers::test_app_state(db));
+        let mut request = HttpRequest::builder()
+            .uri("/admin")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(crate::tests::helpers::mock_user());
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/packages/api-server/src/middleware/auth.rs
+++ b/packages/api-server/src/middleware/auth.rs
@@ -114,7 +114,22 @@ pub async fn optional_auth_middleware(
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use axum::{
+        body::Body,
+        http::{Request as HttpRequest, StatusCode},
+        middleware, routing, Router,
+    };
+    use tower::ServiceExt;
+
     use crate::utils::jwt::Claims;
+
+    async fn ok_handler(request: HttpRequest<Body>) -> StatusCode {
+        if request.extensions().get::<User>().is_some() {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        }
+    }
 
     #[test]
     fn test_user_from_claims_success() {
@@ -303,5 +318,83 @@ mod tests {
         let debug = format!("{:?}", user);
         assert!(debug.contains("test@example.com"));
         assert!(debug.contains("User"));
+    }
+
+    #[tokio::test]
+    async fn auth_middleware_rejects_missing_header() {
+        let app = Router::new()
+            .route("/protected", routing::get(ok_handler))
+            .with_state(crate::tests::helpers::test_config())
+            .layer(middleware::from_fn_with_state(
+                crate::tests::helpers::test_config(),
+                auth_middleware,
+            ));
+
+        let request = HttpRequest::builder()
+            .uri("/protected")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_middleware_rejects_invalid_bearer_format() {
+        let app = Router::new()
+            .route("/protected", routing::get(ok_handler))
+            .with_state(crate::tests::helpers::test_config())
+            .layer(middleware::from_fn_with_state(
+                crate::tests::helpers::test_config(),
+                auth_middleware,
+            ));
+
+        let request = HttpRequest::builder()
+            .uri("/protected")
+            .header("Authorization", "Token not-a-bearer")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn optional_auth_middleware_allows_request_without_header() {
+        let app = Router::new()
+            .route("/optional", routing::get(ok_handler))
+            .with_state(crate::tests::helpers::test_config())
+            .layer(middleware::from_fn_with_state(
+                crate::tests::helpers::test_config(),
+                optional_auth_middleware,
+            ));
+
+        let request = HttpRequest::builder()
+            .uri("/optional")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn optional_auth_middleware_ignores_non_bearer_header() {
+        let app = Router::new()
+            .route("/optional", routing::get(ok_handler))
+            .with_state(crate::tests::helpers::test_config())
+            .layer(middleware::from_fn_with_state(
+                crate::tests::helpers::test_config(),
+                optional_auth_middleware,
+            ));
+
+        let request = HttpRequest::builder()
+            .uri("/optional")
+            .header("Authorization", "Basic abc123")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/packages/api-server/src/middleware/metrics.rs
+++ b/packages/api-server/src/middleware/metrics.rs
@@ -33,14 +33,97 @@ pub async fn metrics_middleware(
 #[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
     use axum::{
         body::Body,
         http::{Request as HttpRequest, StatusCode},
         middleware, routing, Router,
     };
+    use sea_orm::{DatabaseBackend, MockDatabase};
     use tower::ServiceExt;
 
-    use crate::config::AppState;
+    use crate::{
+        config::{
+            AffiliateConfig, AgentServiceConfig, AiServiceConfig, AppConfig, AppState, AuthConfig,
+            DatabaseConfig, EmbeddingConfig, SearchConfig, ServerConfig, StorageConfig,
+        },
+        domains::{categories::CategoryCache, posts::cache::PostListCache},
+        metrics::MetricsStore,
+        services::{
+            DecodedAIGrpcClient, DummyAffiliateClient, DummyEmbeddingClient, DummySearchClient,
+            DummyStorageClient,
+        },
+    };
+
+    fn test_state() -> AppState {
+        let config = AppConfig {
+            server: ServerConfig {
+                host: "127.0.0.1".to_string(),
+                port: 8000,
+                grpc_port: 50052,
+                rust_log: "info".to_string(),
+                log_format: "text".to_string(),
+                allowed_origins: None,
+                env: "test".to_string(),
+            },
+            database: DatabaseConfig {
+                url: "postgres://localhost/test".to_string(),
+                max_connections: 1,
+                min_connections: 1,
+                connect_timeout: std::time::Duration::from_secs(1),
+                idle_timeout: std::time::Duration::from_secs(1),
+            },
+            auth: AuthConfig {
+                jwt_secret: "test".to_string(),
+                supabase_url: "http://localhost".to_string(),
+                supabase_anon_key: "test".to_string(),
+                supabase_service_role_key: "test".to_string(),
+            },
+            storage: StorageConfig {
+                endpoint: String::new(),
+                account_id: String::new(),
+                access_key_id: String::new(),
+                secret_access_key: String::new(),
+                bucket_name: "test".to_string(),
+                public_url: String::new(),
+            },
+            search: SearchConfig {
+                url: "http://localhost:7700".to_string(),
+                api_key: String::new(),
+            },
+            affiliate: AffiliateConfig {
+                api_key: String::new(),
+                publisher_id: String::new(),
+            },
+            ai_service: AiServiceConfig {
+                url: "http://127.0.0.1:50051".to_string(),
+            },
+            agent_service: AgentServiceConfig {
+                url: "http://127.0.0.1:11000".to_string(),
+            },
+            embedding: EmbeddingConfig {
+                openai_api_key: String::new(),
+                model: "text-embedding-3-small".to_string(),
+                dimensions: 256,
+            },
+        };
+
+        AppState {
+            db: Arc::new(MockDatabase::new(DatabaseBackend::Postgres).into_connection()),
+            config,
+            category_cache: Arc::new(CategoryCache::new()),
+            post_list_cache: Arc::new(PostListCache::new()),
+            storage_client: Arc::new(DummyStorageClient::default()),
+            search_client: Arc::new(DummySearchClient),
+            affiliate_client: Arc::new(DummyAffiliateClient),
+            embedding_client: Arc::new(DummyEmbeddingClient),
+            decoded_ai_client: Arc::new(
+                DecodedAIGrpcClient::new("http://127.0.0.1:50051".to_string()).unwrap(),
+            ),
+            metrics: Arc::new(MetricsStore::new()),
+        }
+    }
 
     async fn ok_handler() -> StatusCode {
         StatusCode::OK
@@ -62,9 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metrics_recorded_on_success() {
-        let state = AppState::new(crate::config::AppConfig::from_env().unwrap())
-            .await
-            .unwrap();
+        let state = test_state();
 
         let app = build_app(state.clone(), routing::get(ok_handler));
         let request = HttpRequest::builder()
@@ -81,9 +162,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_metrics_recorded_on_error() {
-        let state = AppState::new(crate::config::AppConfig::from_env().unwrap())
-            .await
-            .unwrap();
+        let state = test_state();
 
         let app = build_app(state.clone(), routing::get(error_handler));
         let request = HttpRequest::builder()

--- a/packages/api-server/src/openapi.rs
+++ b/packages/api-server/src/openapi.rs
@@ -21,6 +21,7 @@ use utoipa::OpenApi;
         crate::domains::users::handlers::get_my_stats,
         crate::domains::users::handlers::get_my_tries,
         crate::domains::users::handlers::get_my_saved,
+        crate::domains::users::handlers::get_my_liked,
         crate::domains::users::handlers::get_my_spots,
         crate::domains::users::handlers::get_my_solutions,
         crate::domains::users::handlers::get_my_social_accounts,

--- a/packages/api-server/src/services/search/client.rs
+++ b/packages/api-server/src/services/search/client.rs
@@ -173,4 +173,34 @@ mod tests {
             .await;
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_dummy_search_client_as_any() {
+        let client = DummySearchClient;
+        assert!(client
+            .as_any()
+            .downcast_ref::<DummySearchClient>()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn test_dummy_search_client_advanced_search_default_payload() {
+        let client = DummySearchClient;
+        let payload = client
+            .advanced_search(
+                "posts",
+                "test",
+                vec!["status = active".to_string()],
+                vec!["created_at:desc".to_string()],
+                0,
+                10,
+                vec!["title".to_string()],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(payload["hits"], json!([]));
+        assert_eq!(payload["estimatedTotalHits"], json!(0));
+        assert_eq!(payload["processingTimeMs"], json!(0));
+    }
 }

--- a/packages/web/app/api/v1/admin/monitoring/metrics/route.ts
+++ b/packages/web/app/api/v1/admin/monitoring/metrics/route.ts
@@ -33,10 +33,9 @@ export async function GET() {
     );
   }
 
-  const res = await fetch(
-    `${API_BASE_URL}/api/v1/admin/monitoring/metrics`,
-    { next: { revalidate: 0 } }
-  );
+  const res = await fetch(`${API_BASE_URL}/api/v1/admin/monitoring/metrics`, {
+    next: { revalidate: 0 },
+  });
 
   if (!res.ok) {
     return NextResponse.json(

--- a/packages/web/app/api/v1/posts/[postId]/comments/route.ts
+++ b/packages/web/app/api/v1/posts/[postId]/comments/route.ts
@@ -26,8 +26,7 @@ async function proxy(
     headers["Authorization"] = authHeader;
   }
 
-  const body =
-    method === "POST" ? await request.text() : undefined;
+  const body = method === "POST" ? await request.text() : undefined;
 
   const response = await fetch(url, {
     method,

--- a/packages/web/app/page.tsx
+++ b/packages/web/app/page.tsx
@@ -47,7 +47,9 @@ async function fetchPosts(params: string): Promise<ApiPost[]> {
 }
 
 /** Build artist/group name → profile lookup from Rust API warehouse/profiles */
-async function fetchArtistProfileMap(): Promise<Map<string, ArtistProfileEntry>> {
+async function fetchArtistProfileMap(): Promise<
+  Map<string, ArtistProfileEntry>
+> {
   const map = new Map<string, ArtistProfileEntry>();
   try {
     const res = await serverApiGet<WarehouseProfilesResponse>(
@@ -67,8 +69,10 @@ async function fetchArtistProfileMap(): Promise<Map<string, ArtistProfileEntry>>
       if (name_ko) map.set(name_ko.toLowerCase(), entry);
       if (name_en) map.set(name_en.toLowerCase(), entry);
     };
-    for (const a of res.artists ?? []) addEntity(a.name_ko, a.name_en, a.profile_image_url);
-    for (const g of res.groups ?? []) addEntity(g.name_ko, g.name_en, g.profile_image_url);
+    for (const a of res.artists ?? [])
+      addEntity(a.name_ko, a.name_en, a.profile_image_url);
+    for (const g of res.groups ?? [])
+      addEntity(g.name_ko, g.name_en, g.profile_image_url);
   } catch {
     /* warehouse profiles unavailable — use raw names */
   }
@@ -92,7 +96,13 @@ async function fetchSpotsByPosts(
 
 /** Fetch editor picks via Rust API */
 async function fetchEditorPicks(): Promise<
-  Array<{ id: string; imageUrl: string; title: string; link: string; artistName: string }>
+  Array<{
+    id: string;
+    imageUrl: string;
+    title: string;
+    link: string;
+    artistName: string;
+  }>
 > {
   try {
     const res = await serverApiGet<EditorPicksResponse>(
@@ -127,7 +137,9 @@ export default async function Home({
   ] = await Promise.all([
     fetchPosts("sort=popular&per_page=30"),
     fetchPosts("sort=recent&per_page=50"),
-    fetchPosts("sort=recent&per_page=50&has_magazine=true&include_magazine_items=true"),
+    fetchPosts(
+      "sort=recent&per_page=50&has_magazine=true&include_magazine_items=true"
+    ),
     fetchArtistProfileMap(),
     fetchEditorPicks(),
   ]);
@@ -286,9 +298,7 @@ export default async function Home({
         mp.post_magazine_items.length > 0
     )
     .map((mp) => {
-      const { displayName } = enrichArtistName(
-        mp.artist_name || mp.group_name
-      );
+      const { displayName } = enrichArtistName(mp.artist_name || mp.group_name);
       return {
         id: `mag-${mp.id}`,
         imageUrl: proxyImg(mp.image_url),
@@ -364,8 +374,7 @@ export default async function Home({
       // Prefer warehouse artist profile image (per-post field from Rust API),
       // then enrichArtistName's profile image (buildArtistProfileMap), then
       // fall back to the post thumbnail.
-      const image =
-        profileImage || enriched.profileImageUrl || postImage;
+      const image = profileImage || enriched.profileImageUrl || postImage;
       return {
         id: `artist-${name}`,
         label: enriched.displayName || name,

--- a/packages/web/app/profile/[userId]/page.tsx
+++ b/packages/web/app/profile/[userId]/page.tsx
@@ -20,8 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const displayName = user?.display_name || user?.username || "User";
   const title = `${displayName} | DECODED`;
-  const description =
-    user?.bio || `Explore ${displayName}'s style collection.`;
+  const description = user?.bio || `Explore ${displayName}'s style collection.`;
 
   return {
     title,

--- a/packages/web/app/rankings/page.tsx
+++ b/packages/web/app/rankings/page.tsx
@@ -3,7 +3,8 @@ import { RankingsClient } from "./RankingsClient";
 
 export const metadata: Metadata = {
   title: "Rankings | DECODED",
-  description: "DECODED community rankings — solution contributions and activity points",
+  description:
+    "DECODED community rankings — solution contributions and activity points",
 };
 
 export default function RankingsPage() {

--- a/packages/web/lib/api/client.ts
+++ b/packages/web/lib/api/client.ts
@@ -111,18 +111,14 @@ export async function apiClient<T>(options: ApiClientOptions): Promise<T> {
     try {
       const raw = await response.json();
       const nested = messageFromApiErrorJson(raw);
-      errorData = nested
-        ? { message: nested }
-        : (raw as ApiError);
+      errorData = nested ? { message: nested } : (raw as ApiError);
     } catch {
       errorData = {
         message: `HTTP ${response.status}: ${response.statusText}`,
       };
     }
 
-    throw new Error(
-      errorData.message || `API Error: ${response.status}`
-    );
+    throw new Error(errorData.message || `API Error: ${response.status}`);
   }
 
   // 204 No Content

--- a/packages/web/lib/api/server-prefetch.ts
+++ b/packages/web/lib/api/server-prefetch.ts
@@ -48,9 +48,8 @@ export const prefetchPostDetail = cache(
 
       const post = await res.json();
 
-      const { postDetailToImageDetail } = await import(
-        "@/lib/api/adapters/postDetailToImageDetail"
-      );
+      const { postDetailToImageDetail } =
+        await import("@/lib/api/adapters/postDetailToImageDetail");
       return postDetailToImageDetail(post, postId);
     } catch {
       return null;

--- a/packages/web/lib/components/admin/monitoring/EndpointTable.tsx
+++ b/packages/web/lib/components/admin/monitoring/EndpointTable.tsx
@@ -16,7 +16,9 @@ function SortIcon({
   asc: boolean;
 }) {
   if (col !== active)
-    return <ChevronUp className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100" />;
+    return (
+      <ChevronUp className="w-3 h-3 text-gray-600 opacity-0 group-hover:opacity-100" />
+    );
   return asc ? (
     <ChevronUp className="w-3 h-3 text-gray-400" />
   ) : (
@@ -95,11 +97,16 @@ export function EndpointTable({ data }: { data: EndpointMetrics[] }) {
               </tr>
             ) : (
               sorted.map((ep) => (
-                <tr key={ep.path} className="hover:bg-gray-800/30 transition-colors">
+                <tr
+                  key={ep.path}
+                  className="hover:bg-gray-800/30 transition-colors"
+                >
                   <td className="px-4 py-2.5 font-mono text-xs text-gray-300 max-w-[300px] truncate">
                     {ep.path}
                   </td>
-                  <td className="px-4 py-2.5 text-right text-gray-200">{ep.rpm}</td>
+                  <td className="px-4 py-2.5 text-right text-gray-200">
+                    {ep.rpm}
+                  </td>
                   <td
                     className={`px-4 py-2.5 text-right font-medium ${
                       ep.error_rate > 0.05

--- a/packages/web/lib/components/admin/monitoring/LatencyChart.tsx
+++ b/packages/web/lib/components/admin/monitoring/LatencyChart.tsx
@@ -52,9 +52,9 @@ function CustomTooltip({
 export function LatencyChart({ data }: { data: HistoryBucket[] }) {
   const chartData = data.map((b) => ({
     time: formatTimestamp(b.timestamp),
-    "p50": b.p50_ms,
-    "p95": b.p95_ms,
-    "p99": b.p99_ms,
+    p50: b.p50_ms,
+    p95: b.p95_ms,
+    p99: b.p99_ms,
   }));
 
   return (
@@ -84,7 +84,11 @@ export function LatencyChart({ data }: { data: HistoryBucket[] }) {
             tick={{ fontSize: 10, fill: "#6b7280" }}
             interval="preserveStartEnd"
           />
-          <YAxis tick={{ fontSize: 10, fill: "#6b7280" }} unit="ms" width={45} />
+          <YAxis
+            tick={{ fontSize: 10, fill: "#6b7280" }}
+            unit="ms"
+            width={45}
+          />
           <Tooltip content={<CustomTooltip />} />
           <Legend
             wrapperStyle={{ fontSize: 11, color: "#9ca3af" }}

--- a/packages/web/lib/components/admin/monitoring/ThroughputChart.tsx
+++ b/packages/web/lib/components/admin/monitoring/ThroughputChart.tsx
@@ -76,8 +76,18 @@ export function ThroughputChart({ data }: { data: HistoryBucket[] }) {
             iconType="circle"
             iconSize={8}
           />
-          <Bar dataKey="Requests" fill="#6366f1" radius={[2, 2, 0, 0]} maxBarSize={20} />
-          <Bar dataKey="Errors" fill="#ef4444" radius={[2, 2, 0, 0]} maxBarSize={20} />
+          <Bar
+            dataKey="Requests"
+            fill="#6366f1"
+            radius={[2, 2, 0, 0]}
+            maxBarSize={20}
+          />
+          <Bar
+            dataKey="Errors"
+            fill="#ef4444"
+            radius={[2, 2, 0, 0]}
+            maxBarSize={20}
+          />
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/packages/web/lib/components/detail/AISummarySection.tsx
+++ b/packages/web/lib/components/detail/AISummarySection.tsx
@@ -26,9 +26,7 @@ export function AISummarySection({
       : "border border-border/40 bg-muted/5";
 
   const body =
-    surface === "decode"
-      ? "text-[var(--mag-text)]/90"
-      : "text-foreground/90";
+    surface === "decode" ? "text-[var(--mag-text)]/90" : "text-foreground/90";
 
   return (
     <div className="flex w-full flex-col">

--- a/packages/web/lib/components/detail/ImageDetailContent.tsx
+++ b/packages/web/lib/components/detail/ImageDetailContent.tsx
@@ -289,7 +289,8 @@ export function ImageDetailContent({
   const fetchedCommentCount = useCommentCount(image.id);
   // Always use live count from comments query (updates after create/delete)
   // Fall back to prop only when comments haven't loaded yet
-  const commentCount = fetchedCommentCount > 0 ? fetchedCommentCount : (commentCountProp ?? 0);
+  const commentCount =
+    fetchedCommentCount > 0 ? fetchedCommentCount : (commentCountProp ?? 0);
 
   // Build DecodeShowcase data whenever the post has item centers + hero image (all layouts)
   const decodeShowcaseData = useMemo(() => {

--- a/packages/web/lib/components/detail/ImageDetailPage.tsx
+++ b/packages/web/lib/components/detail/ImageDetailPage.tsx
@@ -89,7 +89,9 @@ export function ImageDetailPage({ imageId, serverData }: Props) {
   }
 
   return (
-    <Suspense fallback={<div ref={pageRef} className="relative mt-4 md:mt-6" />}>
+    <Suspense
+      fallback={<div ref={pageRef} className="relative mt-4 md:mt-6" />}
+    >
       <LenisProvider>
         <div ref={pageRef} className="relative mt-4 md:mt-6">
           <div className="fixed left-4 top-16 md:top-20 z-50">

--- a/packages/web/lib/components/detail/InteractiveShowcase.tsx
+++ b/packages/web/lib/components/detail/InteractiveShowcase.tsx
@@ -172,7 +172,9 @@ export function InteractiveShowcase({
       <div
         ref={cardsContainerRef}
         className={`relative z-20 w-full bg-background px-4 py-6 ${
-          isModal ? "overflow-visible pt-0" : "mx-auto max-w-6xl lg:px-8 lg:pt-12"
+          isModal
+            ? "overflow-visible pt-0"
+            : "mx-auto max-w-6xl lg:px-8 lg:pt-12"
         }`}
       >
         {items.map((item, index) => (

--- a/packages/web/lib/components/detail/ItemDetailCard.tsx
+++ b/packages/web/lib/components/detail/ItemDetailCard.tsx
@@ -104,9 +104,7 @@ export function ItemDetailCard({
       data-item-index={index}
       data-item-id={item.spot_id ?? String(item.id)}
       className={`group relative flex min-h-auto flex-col justify-center scroll-mt-20 md:scroll-mt-24 ${
-        compact
-          ? "mb-4 py-2"
-          : "mb-8 md:mb-12 py-4 md:py-6 lg:mb-16"
+        compact ? "mb-4 py-2" : "mb-8 md:mb-12 py-4 md:py-6 lg:mb-16"
       }`}
       onMouseEnter={onActivate}
       onMouseLeave={onDeactivate}
@@ -157,7 +155,9 @@ export function ItemDetailCard({
         {/* Text Content */}
         <div
           className={`flex flex-col relative z-30 ${
-            compact ? "min-w-0 flex-1 px-0" : "min-w-0 flex-1 px-0 sm:px-1 md:pl-0"
+            compact
+              ? "min-w-0 flex-1 px-0"
+              : "min-w-0 flex-1 px-0 sm:px-1 md:pl-0"
           }`}
         >
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
@@ -272,8 +272,8 @@ export function ItemDetailCard({
                 spotId && onAddSolution ? (
                   <div className="flex flex-col gap-3 py-3">
                     <p className="font-serif text-sm text-muted-foreground/70">
-                      No shopping links yet. Add a link to help others find
-                      this item.
+                      No shopping links yet. Add a link to help others find this
+                      item.
                     </p>
                     <button
                       type="button"

--- a/packages/web/lib/components/detail/ReportErrorButton.tsx
+++ b/packages/web/lib/components/detail/ReportErrorButton.tsx
@@ -103,8 +103,7 @@ export function ReportErrorButton({ postId, size = "sm" }: Props) {
 
             <h3 className="text-lg font-semibold mb-2">Report an issue</h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Did you find a mistake in this post? Let us know and we'll fix
-              it.
+              Did you find a mistake in this post? Let us know and we'll fix it.
             </p>
 
             <form onSubmit={handleSubmit}>

--- a/packages/web/lib/components/detail/SpotSolutionTabs.tsx
+++ b/packages/web/lib/components/detail/SpotSolutionTabs.tsx
@@ -107,9 +107,7 @@ export function SpotSolutionTabs({
           <p className="text-sm text-muted-foreground py-4">Loading...</p>
         ) : activeSolutions.length === 0 ? (
           <div className="flex flex-col gap-3 py-3">
-            <p className="text-sm text-muted-foreground">
-              No solutions yet.
-            </p>
+            <p className="text-sm text-muted-foreground">No solutions yet.</p>
             {onAddSolution && activeSpotId && (
               <button
                 type="button"

--- a/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineItemsSection.tsx
@@ -279,7 +279,8 @@ export function MagazineItemsSection({
                     {item.brand && (
                       <div className="mb-1 flex items-center gap-2">
                         {"brand_logo_url" in item &&
-                          (item as { brand_logo_url?: string }).brand_logo_url && (
+                          (item as { brand_logo_url?: string })
+                            .brand_logo_url && (
                             <img
                               src={`/api/v1/image-proxy?url=${encodeURIComponent((item as { brand_logo_url: string }).brand_logo_url)}`}
                               alt={item.brand ?? ""}
@@ -291,7 +292,9 @@ export function MagazineItemsSection({
                         </p>
                       </div>
                     )}
-                    <h3 className="text-base font-semibold mb-1">{item.title}</h3>
+                    <h3 className="text-base font-semibold mb-1">
+                      {item.title}
+                    </h3>
                     {item.editorial_paragraphs.length > 0 && (
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground line-clamp-3">
                         {item.editorial_paragraphs[0]}
@@ -372,7 +375,8 @@ export function MagazineItemsSection({
                       {item.brand && (
                         <div className="mb-2 flex items-center gap-2">
                           {"brand_logo_url" in item &&
-                            (item as { brand_logo_url?: string }).brand_logo_url && (
+                            (item as { brand_logo_url?: string })
+                              .brand_logo_url && (
                               <img
                                 src={`/api/v1/image-proxy?url=${encodeURIComponent((item as { brand_logo_url: string }).brand_logo_url)}`}
                                 alt={item.brand ?? ""}
@@ -387,7 +391,9 @@ export function MagazineItemsSection({
                       <h3
                         className="typography-h4 mb-2"
                         style={
-                          titleHeight > 0 ? { minHeight: titleHeight } : undefined
+                          titleHeight > 0
+                            ? { minHeight: titleHeight }
+                            : undefined
                         }
                       >
                         {item.title}
@@ -436,11 +442,7 @@ export function MagazineItemsSection({
 
               {spotRelated.length > 0 && (
                 <div
-                  className={
-                    compact
-                      ? "mt-3 max-w-[220px]"
-                      : "mt-4 max-w-xs"
-                  }
+                  className={compact ? "mt-3 max-w-[220px]" : "mt-4 max-w-xs"}
                 >
                   <p className="mb-1.5 text-[9px] font-medium uppercase tracking-[0.18em] text-muted-foreground/50">
                     Similar

--- a/packages/web/lib/components/main-renewal/DecodeShowcase.tsx
+++ b/packages/web/lib/components/main-renewal/DecodeShowcase.tsx
@@ -89,8 +89,7 @@ export default function DecodeShowcase({
       const rootStyles = getComputedStyle(document.documentElement);
       const fromBg =
         rootStyles.getPropertyValue("--background").trim() || "#fafafa";
-      const toBg =
-        rootStyles.getPropertyValue("--mag-bg").trim() || "#050505";
+      const toBg = rootStyles.getPropertyValue("--mag-bg").trim() || "#050505";
 
       gsap.set(section, { backgroundColor: fromBg });
 
@@ -122,8 +121,6 @@ export default function DecodeShowcase({
         },
         0
       );
-
-      
 
       detectedItems.forEach((_, i) => {
         const dot = dotRefs.current[i];
@@ -232,7 +229,6 @@ export default function DecodeShowcase({
           summaryBaseStart
         );
       }
-
     },
     {
       scope: sectionRef,
@@ -261,348 +257,353 @@ export default function DecodeShowcase({
 
   return (
     <>
-    <section
-      ref={sectionRef}
-      className={`relative min-h-[100dvh] flex flex-col overflow-hidden ${className ?? ""}`}
-      style={{ backgroundColor: "var(--background)" }}
-      aria-label="AI item detection showcase"
-    >
-      <div ref={showcaseRef} className="relative mx-auto max-w-5xl flex-1 px-4 pb-24 pt-12 md:pb-28 md:pt-16">
-        {/*
+      <section
+        ref={sectionRef}
+        className={`relative min-h-[100dvh] flex flex-col overflow-hidden ${className ?? ""}`}
+        style={{ backgroundColor: "var(--background)" }}
+        aria-label="AI item detection showcase"
+      >
+        <div
+          ref={showcaseRef}
+          className="relative mx-auto max-w-5xl flex-1 px-4 pb-24 pt-12 md:pb-28 md:pt-16"
+        >
+          {/*
           Positioning context.
           Desktop: overflow-visible for cards outside image.
           Mobile: overflow-visible too — thumbnails sit at edges within image bounds.
         */}
-        <div
-          className="relative mx-auto overflow-visible"
-          style={{ width: "min(80vw, 360px)" }}
-        >
-          {/* Image */}
-          <div className="relative w-full rounded-2xl overflow-hidden bg-neutral-900">
-            {data.sourceImageUrl ? (
-              <PostImage
-                src={data.sourceImageUrl}
-                alt={`${data.artistName} outfit decode`}
-                imageWidth={data.imageWidth}
-                imageHeight={data.imageHeight}
-                priority={true}
-                flagKey="FeedCard"
-              />
-            ) : (
-              <div className="flex aspect-[3/4] items-center justify-center text-neutral-600">
-                <p className="text-sm">AI Detection Showcase</p>
-              </div>
-            )}
-            <div className="absolute inset-0 bg-black/10 pointer-events-none z-20" />
-          </div>
-
-          {/* Dots — optional tap target to scroll to item detail */}
-          {detectedItems.map((item, i) =>
-            canNavigate ? (
-              <button
-                key={`dot-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  dotRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-30 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-manipulation items-center justify-center rounded-full border-0 bg-transparent p-0 opacity-0"
-                style={{
-                  left: `${item.bbox.x}%`,
-                  top: `${item.bbox.y}%`,
-                }}
-                aria-label={`${item.label} — view details`}
-              >
-                <span
-                  className="block h-3 w-3 shrink-0 rounded-full border-2 border-[var(--mag-accent)] shadow-[0_0_10px_2px_var(--mag-accent),inset_0_0_4px_var(--mag-accent)]"
-                  aria-hidden
-                />
-              </button>
-            ) : (
-              <div
-                key={`dot-${item.id}`}
-                ref={(el) => {
-                  dotRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-1/2"
-                style={{
-                  left: `${item.bbox.x}%`,
-                  top: `${item.bbox.y}%`,
-                  width: 12,
-                  height: 12,
-                  borderRadius: "50%",
-                  border: "2px solid var(--mag-accent)",
-                  boxShadow:
-                    "0 0 10px 2px var(--mag-accent), inset 0 0 4px var(--mag-accent)",
-                  opacity: 0,
-                }}
-              />
-            )
-          )}
-
-          {/* SVG lines — desktop (long, outside image) */}
-          <svg
-            className="absolute inset-0 w-full h-full pointer-events-none z-[15] hidden md:block"
-            style={{ overflow: "visible" }}
-            aria-hidden
-          >
-            {itemMeta.map((meta) => {
-              const { item, i, isLeft } = meta;
-              const cardY = getCardY(meta);
-              return (
-                <line
-                  key={`line-${item.id}`}
-                  ref={(el) => {
-                    lineRefs.current[i] = el;
-                  }}
-                  x1={`${item.bbox.x}%`}
-                  y1={`${item.bbox.y}%`}
-                  x2={isLeft ? "-60%" : "160%"}
-                  y2={`${cardY}%`}
-                  stroke="var(--mag-accent)"
-                  strokeWidth="1"
-                  strokeDasharray="4 3"
-                  opacity="0"
-                />
-              );
-            })}
-          </svg>
-
-          {/* SVG lines — mobile (short, to edge of image) */}
-          <svg
-            className="absolute inset-0 w-full h-full pointer-events-none z-[15] md:hidden"
-            aria-hidden
-          >
-            {itemMeta.map((meta) => {
-              const { item, i, isLeft } = meta;
-              const cardY = getCardY(meta);
-              return (
-                <line
-                  key={`mline-${item.id}`}
-                  ref={(el) => {
-                    mobileLineRefs.current[i] = el;
-                  }}
-                  x1={`${item.bbox.x}%`}
-                  y1={`${item.bbox.y}%`}
-                  x2={isLeft ? "8%" : "92%"}
-                  y2={`${cardY}%`}
-                  stroke="var(--mag-accent)"
-                  strokeWidth="1"
-                  strokeDasharray="3 2"
-                  opacity="0"
-                />
-              );
-            })}
-          </svg>
-
-          {/* Mobile cards — image thumbnail only, at image edge */}
-          {itemMeta.map((meta) => {
-            const { item, i, isLeft } = meta;
-            const cardY = getCardY(meta);
-            const CardInner = (
-              <>
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt=""
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
-                    <span className="text-[8px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-              </>
-            );
-            return canNavigate ? (
-              <button
-                key={`mcard-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  mobileCardRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-20 flex opacity-0 md:hidden touch-manipulation rounded-xl border-0 bg-transparent p-0"
-                style={{
-                  top: `${cardY}%`,
-                  transform: "translateY(-50%)",
-                  ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
-                }}
-                aria-label={`${item.label} — view details`}
-              >
-                {CardInner}
-              </button>
-            ) : (
-              <div
-                key={`mcard-${item.id}`}
-                ref={(el) => {
-                  mobileCardRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-20 md:hidden"
-                style={{
-                  top: `${cardY}%`,
-                  transform: "translateY(-50%)",
-                  ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
-                  opacity: 0,
-                }}
-              >
-                {item.imageUrl ? (
-                  <div className="w-14 h-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt={item.label}
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
-                    <span className="text-[8px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-              </div>
-            );
-          })}
-
-          {/* Desktop cards — full card outside image */}
-          {itemMeta.map((meta) => {
-            const { item, i, isLeft } = meta;
-            const cardY = getCardY(meta);
-            const cardStyle = {
-              top: `${cardY}%`,
-              transform: "translateY(-50%)",
-              ...(isLeft
-                ? { right: "calc(100% + 24px)" }
-                : { left: "calc(100% + 24px)" }),
-              opacity: 0,
-            } as const;
-            const cardBody = (
-              <>
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 flex-none rounded-lg">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt=""
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
-                    <span className="text-[10px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-                <div className="min-w-0 text-left">
-                  <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
-                    {item.label}
-                  </p>
-                  {item.brand && (
-                    <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
-                      {item.brand}
-                    </p>
-                  )}
-                </div>
-              </>
-            );
-            return canNavigate ? (
-              <button
-                key={`card-${item.id}`}
-                type="button"
-                ref={(el) => {
-                  cardRefs.current[i] = el;
-                }}
-                onClick={() => onItemNavigate(item.id)}
-                className="absolute z-20 hidden w-[200px] cursor-pointer touch-manipulation items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 text-left backdrop-blur-sm md:flex"
-                style={cardStyle}
-                aria-label={`${item.label} — view details`}
-              >
-                {cardBody}
-              </button>
-            ) : (
-              <div
-                key={`card-${item.id}`}
-                ref={(el) => {
-                  cardRefs.current[i] = el;
-                }}
-                className="pointer-events-none absolute z-20 hidden w-[200px] items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 backdrop-blur-sm md:flex"
-                style={cardStyle}
-              >
-                {item.imageUrl ? (
-                  <div className="h-14 w-14 flex-none rounded-lg">
-                    <ItemImage
-                      src={item.imageUrl}
-                      alt={item.label}
-                      size="thumbnail"
-                      className="rounded-lg"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
-                    <span className="text-[10px] text-neutral-500">IMG</span>
-                  </div>
-                )}
-                <div className="min-w-0">
-                  <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
-                    {item.label}
-                  </p>
-                  {item.brand && (
-                    <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
-                      {item.brand}
-                    </p>
-                  )}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-
-        {artist?.displayName ? (
           <div
-            ref={artistRevealRef}
-            className="mx-auto mt-8 max-w-md px-2 text-center md:mt-10"
+            className="relative mx-auto overflow-visible"
+            style={{ width: "min(80vw, 360px)" }}
           >
-            <div className="flex flex-col items-center gap-2">
-              {artist.profileImageUrl ? (
-                <img
-                  src={`/api/v1/image-proxy?url=${encodeURIComponent(artist.profileImageUrl)}`}
-                  alt=""
-                  className="h-12 w-12 rounded-full border border-white/15 object-cover"
+            {/* Image */}
+            <div className="relative w-full rounded-2xl overflow-hidden bg-neutral-900">
+              {data.sourceImageUrl ? (
+                <PostImage
+                  src={data.sourceImageUrl}
+                  alt={`${data.artistName} outfit decode`}
+                  imageWidth={data.imageWidth}
+                  imageHeight={data.imageHeight}
+                  priority={true}
+                  flagKey="FeedCard"
                 />
               ) : (
-                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5 text-base font-bold text-[var(--mag-text)]/50">
-                  {artist.displayName.charAt(0).toUpperCase()}
+                <div className="flex aspect-[3/4] items-center justify-center text-neutral-600">
+                  <p className="text-sm">AI Detection Showcase</p>
                 </div>
               )}
-              <div className="text-center">
-                <Link
-                  href={`/explore?q=${encodeURIComponent(artist.displayName)}`}
-                  className="text-lg font-semibold text-[var(--mag-text)] transition-colors hover:text-[var(--mag-accent)]"
+              <div className="absolute inset-0 bg-black/10 pointer-events-none z-20" />
+            </div>
+
+            {/* Dots — optional tap target to scroll to item detail */}
+            {detectedItems.map((item, i) =>
+              canNavigate ? (
+                <button
+                  key={`dot-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    dotRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-30 flex h-11 w-11 -translate-x-1/2 -translate-y-1/2 cursor-pointer touch-manipulation items-center justify-center rounded-full border-0 bg-transparent p-0 opacity-0"
+                  style={{
+                    left: `${item.bbox.x}%`,
+                    top: `${item.bbox.y}%`,
+                  }}
+                  aria-label={`${item.label} — view details`}
                 >
-                  {artist.displayName}
-                </Link>
-                <p className="text-[11px] uppercase tracking-wider text-neutral-500">
-                  Artist
-                </p>
+                  <span
+                    className="block h-3 w-3 shrink-0 rounded-full border-2 border-[var(--mag-accent)] shadow-[0_0_10px_2px_var(--mag-accent),inset_0_0_4px_var(--mag-accent)]"
+                    aria-hidden
+                  />
+                </button>
+              ) : (
+                <div
+                  key={`dot-${item.id}`}
+                  ref={(el) => {
+                    dotRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-1/2"
+                  style={{
+                    left: `${item.bbox.x}%`,
+                    top: `${item.bbox.y}%`,
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    border: "2px solid var(--mag-accent)",
+                    boxShadow:
+                      "0 0 10px 2px var(--mag-accent), inset 0 0 4px var(--mag-accent)",
+                    opacity: 0,
+                  }}
+                />
+              )
+            )}
+
+            {/* SVG lines — desktop (long, outside image) */}
+            <svg
+              className="absolute inset-0 w-full h-full pointer-events-none z-[15] hidden md:block"
+              style={{ overflow: "visible" }}
+              aria-hidden
+            >
+              {itemMeta.map((meta) => {
+                const { item, i, isLeft } = meta;
+                const cardY = getCardY(meta);
+                return (
+                  <line
+                    key={`line-${item.id}`}
+                    ref={(el) => {
+                      lineRefs.current[i] = el;
+                    }}
+                    x1={`${item.bbox.x}%`}
+                    y1={`${item.bbox.y}%`}
+                    x2={isLeft ? "-60%" : "160%"}
+                    y2={`${cardY}%`}
+                    stroke="var(--mag-accent)"
+                    strokeWidth="1"
+                    strokeDasharray="4 3"
+                    opacity="0"
+                  />
+                );
+              })}
+            </svg>
+
+            {/* SVG lines — mobile (short, to edge of image) */}
+            <svg
+              className="absolute inset-0 w-full h-full pointer-events-none z-[15] md:hidden"
+              aria-hidden
+            >
+              {itemMeta.map((meta) => {
+                const { item, i, isLeft } = meta;
+                const cardY = getCardY(meta);
+                return (
+                  <line
+                    key={`mline-${item.id}`}
+                    ref={(el) => {
+                      mobileLineRefs.current[i] = el;
+                    }}
+                    x1={`${item.bbox.x}%`}
+                    y1={`${item.bbox.y}%`}
+                    x2={isLeft ? "8%" : "92%"}
+                    y2={`${cardY}%`}
+                    stroke="var(--mag-accent)"
+                    strokeWidth="1"
+                    strokeDasharray="3 2"
+                    opacity="0"
+                  />
+                );
+              })}
+            </svg>
+
+            {/* Mobile cards — image thumbnail only, at image edge */}
+            {itemMeta.map((meta) => {
+              const { item, i, isLeft } = meta;
+              const cardY = getCardY(meta);
+              const CardInner = (
+                <>
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt=""
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
+                      <span className="text-[8px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                </>
+              );
+              return canNavigate ? (
+                <button
+                  key={`mcard-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    mobileCardRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-20 flex opacity-0 md:hidden touch-manipulation rounded-xl border-0 bg-transparent p-0"
+                  style={{
+                    top: `${cardY}%`,
+                    transform: "translateY(-50%)",
+                    ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
+                  }}
+                  aria-label={`${item.label} — view details`}
+                >
+                  {CardInner}
+                </button>
+              ) : (
+                <div
+                  key={`mcard-${item.id}`}
+                  ref={(el) => {
+                    mobileCardRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-20 md:hidden"
+                  style={{
+                    top: `${cardY}%`,
+                    transform: "translateY(-50%)",
+                    ...(isLeft ? { left: "-4px" } : { right: "-4px" }),
+                    opacity: 0,
+                  }}
+                >
+                  {item.imageUrl ? (
+                    <div className="w-14 h-14 rounded-lg border border-[var(--mag-accent)]/40 shadow-[0_0_8px_rgba(var(--mag-accent-rgb,200,170,100),0.3)]">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt={item.label}
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 items-center justify-center rounded-lg border border-[var(--mag-accent)]/40 bg-neutral-800">
+                      <span className="text-[8px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {/* Desktop cards — full card outside image */}
+            {itemMeta.map((meta) => {
+              const { item, i, isLeft } = meta;
+              const cardY = getCardY(meta);
+              const cardStyle = {
+                top: `${cardY}%`,
+                transform: "translateY(-50%)",
+                ...(isLeft
+                  ? { right: "calc(100% + 24px)" }
+                  : { left: "calc(100% + 24px)" }),
+                opacity: 0,
+              } as const;
+              const cardBody = (
+                <>
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 flex-none rounded-lg">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt=""
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
+                      <span className="text-[10px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                  <div className="min-w-0 text-left">
+                    <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
+                      {item.label}
+                    </p>
+                    {item.brand && (
+                      <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
+                        {item.brand}
+                      </p>
+                    )}
+                  </div>
+                </>
+              );
+              return canNavigate ? (
+                <button
+                  key={`card-${item.id}`}
+                  type="button"
+                  ref={(el) => {
+                    cardRefs.current[i] = el;
+                  }}
+                  onClick={() => onItemNavigate(item.id)}
+                  className="absolute z-20 hidden w-[200px] cursor-pointer touch-manipulation items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 text-left backdrop-blur-sm md:flex"
+                  style={cardStyle}
+                  aria-label={`${item.label} — view details`}
+                >
+                  {cardBody}
+                </button>
+              ) : (
+                <div
+                  key={`card-${item.id}`}
+                  ref={(el) => {
+                    cardRefs.current[i] = el;
+                  }}
+                  className="pointer-events-none absolute z-20 hidden w-[200px] items-center gap-3 rounded-xl border border-[var(--mag-accent)]/30 bg-black/80 px-4 py-3 backdrop-blur-sm md:flex"
+                  style={cardStyle}
+                >
+                  {item.imageUrl ? (
+                    <div className="h-14 w-14 flex-none rounded-lg">
+                      <ItemImage
+                        src={item.imageUrl}
+                        alt={item.label}
+                        size="thumbnail"
+                        className="rounded-lg"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-14 w-14 flex-none items-center justify-center rounded-lg bg-neutral-800">
+                      <span className="text-[10px] text-neutral-500">IMG</span>
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <p className="truncate text-xs font-semibold leading-tight text-[var(--mag-text)]">
+                      {item.label}
+                    </p>
+                    {item.brand && (
+                      <p className="mt-0.5 truncate text-[11px] leading-tight text-[var(--mag-accent)]">
+                        {item.brand}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {artist?.displayName ? (
+            <div
+              ref={artistRevealRef}
+              className="mx-auto mt-8 max-w-md px-2 text-center md:mt-10"
+            >
+              <div className="flex flex-col items-center gap-2">
+                {artist.profileImageUrl ? (
+                  <img
+                    src={`/api/v1/image-proxy?url=${encodeURIComponent(artist.profileImageUrl)}`}
+                    alt=""
+                    className="h-12 w-12 rounded-full border border-white/15 object-cover"
+                  />
+                ) : (
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-white/5 text-base font-bold text-[var(--mag-text)]/50">
+                    {artist.displayName.charAt(0).toUpperCase()}
+                  </div>
+                )}
+                <div className="text-center">
+                  <Link
+                    href={`/explore?q=${encodeURIComponent(artist.displayName)}`}
+                    className="text-lg font-semibold text-[var(--mag-text)] transition-colors hover:text-[var(--mag-accent)]"
+                  >
+                    {artist.displayName}
+                  </Link>
+                  <p className="text-[11px] uppercase tracking-wider text-neutral-500">
+                    Artist
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        ) : null}
+          ) : null}
 
-        {aiSummary?.trim() ? (
-          <div ref={summaryRevealRef} className="mx-auto mt-6 w-full max-w-3xl px-2">
-            <AISummarySection
-              summary={aiSummary.trim()}
-              isModal={isModal}
-              surface="decode"
-            />
-          </div>
-        ) : null}
-      </div>
-
-    </section>
+          {aiSummary?.trim() ? (
+            <div
+              ref={summaryRevealRef}
+              className="mx-auto mt-6 w-full max-w-3xl px-2"
+            >
+              <AISummarySection
+                summary={aiSummary.trim()}
+                isModal={isModal}
+                surface="decode"
+              />
+            </div>
+          ) : null}
+        </div>
+      </section>
 
       {/* Scroll hint — portal to body so GSAP pin transforms don't break fixed positioning */}
       {portalTarget &&
@@ -632,10 +633,15 @@ export default function DecodeShowcase({
                 strokeWidth="1.5"
                 className="text-white/30"
               />
-              <circle cx="10" cy="9" r="2" className="fill-white/60 animate-scroll-dot" />
+              <circle
+                cx="10"
+                cy="9"
+                r="2"
+                className="fill-white/60 animate-scroll-dot"
+              />
             </svg>
           </div>,
-          portalTarget,
+          portalTarget
         )}
     </>
   );

--- a/packages/web/lib/components/main/LatestPostsScroll.tsx
+++ b/packages/web/lib/components/main/LatestPostsScroll.tsx
@@ -59,9 +59,7 @@ export function LatestPostsScroll({ posts }: LatestPostsScrollProps) {
                       : "bg-white/15 text-white/90"
                   }`}
                 >
-                  {post.createdWithSolutions
-                    ? "Sharing items"
-                    : "Curious"}
+                  {post.createdWithSolutions ? "Sharing items" : "Curious"}
                 </span>
               )}
             </div>

--- a/packages/web/lib/components/main/WhatsNewSection.tsx
+++ b/packages/web/lib/components/main/WhatsNewSection.tsx
@@ -19,8 +19,7 @@ const sampleStyles: StyleCardData[] = [
   {
     id: "wn-s2",
     title: "aespa Karina Streetwear",
-    description:
-      "aespa Karina's street style — standout color combinations.",
+    description: "aespa Karina's street style — standout color combinations.",
     artistName: "aespa Karina",
     link: "/feed",
     imageUrl: "https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800",

--- a/packages/web/lib/components/profile/ActivityTabs.tsx
+++ b/packages/web/lib/components/profile/ActivityTabs.tsx
@@ -2,7 +2,13 @@
 
 import { cn } from "@/lib/utils";
 
-export type ActivityTab = "posts" | "spots" | "solutions" | "tries" | "saved" | "likes";
+export type ActivityTab =
+  | "posts"
+  | "spots"
+  | "solutions"
+  | "tries"
+  | "saved"
+  | "likes";
 
 interface ActivityTabsProps {
   activeTab: ActivityTab;

--- a/packages/web/lib/components/profile/EmptyState.tsx
+++ b/packages/web/lib/components/profile/EmptyState.tsx
@@ -2,7 +2,14 @@
 
 import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { FileText, MapPin, Lightbulb, Bookmark, Sparkles, Heart } from "lucide-react";
+import {
+  FileText,
+  MapPin,
+  Lightbulb,
+  Bookmark,
+  Sparkles,
+  Heart,
+} from "lucide-react";
 import type { ActivityTab } from "./ActivityTabs";
 
 interface EmptyStateProps {

--- a/packages/web/lib/components/profile/LikesGrid.tsx
+++ b/packages/web/lib/components/profile/LikesGrid.tsx
@@ -170,7 +170,9 @@ export function LikesGrid({ className }: LikesGridProps) {
     return (
       <div className="py-12 text-center">
         <Heart className="h-10 w-10 mx-auto text-muted-foreground/50 mb-3" />
-        <p className="text-sm text-muted-foreground">좋아요한 포스트가 없습니다</p>
+        <p className="text-sm text-muted-foreground">
+          좋아요한 포스트가 없습니다
+        </p>
         <p className="mt-1 text-xs text-muted-foreground/60">
           마음에 드는 포스트에 좋아요를 눌러보세요
         </p>

--- a/packages/web/lib/components/request/SolutionInputForm.tsx
+++ b/packages/web/lib/components/request/SolutionInputForm.tsx
@@ -109,7 +109,9 @@ export const SolutionInputForm = memo(
 
         {/* Product name */}
         <div className="space-y-1">
-          <label className="text-xs text-muted-foreground">Product name *</label>
+          <label className="text-xs text-muted-foreground">
+            Product name *
+          </label>
           <input
             type="text"
             value={title}

--- a/packages/web/lib/components/shared/CommentSection.tsx
+++ b/packages/web/lib/components/shared/CommentSection.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  Send,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-  Trash2,
-} from "lucide-react";
+import { Send, ChevronDown, ChevronUp, Loader2, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { AccountAvatar } from "./AccountAvatar";
@@ -132,11 +126,7 @@ function CommentItem({
 function CommentListSkeleton({ rows = 3 }: { rows?: number }) {
   const widths = ["w-[92%]", "w-[78%]", "w-[85%]", "w-[70%]", "w-[88%]"];
   return (
-    <div
-      className="space-y-5 py-2"
-      role="status"
-      aria-label="Loading comments"
-    >
+    <div className="space-y-5 py-2" role="status" aria-label="Loading comments">
       <span className="sr-only">Loading comments</span>
       {Array.from({ length: rows }).map((_, i) => (
         <div key={i} className="flex gap-3">

--- a/packages/web/lib/hooks/admin/useMonitoring.ts
+++ b/packages/web/lib/hooks/admin/useMonitoring.ts
@@ -8,7 +8,9 @@
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import type { MonitoringMetrics } from "@/lib/api/admin/monitoring";
 
-async function fetchMonitoringMetrics(signal?: AbortSignal): Promise<MonitoringMetrics> {
+async function fetchMonitoringMetrics(
+  signal?: AbortSignal
+): Promise<MonitoringMetrics> {
   const res = await fetch("/api/v1/admin/monitoring/metrics", { signal });
   if (!res.ok) {
     throw new Error(`Monitoring API error: ${res.status}`);

--- a/packages/web/lib/hooks/useImages.ts
+++ b/packages/web/lib/hooks/useImages.ts
@@ -214,8 +214,7 @@ export function useInfinitePosts(params: {
     queryFn: async ({ pageParam }) => {
       const page = (pageParam as number) ?? 1;
       const tp = totalPagesRef.current;
-      const actualPage =
-        loop && tp > 0 ? ((page - 1) % tp) + 1 : page;
+      const actualPage = loop && tp > 0 ? ((page - 1) % tp) + 1 : page;
 
       const response = await listPosts({
         page: actualPage,

--- a/packages/web/lib/stores/authStore.ts
+++ b/packages/web/lib/stores/authStore.ts
@@ -159,8 +159,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // OAuth는 리다이렉트되므로 여기서 loading 상태는 유지됨
       // 실제 로그인 완료는 onAuthStateChange에서 처리
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Login failed.";
+      const message = error instanceof Error ? error.message : "Login failed.";
       set({
         error: message,
         isLoading: false,
@@ -199,8 +198,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         sessionExpired: false,
       });
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Logout failed.";
+      const message = error instanceof Error ? error.message : "Logout failed.";
       set({
         error: message,
         isLoading: false,

--- a/packages/web/orval.config.ts
+++ b/packages/web/orval.config.ts
@@ -1,4 +1,20 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "orval";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = join(packageRoot, "..", "..");
+
+function prettierWriteHook(): string {
+  const local = join(packageRoot, "node_modules", ".bin", "prettier");
+  const hoisted = join(monorepoRoot, "node_modules", ".bin", "prettier");
+
+  if (existsSync(local)) return `${local} --write`;
+  if (existsSync(hoisted)) return `${hoisted} --write`;
+
+  return "bunx prettier --write";
+}
 
 export default defineConfig({
   decodedApi: {
@@ -56,7 +72,7 @@ export default defineConfig({
       },
     },
     hooks: {
-      afterAllFilesWrite: "./node_modules/.bin/prettier --write",
+      afterAllFilesWrite: prettierWriteHook(),
     },
   },
   decodedApiZod: {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
     "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "gsap": "^3.13.0",
+    "gsap": "3.13.0",
     "lenis": "^1.3.15",
     "lucide-react": "^0.577.0",
     "motion": "^12.23.12",


### PR DESCRIPTION
## Summary
- fix the `web` pre-push blockers from `#216` by stabilizing Orval's Prettier hook, pinning the GSAP dependency path safely, and re-aligning the affected frontend files with Prettier
- restore the remaining `api-server` pre-push checks from `#219` and `#220` by fixing stale test fixtures, adding lightweight middleware/search coverage, and registering the missing OpenAPI handler
- update `cargo-deny` advisory ignores to reflect the current AWS SDK TLS chain until the upstream transport dependency can be upgraded

## Test plan
- [x] `bash scripts/git-pre-push.sh`
- [x] `bash packages/api-server/scripts/pre-push.sh`
- [x] `cargo deny check advisories`
- [x] `cargo tarpaulin --lib --exclude-files 'src/entities/*' --fail-under 65 --out Stdout -- --skip config::tests`

Closes #216
Closes #219
Closes #220

Supersedes #218.

Made with [Cursor](https://cursor.com)