### PR TITLE
feat(#151): Admin 페이지 파이프라인 mock→real 데이터 전환

### DIFF
--- a/docs/superpowers/plans/2026-04-17-151-admin-real-data-plan.md
+++ b/docs/superpowers/plans/2026-04-17-151-admin-real-data-plan.md
@@ -1,0 +1,2349 @@
+# #151 Admin 실데이터 연동 잔여 범위 — 실행 플랜
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec**: [docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md](../specs/2026-04-17-151-admin-real-data-design.md)
+**Issue**: [#151](https://github.com/decodedcorp/decoded/issues/151)
+**PR**: [#224](https://github.com/decodedcorp/decoded/pull/224)
+**Branch**: `feature/151-admin-real-data` → `dev`
+**Worktree**: `.worktrees/151-admin-real-data`
+
+**Goal:** Admin 페이지 empty state 4개 적용 + Post Magazine 승인 워크플로우(DB+RPC+API+UI) 전체 빌드 + 분리 이슈(#152 Rust audit, #153 entities/seed) 생성.
+
+**Architecture:** 기존 Next.js admin route 패턴 재사용. Magazine 승인은 `update_magazine_status` Postgres RPC로 UPDATE+audit INSERT 원자 처리. Admin mutation은 `createAdminSupabaseClient()` (service_role) 사용. UI는 `/admin/content?tab=magazines` 신규 탭.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript 5.9 strict, Supabase (public + warehouse), TanStack Query 5.90, vitest + RTL, Playwright 1.58, Tailwind 3.4.
+
+**Harness:** TDD per task (Superpowers). Wave 1은 OMC `/team` 혹은 4 병렬 subagent 가능. 머지 전 gstack `/cso`, `/review`, `/qa`.
+
+---
+
+## File Structure
+
+### 신규
+
+```
+packages/web/lib/supabase/admin-server.ts                 # service_role 클라이언트
+packages/web/lib/api/admin/magazines.ts                    # MagazineStatus + fetcher
+packages/web/lib/hooks/admin/useAdminMagazineList.ts       # GET 훅
+packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts    # PATCH 훅
+packages/web/lib/components/admin/magazines/
+  index.ts
+  MagazineApprovalTable.tsx
+  MagazineStatusFilter.tsx
+  RejectModal.tsx
+  MagazineActions.tsx
+packages/web/app/api/v1/admin/posts/magazines/route.ts
+packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
+
+supabase/migrations/20260417120000_magazine_approval_fields.sql
+supabase/migrations/20260417120001_update_magazine_status_rpc.sql
+
+packages/web/tests/admin/magazine-approval.spec.ts         # Playwright E2E
+```
+
+### 수정
+
+```
+packages/web/app/admin/audit-log/page.tsx
+packages/web/app/admin/content/page.tsx                    # ContentTab 확장
+packages/web/app/admin/editorial-candidates/page.tsx
+packages/web/app/admin/monitoring/page.tsx
+packages/web/lib/supabase/types.ts                         # supabase:types 재생성
+```
+
+---
+
+## Wave 0.5 — 선행 조사 및 셋업
+
+### Task 1: RLS/is_admin 함수 존재 확인
+
+**Files:**
+
+- Inspect: `supabase/migrations/*.sql`, `packages/web/lib/api/admin/` 전체
+
+- [ ] **Step 1: is_admin 함수 존재 확인**
+
+```bash
+grep -rn "CREATE OR REPLACE FUNCTION.*is_admin\|CREATE FUNCTION.*is_admin" supabase/migrations/
+```
+
+Expected: 기존 함수 정의 1건 이상 발견. 없으면 migration 파일에 함수 정의 포함 필요 (Task 8에서 처리).
+
+- [ ] **Step 2: post_magazines RLS 정책 확인**
+
+```bash
+grep -n "post_magazines" supabase/migrations/20260409075040_remote_schema.sql | head -40
+```
+
+Expected: `ENABLE ROW LEVEL SECURITY` + `"Allow public read" FOR SELECT` 정책만. UPDATE/INSERT/DELETE 정책 없음 확인.
+
+- [ ] **Step 3: checkIsAdmin 미들웨어 위치 확인**
+
+```bash
+grep -rn "checkIsAdmin\|export.*isAdmin" packages/web/lib/api packages/web/middleware 2>/dev/null
+```
+
+Expected: 기존 유틸 위치 특정 (magazine route에서 재사용).
+
+- [ ] **Step 4: 결과를 스펙 §6 (조사 결과 기록)에 업데이트**
+
+```bash
+code docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+# §6 placeholder 3개 채움
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+git commit -m "docs(#151): wave 0.5 선행 조사 결과 스펙 반영"
+```
+
+---
+
+### Task 2: `createAdminSupabaseClient()` 유틸 생성
+
+**Files:**
+
+- Create: `packages/web/lib/supabase/admin-server.ts`
+- Test: `packages/web/lib/supabase/__tests__/admin-server.test.ts`
+
+**배경**: 기존 `createSupabaseServerClient()`는 anon key + 쿠키. Magazine UPDATE는 RLS 통과 위해 service_role 필요.
+
+- [ ] **Step 1: 실패하는 테스트 작성**
+
+```typescript
+// packages/web/lib/supabase/__tests__/admin-server.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createAdminSupabaseClient } from "../admin-server";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({ mocked: true })),
+}));
+
+describe("createAdminSupabaseClient", () => {
+  it("throws when SUPABASE_SERVICE_ROLE_KEY is missing", () => {
+    const orig = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(() => createAdminSupabaseClient()).toThrow(
+      "SUPABASE_SERVICE_ROLE_KEY",
+    );
+    process.env.SUPABASE_SERVICE_ROLE_KEY = orig;
+  });
+
+  it("returns a client with service_role key when env set", () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    const client = createAdminSupabaseClient();
+    expect(client).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+```bash
+cd packages/web && bun test lib/supabase/__tests__/admin-server.test.ts
+```
+
+Expected: FAIL (파일 없음).
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/lib/supabase/admin-server.ts
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+import { getEnv } from "./env";
+
+const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL");
+
+/**
+ * Server-only Supabase client with service_role key.
+ * Bypasses RLS. Use ONLY in admin-authenticated route handlers
+ * after `checkIsAdmin()` has verified the caller.
+ */
+export function createAdminSupabaseClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is not set. Admin mutations require service_role.",
+    );
+  }
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 재실행 → 통과**
+
+```bash
+cd packages/web && bun test lib/supabase/__tests__/admin-server.test.ts
+```
+
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/supabase/admin-server.ts \
+        packages/web/lib/supabase/__tests__/admin-server.test.ts
+git commit -m "feat(admin): add createAdminSupabaseClient for service_role mutations"
+```
+
+---
+
+## Wave 1 — Empty state 4개 페이지 (병렬 가능)
+
+> **병렬 힌트**: Task 3~6은 독립적. OMC `/team` 혹은 4 subagent로 동시 실행 가능. 본문은 순차 기술이지만 실행은 병렬로.
+
+### Task 3: `audit-log` 페이지 empty state
+
+**Files:**
+
+- Modify: `packages/web/app/admin/audit-log/page.tsx`
+- Test: `packages/web/app/admin/audit-log/__tests__/page.test.tsx`
+
+- [ ] **Step 1: 실패 테스트**
+
+```typescript
+// packages/web/app/admin/audit-log/__tests__/page.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AuditLogPage from "../page";
+
+vi.mock("@/lib/hooks/admin/useAuditLog", () => ({
+  useAuditLogList: () => ({
+    data: { data: [], total: 0 },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("audit-log page", () => {
+  it("renders AdminEmptyState when no filters and no results", () => {
+    renderWithClient(<AuditLogPage />);
+    expect(screen.getByText(/no audit log entries yet|감사 로그 없음/i))
+      .toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 테스트 실행 → 실패 확인**
+
+```bash
+cd packages/web && bun test app/admin/audit-log/__tests__/page.test.tsx
+```
+
+- [ ] **Step 3: 페이지 수정**
+
+`page.tsx`의 렌더 파트에 `AdminEmptyState` 분기 추가 (ai-audit 패턴 참조: `app/admin/ai-audit/page.tsx:71`).
+
+```tsx
+import { AdminEmptyState } from "@/lib/components/admin/common";
+import { ClipboardListIcon } from "lucide-react"; // 또는 기존 아이콘
+
+// ... 기존 코드 ...
+
+const isEmpty =
+  !listQuery.isLoading &&
+  (listQuery.data?.data?.length ?? 0) === 0 &&
+  !currentAction &&
+  !currentTable;
+
+// render 영역
+{isEmpty ? (
+  <AdminEmptyState
+    icon={<ClipboardListIcon className="w-12 h-12" />}
+    title="No audit log entries yet"
+    description="Administrator actions will appear here as they happen."
+  />
+) : (
+  <AuditTable ... />
+)}
+```
+
+- [ ] **Step 4: 테스트 재실행 → 통과**
+
+```bash
+cd packages/web && bun test app/admin/audit-log/__tests__/page.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/admin/audit-log/
+git commit -m "feat(admin): add empty state to audit-log page"
+```
+
+---
+
+### Task 4: `content` 페이지 empty state (posts/reports 각 탭)
+
+**Files:**
+
+- Modify: `packages/web/app/admin/content/page.tsx`
+- Test: `packages/web/app/admin/content/__tests__/page.test.tsx`
+
+- [ ] **Step 1: 실패 테스트 (posts 탭 빈 상태)**
+
+```typescript
+// packages/web/app/admin/content/__tests__/page.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ContentPage from "../page";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("tab=posts"),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock("@/lib/hooks/admin/useAdminPosts", () => ({
+  useAdminPostList: () => ({ data: { data: [] }, isLoading: false }),
+}));
+vi.mock("@/lib/hooks/admin/useAdminReports", () => ({
+  useAdminReports: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe("content page", () => {
+  it("shows empty state on posts tab when no data", () => {
+    renderWithClient(<ContentPage />);
+    expect(screen.getByText(/no posts found|게시물 없음/i))
+      .toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+```bash
+cd packages/web && bun test app/admin/content/__tests__/page.test.tsx
+```
+
+- [ ] **Step 3: 구현 — 탭별 분기**
+
+탭 렌더 함수 내부에서 data.length===0 일 때 `AdminEmptyState` 렌더. Posts/Reports 탭 각각.
+
+```tsx
+{posts.length === 0 ? (
+  <AdminEmptyState
+    icon={<FileTextIcon className="w-12 h-12" />}
+    title="No posts found"
+    description="Posts submitted by users will appear here."
+  />
+) : (
+  <PostsTable items={posts} ... />
+)}
+
+{reports.length === 0 ? (
+  <AdminEmptyState
+    icon={<FlagIcon className="w-12 h-12" />}
+    title="No reports to review"
+    description="User-submitted reports will appear here for moderation."
+  />
+) : (
+  <ReportsTable items={reports} ... />
+)}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/admin/content/
+git commit -m "feat(admin): add empty states to content page posts/reports tabs"
+```
+
+---
+
+### Task 5: `editorial-candidates` 페이지 empty state
+
+**Files:**
+
+- Modify: `packages/web/app/admin/editorial-candidates/page.tsx`
+- Test: `packages/web/app/admin/editorial-candidates/__tests__/page.test.tsx`
+
+- [ ] **Step 1: 테스트**
+
+```typescript
+vi.mock("@/lib/hooks/admin/useEditorialCandidates", () => ({
+  useEditorialCandidates: () => ({ data: { data: [] }, isLoading: false }),
+}));
+
+it("shows empty state when no candidates", () => {
+  renderWithClient(<EditorialCandidatesPage />);
+  expect(
+    screen.getByText(/no editorial candidates|에디토리얼 후보 없음/i),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```tsx
+{candidates.length === 0 && !isLoading ? (
+  <AdminEmptyState
+    icon={<SparklesIcon className="w-12 h-12" />}
+    title="No editorial candidates"
+    description="Candidate posts awaiting editorial promotion will appear here."
+  />
+) : (
+  // 기존 후보 목록
+)}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/admin/editorial-candidates/
+git commit -m "feat(admin): add empty state to editorial-candidates page"
+```
+
+---
+
+### Task 6: `monitoring` 페이지 empty state
+
+**Files:**
+
+- Modify: `packages/web/app/admin/monitoring/page.tsx`
+- Test: `packages/web/app/admin/monitoring/__tests__/page.test.tsx`
+
+**주의**: monitoring은 KPI + 차트 섹션 별로 다루기. 데이터 없을 때 섹션별 명시 메시지 (skeleton이 아닌 명시적 empty).
+
+- [ ] **Step 1: 테스트**
+
+```typescript
+vi.mock("@/lib/hooks/admin/useMonitoring", () => ({
+  useMonitoringMetrics: () => ({
+    data: { metrics: [], uptime: null, errorRate: null },
+    isLoading: false,
+  }),
+}));
+
+it("shows empty state when no metrics available", () => {
+  renderWithClient(<MonitoringPage />);
+  expect(
+    screen.getByText(/no monitoring data|모니터링 데이터 없음/i),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현 — KPI/차트 섹션별 empty**
+
+```tsx
+{
+  !metrics || metrics.length === 0 ? (
+    <AdminEmptyState
+      icon={<ActivityIcon className="w-12 h-12" />}
+      title="No monitoring data yet"
+      description="Once the backend starts reporting metrics, dashboards will appear here."
+    />
+  ) : (
+    <>
+      <KPIRow data={metrics} />
+      <LatencyChart data={metrics} />
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/admin/monitoring/
+git commit -m "feat(admin): add empty state to monitoring page"
+```
+
+---
+
+## Wave 2a — DB Migration + RPC
+
+### Task 7: Magazine 승인 필드 마이그레이션
+
+**Files:**
+
+- Create: `supabase/migrations/20260417120000_magazine_approval_fields.sql`
+
+- [ ] **Step 1: Migration 파일 작성**
+
+```sql
+-- 20260417120000_magazine_approval_fields.sql
+-- #151 Post Magazine 승인 워크플로우: 필드 추가 + CHECK 제약 + RLS UPDATE 정책
+
+-- 1) 승인 메타데이터 컬럼
+ALTER TABLE public.post_magazines
+  ADD COLUMN IF NOT EXISTS approved_by UUID REFERENCES auth.users(id),
+  ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+
+-- 2) 기존 NULL 레코드 안전하게 'draft'로 백필
+UPDATE public.post_magazines SET status = 'draft' WHERE status IS NULL;
+
+-- 3) status CHECK 제약
+ALTER TABLE public.post_magazines
+  DROP CONSTRAINT IF EXISTS post_magazines_status_check;
+ALTER TABLE public.post_magazines
+  ADD CONSTRAINT post_magazines_status_check
+  CHECK (status IN ('draft', 'pending', 'published', 'rejected'));
+
+-- 4) 관리자 UPDATE RLS 정책
+-- 전제: public.is_admin(uuid) 함수가 존재해야 함. 없으면 Task 8에서 함수 정의 추가.
+DROP POLICY IF EXISTS "admin_can_update_magazines" ON public.post_magazines;
+CREATE POLICY "admin_can_update_magazines"
+  ON public.post_magazines
+  FOR UPDATE
+  USING (public.is_admin(auth.uid()))
+  WITH CHECK (public.is_admin(auth.uid()));
+
+-- 5) 인덱스: status 필터링
+CREATE INDEX IF NOT EXISTS post_magazines_status_idx
+  ON public.post_magazines(status)
+  WHERE status IN ('pending', 'draft');
+```
+
+- [ ] **Step 2: is_admin 함수 존재 확인 (Task 1 결과 재확인)**
+
+만약 함수가 없으면, 이 migration 시작부에 다음 추가:
+
+```sql
+-- 함수가 없을 때만 생성 (전제: auth.users에 role 또는 admins 테이블 존재 확인 후 수정)
+CREATE OR REPLACE FUNCTION public.is_admin(user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.admins WHERE user_id = is_admin.user_id
+  );
+$$;
+```
+
+- [ ] **Step 3: 로컬 Supabase 적용**
+
+```bash
+bunx supabase migration up --local
+```
+
+Expected: 성공. 에러 시 `is_admin` 함수 누락 등 확인 후 Step 2 수정.
+
+- [ ] **Step 4: 수동 검증**
+
+```bash
+bunx supabase db query "
+  SELECT column_name, data_type
+  FROM information_schema.columns
+  WHERE table_name='post_magazines' AND column_name IN ('approved_by','rejection_reason');
+"
+```
+
+Expected: 2행 반환.
+
+```bash
+bunx supabase db query "
+  INSERT INTO public.post_magazines (title, status) VALUES ('x','invalid');
+"
+```
+
+Expected: CHECK 제약 위반 에러.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260417120000_magazine_approval_fields.sql
+git commit -m "feat(db): add magazine approval fields + CHECK + admin RLS policy"
+```
+
+---
+
+### Task 8: `update_magazine_status` RPC
+
+**Files:**
+
+- Create: `supabase/migrations/20260417120001_update_magazine_status_rpc.sql`
+
+- [ ] **Step 1: RPC migration 작성**
+
+```sql
+-- 20260417120001_update_magazine_status_rpc.sql
+-- #151 UPDATE post_magazines + INSERT admin_audit_log 원자 처리
+
+CREATE OR REPLACE FUNCTION public.update_magazine_status(
+  p_magazine_id UUID,
+  p_new_status VARCHAR,
+  p_admin_user_id UUID,
+  p_rejection_reason TEXT DEFAULT NULL
+) RETURNS SETOF public.post_magazines
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, warehouse, pg_temp
+AS $$
+DECLARE
+  v_before public.post_magazines;
+  v_after public.post_magazines;
+  v_action TEXT;
+BEGIN
+  SELECT * INTO v_before FROM public.post_magazines
+    WHERE id = p_magazine_id FOR UPDATE;
+
+  IF v_before IS NULL THEN
+    RAISE EXCEPTION 'magazine_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 전이 유효성
+  IF NOT (
+    (v_before.status = 'draft'     AND p_new_status = 'pending')   OR
+    (v_before.status = 'pending'   AND p_new_status = 'published') OR
+    (v_before.status = 'pending'   AND p_new_status = 'rejected')  OR
+    (v_before.status = 'rejected'  AND p_new_status = 'pending')   OR
+    (v_before.status = 'published' AND p_new_status = 'draft')
+  ) THEN
+    RAISE EXCEPTION 'invalid_transition: % -> %', v_before.status, p_new_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_new_status = 'rejected' AND (p_rejection_reason IS NULL OR length(trim(p_rejection_reason)) = 0) THEN
+    RAISE EXCEPTION 'rejection_reason_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.post_magazines
+  SET status = p_new_status,
+      approved_by = CASE WHEN p_new_status = 'published' THEN p_admin_user_id ELSE approved_by END,
+      published_at = CASE WHEN p_new_status = 'published' THEN now() ELSE published_at END,
+      rejection_reason = CASE WHEN p_new_status = 'rejected' THEN p_rejection_reason ELSE NULL END,
+      updated_at = now()
+  WHERE id = p_magazine_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE p_new_status
+    WHEN 'published' THEN 'magazine_approve'
+    WHEN 'rejected'  THEN 'magazine_reject'
+    WHEN 'pending'   THEN 'magazine_submit'
+    WHEN 'draft'     THEN 'magazine_unpublish'
+    ELSE 'magazine_status_change'
+  END;
+
+  INSERT INTO warehouse.admin_audit_log (
+    admin_user_id, action, target_table, target_id,
+    before_state, after_state, metadata
+  ) VALUES (
+    p_admin_user_id, v_action, 'post_magazines', p_magazine_id,
+    row_to_json(v_before)::jsonb,
+    row_to_json(v_after)::jsonb,
+    jsonb_build_object('rejection_reason', p_rejection_reason)
+  );
+
+  RETURN QUERY SELECT * FROM public.post_magazines WHERE id = p_magazine_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) TO authenticated, service_role;
+```
+
+- [ ] **Step 2: Migration 적용**
+
+```bash
+bunx supabase migration up --local
+```
+
+- [ ] **Step 3: 수동 RPC 호출 검증**
+
+```sql
+-- 1. draft → pending
+SELECT * FROM public.update_magazine_status(
+  '<magazine_id>', 'pending', '<admin_user_id>', NULL
+);
+-- 2. pending → published
+SELECT * FROM public.update_magazine_status(
+  '<magazine_id>', 'published', '<admin_user_id>', NULL
+);
+-- 3. invalid transition (draft → published)
+-- expected: exception 'invalid_transition: draft -> published'
+-- 4. reject without reason → exception 'rejection_reason_required'
+-- 5. warehouse.admin_audit_log 3 rows 확인 (submit, approve)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260417120001_update_magazine_status_rpc.sql
+git commit -m "feat(db): add update_magazine_status RPC with atomic audit logging"
+```
+
+---
+
+### Task 9: Supabase 타입 재생성
+
+**Files:**
+
+- Modify: `packages/web/lib/supabase/types.ts` (regenerated)
+
+- [ ] **Step 1: types.ts 재생성**
+
+```bash
+cd packages/web && bun run supabase:types
+```
+
+Expected: `post_magazines` Row 타입에 `approved_by`, `rejection_reason` 추가됨. `Functions.update_magazine_status` 시그니처 생성.
+
+- [ ] **Step 2: 타입 확인**
+
+```bash
+grep -A 3 "approved_by" packages/web/lib/supabase/types.ts | head -10
+grep -A 5 "update_magazine_status" packages/web/lib/supabase/types.ts | head -12
+```
+
+- [ ] **Step 3: 타입 체크**
+
+```bash
+cd packages/web && bun run type-check
+```
+
+Expected: 에러 없음.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/lib/supabase/types.ts
+git commit -m "chore(db): regenerate Supabase types for magazine approval fields"
+```
+
+---
+
+## Wave 2b — Admin Magazine API
+
+### Task 10: `MagazineStatus` 타입 + fetcher 모듈
+
+**Files:**
+
+- Create: `packages/web/lib/api/admin/magazines.ts`
+- Test: `packages/web/lib/api/admin/__tests__/magazines.test.ts`
+
+- [ ] **Step 1: 실패 테스트**
+
+```typescript
+// packages/web/lib/api/admin/__tests__/magazines.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  MAGAZINE_STATUSES,
+  isValidMagazineStatus,
+  type MagazineStatus,
+} from "../magazines";
+
+describe("MagazineStatus", () => {
+  it("exports all 4 statuses", () => {
+    expect(MAGAZINE_STATUSES).toEqual([
+      "draft",
+      "pending",
+      "published",
+      "rejected",
+    ]);
+  });
+
+  it("isValidMagazineStatus returns true for valid", () => {
+    expect(isValidMagazineStatus("pending")).toBe(true);
+    expect(isValidMagazineStatus("published")).toBe(true);
+  });
+
+  it("isValidMagazineStatus returns false for invalid", () => {
+    expect(isValidMagazineStatus("foo")).toBe(false);
+    expect(isValidMagazineStatus("")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+```bash
+cd packages/web && bun test lib/api/admin/__tests__/magazines.test.ts
+```
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/lib/api/admin/magazines.ts
+export const MAGAZINE_STATUSES = [
+  "draft",
+  "pending",
+  "published",
+  "rejected",
+] as const;
+
+export type MagazineStatus = (typeof MAGAZINE_STATUSES)[number];
+
+export function isValidMagazineStatus(s: string): s is MagazineStatus {
+  return (MAGAZINE_STATUSES as readonly string[]).includes(s);
+}
+
+export interface AdminMagazineListItem {
+  id: string;
+  title: string | null;
+  status: MagazineStatus;
+  author_id: string | null;
+  submitted_at: string | null;
+  published_at: string | null;
+  rejection_reason: string | null;
+  approved_by: string | null;
+}
+
+export interface AdminMagazineListResponse {
+  data: AdminMagazineListItem[];
+  total: number;
+  page: number;
+  limit: number;
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/api/admin/magazines.ts \
+        packages/web/lib/api/admin/__tests__/magazines.test.ts
+git commit -m "feat(admin): add MagazineStatus types and list response shape"
+```
+
+---
+
+### Task 11: `GET /api/v1/admin/posts/magazines` 라우트
+
+**Files:**
+
+- Create: `packages/web/app/api/v1/admin/posts/magazines/route.ts`
+- Test: `packages/web/app/api/v1/admin/posts/magazines/__tests__/route.test.ts`
+
+- [ ] **Step 1: 실패 테스트**
+
+```typescript
+// packages/web/app/api/v1/admin/posts/magazines/__tests__/route.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { GET } from "../route";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: async () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          order: () => ({
+            range: async () => ({ data: [], count: 0, error: null }),
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+vi.mock("@/lib/api/admin/auth", () => ({
+  checkIsAdmin: async () => ({ isAdmin: true, userId: "admin-1" }),
+}));
+
+function makeRequest(url: string) {
+  return new Request(url);
+}
+
+describe("GET /api/v1/admin/posts/magazines", () => {
+  it("returns 403 when not admin", async () => {
+    vi.doMock("@/lib/api/admin/auth", () => ({
+      checkIsAdmin: async () => ({ isAdmin: false }),
+    }));
+    const res = await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns list with pending filter", async () => {
+    const res = await GET(
+      makeRequest(
+        "http://localhost/api/v1/admin/posts/magazines?status=pending",
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("data");
+    expect(body).toHaveProperty("total");
+  });
+
+  it("rejects invalid status", async () => {
+    const res = await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines?status=foo"),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/app/api/v1/admin/posts/magazines/route.ts
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/api/admin/auth";
+import {
+  isValidMagazineStatus,
+  type AdminMagazineListResponse,
+} from "@/lib/api/admin/magazines";
+
+export async function GET(req: Request) {
+  const auth = await checkIsAdmin();
+  if (!auth.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const status = url.searchParams.get("status");
+  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(url.searchParams.get("limit") ?? "20", 10)),
+  );
+
+  if (status && !isValidMagazineStatus(status)) {
+    return NextResponse.json(
+      {
+        error: "invalid_status",
+        validStatuses: ["draft", "pending", "published", "rejected"],
+      },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  let query = supabase
+    .from("post_magazines")
+    .select(
+      "id,title,status,author_id,submitted_at,published_at,rejection_reason,approved_by",
+      { count: "exact" },
+    )
+    .order("submitted_at", { ascending: false, nullsFirst: false });
+
+  if (status) query = query.eq("status", status);
+
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+  const { data, count, error } = await query.range(from, to);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const response: AdminMagazineListResponse = {
+    data: (data ?? []) as AdminMagazineListResponse["data"],
+    total: count ?? 0,
+    page,
+    limit,
+  };
+  return NextResponse.json(response);
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/api/v1/admin/posts/magazines/route.ts \
+        packages/web/app/api/v1/admin/posts/magazines/__tests__
+git commit -m "feat(admin): add GET /api/v1/admin/posts/magazines route"
+```
+
+---
+
+### Task 12: `PATCH /api/v1/admin/posts/magazines/[id]/status` 라우트
+
+**Files:**
+
+- Create: `packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts`
+- Test: `packages/web/app/api/v1/admin/posts/magazines/[id]/status/__tests__/route.test.ts`
+
+- [ ] **Step 1: 실패 테스트 (approve happy path + invalid transition + 403 + reject reason 필수)**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PATCH } from "../route";
+
+const rpc = vi.fn();
+vi.mock("@/lib/supabase/admin-server", () => ({
+  createAdminSupabaseClient: () => ({ rpc }),
+}));
+vi.mock("@/lib/api/admin/auth", () => ({
+  checkIsAdmin: async () => ({ isAdmin: true, userId: "admin-1" }),
+}));
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/x", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH magazines/[id]/status", () => {
+  beforeEach(() => rpc.mockReset());
+
+  it("approves (pending→published)", async () => {
+    rpc.mockResolvedValue({
+      data: [{ id: "m1", status: "published" }],
+      error: null,
+    });
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("update_magazine_status", {
+      p_magazine_id: "m1",
+      p_new_status: "published",
+      p_admin_user_id: "admin-1",
+      p_rejection_reason: null,
+    });
+  });
+
+  it("rejects invalid transition with 409", async () => {
+    rpc.mockResolvedValue({
+      data: null,
+      error: {
+        message: "invalid_transition: draft -> published",
+        code: "P0001",
+      },
+    });
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 404 on magazine_not_found", async () => {
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "magazine_not_found", code: "P0002" },
+    });
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects empty rejection reason with 400", async () => {
+    const res = await PATCH(
+      makeRequest({ status: "rejected", rejectionReason: "" }),
+      { params: Promise.resolve({ id: "m1" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
+import { NextResponse } from "next/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin-server";
+import { checkIsAdmin } from "@/lib/api/admin/auth";
+import { isValidMagazineStatus } from "@/lib/api/admin/magazines";
+
+interface PatchBody {
+  status: string;
+  rejectionReason?: string;
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await checkIsAdmin();
+  if (!auth.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  let body: PatchBody;
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!isValidMagazineStatus(body.status)) {
+    return NextResponse.json({ error: "invalid_status" }, { status: 400 });
+  }
+  if (body.status === "rejected") {
+    const reason = body.rejectionReason?.trim();
+    if (!reason) {
+      return NextResponse.json(
+        { error: "rejection_reason_required" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const supabase = createAdminSupabaseClient();
+  const { data, error } = await supabase.rpc("update_magazine_status", {
+    p_magazine_id: id,
+    p_new_status: body.status,
+    p_admin_user_id: auth.userId,
+    p_rejection_reason: body.rejectionReason ?? null,
+  });
+
+  if (error) {
+    if (error.message?.includes("magazine_not_found")) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    if (error.message?.includes("invalid_transition")) {
+      return NextResponse.json(
+        { error: "invalid_transition", message: error.message },
+        { status: 409 },
+      );
+    }
+    if (error.message?.includes("rejection_reason_required")) {
+      return NextResponse.json(
+        { error: "rejection_reason_required" },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data }, { status: 200 });
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/app/api/v1/admin/posts/magazines/[id]/
+git commit -m "feat(admin): add PATCH magazines/:id/status via RPC"
+```
+
+---
+
+## Wave 2c — Hooks + UI
+
+### Task 13: `useAdminMagazineList` 훅
+
+**Files:**
+
+- Create: `packages/web/lib/hooks/admin/useAdminMagazineList.ts`
+- Test: `packages/web/lib/hooks/admin/__tests__/useAdminMagazineList.test.ts`
+
+- [ ] **Step 1: 실패 테스트**
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAdminMagazineList } from "../useAdminMagazineList";
+
+global.fetch = vi.fn();
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useAdminMagazineList", () => {
+  it("fetches magazines with status filter", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], total: 0, page: 1, limit: 20 }),
+    });
+    const { result } = renderHook(
+      () => useAdminMagazineList({ status: "pending", page: 1, limit: 20 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("status=pending&page=1&limit=20"),
+      expect.anything(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/lib/hooks/admin/useAdminMagazineList.ts
+import { useQuery } from "@tanstack/react-query";
+import type {
+  AdminMagazineListResponse,
+  MagazineStatus,
+} from "@/lib/api/admin/magazines";
+
+interface Params {
+  status?: MagazineStatus;
+  page?: number;
+  limit?: number;
+}
+
+export function useAdminMagazineList(params: Params = {}) {
+  const { status, page = 1, limit = 20 } = params;
+  const qs = new URLSearchParams();
+  if (status) qs.set("status", status);
+  qs.set("page", String(page));
+  qs.set("limit", String(limit));
+
+  return useQuery<AdminMagazineListResponse>({
+    queryKey: ["admin", "magazines", { status, page, limit }],
+    queryFn: async () => {
+      const res = await fetch(`/api/v1/admin/posts/magazines?${qs}`, {
+        credentials: "include",
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/hooks/admin/useAdminMagazineList.ts \
+        packages/web/lib/hooks/admin/__tests__
+git commit -m "feat(admin): add useAdminMagazineList hook"
+```
+
+---
+
+### Task 14: `useUpdateMagazineStatus` 훅
+
+**Files:**
+
+- Create: `packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts`
+- Test: `packages/web/lib/hooks/admin/__tests__/useUpdateMagazineStatus.test.ts`
+
+- [ ] **Step 1: 실패 테스트 (approve + invalidateQueries)**
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUpdateMagazineStatus } from "../useUpdateMagazineStatus";
+
+global.fetch = vi.fn();
+const invalidateSpy = vi.fn();
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  client.invalidateQueries = invalidateSpy as never;
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useUpdateMagazineStatus", () => {
+  it("calls PATCH and invalidates list", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "m1", status: "published" }] }),
+    });
+    const { result } = renderHook(() => useUpdateMagazineStatus(), { wrapper });
+    result.current.mutate({ id: "m1", status: "published" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["admin", "magazines"] }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```typescript
+// packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { MagazineStatus } from "@/lib/api/admin/magazines";
+
+interface MutationInput {
+  id: string;
+  status: MagazineStatus;
+  rejectionReason?: string;
+}
+
+export function useUpdateMagazineStatus() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: MutationInput) => {
+      const res = await fetch(
+        `/api/v1/admin/posts/magazines/${input.id}/status`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({
+            status: input.status,
+            rejectionReason: input.rejectionReason,
+          }),
+        },
+      );
+      if (!res.ok) {
+        const errBody = await res.json().catch(() => ({}));
+        throw new Error(errBody.error ?? `HTTP ${res.status}`);
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "magazines"] });
+    },
+  });
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts \
+        packages/web/lib/hooks/admin/__tests__/useUpdateMagazineStatus.test.ts
+git commit -m "feat(admin): add useUpdateMagazineStatus mutation hook"
+```
+
+---
+
+### Task 15: `MagazineStatusFilter` 컴포넌트
+
+**Files:**
+
+- Create: `packages/web/lib/components/admin/magazines/MagazineStatusFilter.tsx`
+- Test: `packages/web/lib/components/admin/magazines/__tests__/MagazineStatusFilter.test.tsx`
+
+- [ ] **Step 1: 실패 테스트**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MagazineStatusFilter } from "../MagazineStatusFilter";
+
+describe("MagazineStatusFilter", () => {
+  it("renders all 5 options (All + 4 statuses)", () => {
+    render(<MagazineStatusFilter value={undefined} onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: /all/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /pending/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /published/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with selected status", () => {
+    const onChange = vi.fn();
+    render(<MagazineStatusFilter value={undefined} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /pending/i }));
+    expect(onChange).toHaveBeenCalledWith("pending");
+  });
+
+  it("calls onChange with undefined when All clicked", () => {
+    const onChange = vi.fn();
+    render(<MagazineStatusFilter value="pending" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /all/i }));
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// packages/web/lib/components/admin/magazines/MagazineStatusFilter.tsx
+"use client";
+import {
+  MAGAZINE_STATUSES,
+  type MagazineStatus,
+} from "@/lib/api/admin/magazines";
+
+interface Props {
+  value: MagazineStatus | undefined;
+  onChange: (next: MagazineStatus | undefined) => void;
+}
+
+export function MagazineStatusFilter({ value, onChange }: Props) {
+  return (
+    <div
+      className="flex gap-2"
+      role="group"
+      aria-label="Magazine status filter"
+    >
+      <button
+        type="button"
+        onClick={() => onChange(undefined)}
+        className={`px-3 py-1.5 rounded text-sm ${
+          value === undefined
+            ? "bg-blue-600 text-white"
+            : "bg-gray-100 text-gray-700"
+        }`}
+      >
+        All
+      </button>
+      {MAGAZINE_STATUSES.map((s) => (
+        <button
+          key={s}
+          type="button"
+          onClick={() => onChange(s)}
+          className={`px-3 py-1.5 rounded text-sm capitalize ${
+            value === s ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-700"
+          }`}
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/components/admin/magazines/MagazineStatusFilter.tsx \
+        packages/web/lib/components/admin/magazines/__tests__/MagazineStatusFilter.test.tsx
+git commit -m "feat(admin): add MagazineStatusFilter component"
+```
+
+---
+
+### Task 16: `RejectModal` 컴포넌트 (사유 필수)
+
+**Files:**
+
+- Create: `packages/web/lib/components/admin/magazines/RejectModal.tsx`
+- Test: `packages/web/lib/components/admin/magazines/__tests__/RejectModal.test.tsx`
+
+- [ ] **Step 1: 실패 테스트**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RejectModal } from "../RejectModal";
+
+describe("RejectModal", () => {
+  it("disables submit button when reason is empty", () => {
+    render(<RejectModal open onClose={() => {}} onSubmit={() => {}} />);
+    const submit = screen.getByRole("button", { name: /reject|거부/i });
+    expect(submit).toBeDisabled();
+  });
+
+  it("enables submit after typing non-empty reason", () => {
+    render(<RejectModal open onClose={() => {}} onSubmit={() => {}} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "off-topic" } });
+    expect(
+      screen.getByRole("button", { name: /reject|거부/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("calls onSubmit with trimmed reason", () => {
+    const onSubmit = vi.fn();
+    render(<RejectModal open onClose={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "  off-topic  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /reject|거부/i }));
+    expect(onSubmit).toHaveBeenCalledWith("off-topic");
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// packages/web/lib/components/admin/magazines/RejectModal.tsx
+"use client";
+import { useState } from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => void;
+  submitting?: boolean;
+}
+
+export function RejectModal({ open, onClose, onSubmit, submitting }: Props) {
+  const [reason, setReason] = useState("");
+  if (!open) return null;
+  const trimmed = reason.trim();
+  const canSubmit = trimmed.length > 0 && !submitting;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-lg p-6 w-full max-w-md">
+        <h2 className="text-lg font-semibold mb-4">Reject Magazine</h2>
+        <label className="block text-sm font-medium mb-2">
+          Reason (required)
+        </label>
+        <textarea
+          className="w-full rounded border border-gray-300 dark:border-gray-700 p-2 min-h-[100px]"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Explain why this magazine is rejected"
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm bg-gray-100 rounded"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => canSubmit && onSubmit(trimmed)}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-sm bg-red-600 text-white rounded disabled:opacity-50"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/components/admin/magazines/RejectModal.tsx \
+        packages/web/lib/components/admin/magazines/__tests__/RejectModal.test.tsx
+git commit -m "feat(admin): add RejectModal with required reason"
+```
+
+---
+
+### Task 17: `MagazineActions` 컴포넌트
+
+**Files:**
+
+- Create: `packages/web/lib/components/admin/magazines/MagazineActions.tsx`
+- Test: `packages/web/lib/components/admin/magazines/__tests__/MagazineActions.test.tsx`
+
+- [ ] **Step 1: 실패 테스트**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MagazineActions } from "../MagazineActions";
+
+describe("MagazineActions", () => {
+  it("shows Approve/Reject for pending status", () => {
+    render(
+      <MagazineActions
+        status="pending"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /approve/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeInTheDocument();
+  });
+
+  it("shows Revert only for published", () => {
+    render(
+      <MagazineActions
+        status="published"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /revert|unpublish/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onApprove when Approve clicked", () => {
+    const onApprove = vi.fn();
+    render(
+      <MagazineActions
+        status="pending"
+        onApprove={onApprove}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+    expect(onApprove).toHaveBeenCalledOnce();
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// packages/web/lib/components/admin/magazines/MagazineActions.tsx
+"use client";
+import type { MagazineStatus } from "@/lib/api/admin/magazines";
+
+interface Props {
+  status: MagazineStatus;
+  disabled?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onRevert: () => void;
+}
+
+export function MagazineActions({
+  status,
+  disabled,
+  onApprove,
+  onReject,
+  onRevert,
+}: Props) {
+  if (status === "pending") {
+    return (
+      <div className="flex gap-2">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onApprove}
+          className="px-3 py-1.5 text-xs bg-green-600 text-white rounded disabled:opacity-50"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onReject}
+          className="px-3 py-1.5 text-xs bg-red-600 text-white rounded disabled:opacity-50"
+        >
+          Reject
+        </button>
+      </div>
+    );
+  }
+  if (status === "published") {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onRevert}
+        className="px-3 py-1.5 text-xs bg-yellow-600 text-white rounded disabled:opacity-50"
+      >
+        Unpublish
+      </button>
+    );
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/components/admin/magazines/MagazineActions.tsx \
+        packages/web/lib/components/admin/magazines/__tests__/MagazineActions.test.tsx
+git commit -m "feat(admin): add MagazineActions component"
+```
+
+---
+
+### Task 18: `MagazineApprovalTable` + index export
+
+**Files:**
+
+- Create: `packages/web/lib/components/admin/magazines/MagazineApprovalTable.tsx`
+- Create: `packages/web/lib/components/admin/magazines/index.ts`
+- Test: `packages/web/lib/components/admin/magazines/__tests__/MagazineApprovalTable.test.tsx`
+
+- [ ] **Step 1: 실패 테스트**
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MagazineApprovalTable } from "../MagazineApprovalTable";
+
+const items = [
+  {
+    id: "m1",
+    title: "Sample",
+    status: "pending" as const,
+    author_id: "u1",
+    submitted_at: "2026-04-17T10:00:00Z",
+    published_at: null,
+    rejection_reason: null,
+    approved_by: null,
+  },
+];
+
+describe("MagazineApprovalTable", () => {
+  it("renders title and status", () => {
+    render(
+      <MagazineApprovalTable
+        items={items}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />,
+    );
+    expect(screen.getByText("Sample")).toBeInTheDocument();
+    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+  });
+
+  it("fires onApprove with item id", () => {
+    const onApprove = vi.fn();
+    render(
+      <MagazineApprovalTable
+        items={items}
+        onApprove={onApprove}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />,
+    );
+    screen.getByRole("button", { name: /approve/i }).click();
+    expect(onApprove).toHaveBeenCalledWith("m1");
+  });
+});
+```
+
+- [ ] **Step 2: 실패 확인**
+
+- [ ] **Step 3: 구현**
+
+```tsx
+// packages/web/lib/components/admin/magazines/MagazineApprovalTable.tsx
+"use client";
+import type { AdminMagazineListItem } from "@/lib/api/admin/magazines";
+import { MagazineActions } from "./MagazineActions";
+
+interface Props {
+  items: AdminMagazineListItem[];
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onRevert: (id: string) => void;
+  mutatingId?: string | null;
+}
+
+export function MagazineApprovalTable({
+  items,
+  onApprove,
+  onReject,
+  onRevert,
+  mutatingId,
+}: Props) {
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-left text-gray-500">
+        <tr>
+          <th className="py-2">Title</th>
+          <th>Author</th>
+          <th>Submitted</th>
+          <th>Status</th>
+          <th className="text-right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((m) => (
+          <tr
+            key={m.id}
+            className="border-t border-gray-100 dark:border-gray-800"
+          >
+            <td className="py-3 font-medium">{m.title ?? "Untitled"}</td>
+            <td className="text-gray-500">{m.author_id ?? "—"}</td>
+            <td className="text-gray-500">
+              {m.submitted_at ? new Date(m.submitted_at).toLocaleString() : "—"}
+            </td>
+            <td>
+              <span className="inline-block px-2 py-0.5 text-xs rounded bg-gray-100 dark:bg-gray-800 capitalize">
+                {m.status}
+              </span>
+            </td>
+            <td className="text-right">
+              <MagazineActions
+                status={m.status}
+                disabled={mutatingId === m.id}
+                onApprove={() => onApprove(m.id)}
+                onReject={() => onReject(m.id)}
+                onRevert={() => onRevert(m.id)}
+              />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+```
+
+```ts
+// packages/web/lib/components/admin/magazines/index.ts
+export { MagazineApprovalTable } from "./MagazineApprovalTable";
+export { MagazineStatusFilter } from "./MagazineStatusFilter";
+export { MagazineActions } from "./MagazineActions";
+export { RejectModal } from "./RejectModal";
+```
+
+- [ ] **Step 4: 테스트 통과**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/web/lib/components/admin/magazines/
+git commit -m "feat(admin): add MagazineApprovalTable + barrel export"
+```
+
+---
+
+### Task 19: `ContentTab` 확장 + magazines 탭 렌더
+
+**Files:**
+
+- Modify: `packages/web/app/admin/content/page.tsx`
+
+**참고**: Task 4에서 empty state를 추가한 파일을 다시 수정. Task 4 commit 이후 이어서.
+
+- [ ] **Step 1: ContentTab 타입 확장**
+
+```tsx
+// content/page.tsx (상단)
+type ContentTab = "posts" | "reports" | "magazines";
+
+const TAB_OPTIONS: { value: ContentTab; label: string }[] = [
+  { value: "posts", label: "Posts" },
+  { value: "reports", label: "Reports" },
+  { value: "magazines", label: "Magazines" },
+];
+```
+
+- [ ] **Step 2: magazines 탭 내용 추가**
+
+```tsx
+import { useState } from "react";
+import { useAdminMagazineList } from "@/lib/hooks/admin/useAdminMagazineList";
+import { useUpdateMagazineStatus } from "@/lib/hooks/admin/useUpdateMagazineStatus";
+import {
+  MagazineApprovalTable,
+  MagazineStatusFilter,
+  RejectModal,
+} from "@/lib/components/admin/magazines";
+import { AdminEmptyState } from "@/lib/components/admin/common";
+import { FileTextIcon } from "lucide-react";
+import type { MagazineStatus } from "@/lib/api/admin/magazines";
+
+function MagazinesTab() {
+  const [filterStatus, setFilterStatus] = useState<MagazineStatus | undefined>(
+    "pending",
+  );
+  const [rejectTargetId, setRejectTargetId] = useState<string | null>(null);
+  const listQuery = useAdminMagazineList({ status: filterStatus, limit: 20 });
+  const mutation = useUpdateMagazineStatus();
+
+  const handleApprove = (id: string) =>
+    mutation.mutate({ id, status: "published" });
+  const handleReject = (id: string) => setRejectTargetId(id);
+  const handleRevert = (id: string) => mutation.mutate({ id, status: "draft" });
+  const handleConfirmReject = (reason: string) => {
+    if (!rejectTargetId) return;
+    mutation.mutate(
+      { id: rejectTargetId, status: "rejected", rejectionReason: reason },
+      { onSuccess: () => setRejectTargetId(null) },
+    );
+  };
+
+  const items = listQuery.data?.data ?? [];
+  const isEmpty = !listQuery.isLoading && items.length === 0;
+
+  return (
+    <div className="space-y-4">
+      <MagazineStatusFilter value={filterStatus} onChange={setFilterStatus} />
+      {isEmpty ? (
+        <AdminEmptyState
+          icon={<FileTextIcon className="w-12 h-12" />}
+          title="No magazines in this bucket"
+          description="Magazines matching the current filter will appear here."
+        />
+      ) : (
+        <MagazineApprovalTable
+          items={items}
+          onApprove={handleApprove}
+          onReject={handleReject}
+          onRevert={handleRevert}
+          mutatingId={mutation.isPending ? mutation.variables?.id : null}
+        />
+      )}
+      <RejectModal
+        open={!!rejectTargetId}
+        onClose={() => setRejectTargetId(null)}
+        onSubmit={handleConfirmReject}
+        submitting={mutation.isPending}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: 탭 렌더링에 magazines 케이스 추가**
+
+```tsx
+{
+  currentTab === "magazines" && <MagazinesTab />;
+}
+```
+
+- [ ] **Step 4: 타입 체크 + lint**
+
+```bash
+cd packages/web && bun run type-check && bun run lint
+```
+
+- [ ] **Step 5: 수동 검증**
+
+```bash
+bun run dev
+# http://localhost:3000/admin/content?tab=magazines 접속
+# 탭 필터, Approve/Reject 동작 확인
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/web/app/admin/content/page.tsx
+git commit -m "feat(admin): wire magazine approval tab into content page"
+```
+
+---
+
+### Task 20: Playwright E2E — 매거진 승인 흐름
+
+**Files:**
+
+- Create: `packages/web/tests/admin/magazine-approval.spec.ts`
+
+- [ ] **Step 1: 기존 admin 테스트 셋업 확인**
+
+```bash
+ls packages/web/tests/admin/ 2>/dev/null
+grep -rn "service_role\|admin session" packages/web/tests/ 2>/dev/null | head -20
+```
+
+세션 셋업 유틸이 있으면 재사용. 없으면 Step 2에서 생성.
+
+- [ ] **Step 2: E2E 스펙 작성**
+
+```typescript
+// packages/web/tests/admin/magazine-approval.spec.ts
+import { test, expect } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+test.describe("magazine approval", () => {
+  let magazineId: string;
+
+  test.beforeEach(async () => {
+    const { data, error } = await supabaseAdmin
+      .from("post_magazines")
+      .insert({ title: "E2E Test Magazine", status: "pending" })
+      .select()
+      .single();
+    if (error) throw error;
+    magazineId = data!.id;
+  });
+
+  test.afterEach(async () => {
+    await supabaseAdmin.from("post_magazines").delete().eq("id", magazineId);
+  });
+
+  test("admin approves a pending magazine", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines");
+    await expect(page.getByText("E2E Test Magazine")).toBeVisible();
+    await page
+      .getByRole("button", { name: /approve/i })
+      .first()
+      .click();
+    await expect(page.getByText("E2E Test Magazine")).not.toBeVisible();
+
+    const { data } = await supabaseAdmin
+      .from("post_magazines")
+      .select("status, approved_by, published_at")
+      .eq("id", magazineId)
+      .single();
+    expect(data?.status).toBe("published");
+    expect(data?.approved_by).not.toBeNull();
+    expect(data?.published_at).not.toBeNull();
+  });
+
+  test("admin rejects with reason", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines");
+    await page
+      .getByRole("button", { name: /reject/i })
+      .first()
+      .click();
+    await page.getByRole("textbox").fill("Off-topic content");
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /reject/i })
+      .click();
+
+    const { data } = await supabaseAdmin
+      .from("post_magazines")
+      .select("status, rejection_reason")
+      .eq("id", magazineId)
+      .single();
+    expect(data?.status).toBe("rejected");
+    expect(data?.rejection_reason).toBe("Off-topic content");
+  });
+
+  test("audit log records approval", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines");
+    await page
+      .getByRole("button", { name: /approve/i })
+      .first()
+      .click();
+
+    const { data } = await supabaseAdmin
+      .schema("warehouse")
+      .from("admin_audit_log")
+      .select("action, target_id")
+      .eq("target_id", magazineId)
+      .eq("action", "magazine_approve");
+    expect(data?.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 3: 로컬 E2E 실행**
+
+```bash
+cd packages/web && bun run test:e2e -- tests/admin/magazine-approval.spec.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/tests/admin/magazine-approval.spec.ts
+git commit -m "test(admin): e2e magazine approval + reject + audit log"
+```
+
+---
+
+## Wave 3 — Next.js audit 갭 보완
+
+### Task 21: Next.js mutation route 감사 갭 조사
+
+**Files:**
+
+- Inspect only
+
+- [ ] **Step 1: Next.js mutation route 목록화**
+
+```bash
+grep -rln "export async function \(POST\|PATCH\|DELETE\|PUT\)" packages/web/app/api/admin packages/web/app/api/v1/admin 2>/dev/null
+```
+
+- [ ] **Step 2: writeAuditLog 호출처 대비**
+
+```bash
+grep -L "writeAuditLog" $(grep -rln "export async function \(POST\|PATCH\|DELETE\|PUT\)" packages/web/app/api/admin packages/web/app/api/v1/admin 2>/dev/null)
+```
+
+Expected: 누락 route 목록. (Magazine status는 RPC에서 자동 처리 — 제외)
+
+- [ ] **Step 3: 각 누락 route에 대해 추가 여부 판단**
+
+- 진짜 mutation이면 추가
+- 내부 조회/캐시 API면 skip
+- Rust로 proxy하는 경우 → #152로 이관
+
+- [ ] **Step 4: 결과를 체크리스트로 다음 Task에 반영**
+
+---
+
+### Task 22: 감사 갭 보완 구현 (조사 결과에 따라)
+
+**Files:**
+
+- Modify: Task 21에서 식별된 Next.js route 각각
+
+> 조사 결과 누락이 없다면 이 Task는 `skip` commit으로 마무리. 있으면 각 route에 `writeAuditLog` 호출 추가.
+
+- [ ] **Step 1: 각 route 수정 (패턴)**
+
+```typescript
+import { writeAuditLog } from "@/lib/api/admin/audit-log";
+import { getAdminUserId } from "@/lib/api/admin/audit-log";
+
+// 기존 mutation 직후
+const adminUserId = await getAdminUserId();
+if (adminUserId) {
+  await writeAuditLog({
+    adminUserId,
+    action: "<action_name>", // 예: "report_status_change"
+    targetTable: "<table>",
+    targetId: id,
+    beforeState: before,
+    afterState: after,
+    metadata: {
+      /* optional */
+    },
+  });
+}
+```
+
+- [ ] **Step 2: 각 수정 건에 대한 최소 테스트 추가**
+
+- [ ] **Step 3: 타입 체크 + 테스트**
+
+```bash
+cd packages/web && bun run type-check && bun test
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/web/app/api/
+git commit -m "feat(admin): wave 3 Next.js audit 갭 보완"
+```
+
+---
+
+### Task 23: 분리 이슈 #152 / #153 생성 + #151 본문 업데이트
+
+**Files:**
+
+- GitHub issues (gh CLI)
+- Modify (optional): issue body template
+
+- [ ] **Step 1: #152 생성 (Rust audit 통합)**
+
+```bash
+gh issue create \
+  --repo decodedcorp/decoded \
+  --title "Rust API audit 통합 (picks, posts status 등)" \
+  --body "$(cat <<'EOF'
+## 배경
+#151 에서 Next.js admin route의 audit log는 거의 완성됨.
+그러나 `picks` CRUD, `posts/:id/status` 등은 Rust API server에서 처리하므로
+현재 `warehouse.admin_audit_log`에 기록되지 않음.
+
+## 범위
+- [ ] Rust 측에서 `writeAuditLog` 상응 유틸 설계
+- [ ] 또는 Next.js proxy route를 생성해 통합
+- [ ] picks CRUD 감사 기록
+- [ ] posts status change 감사 기록
+- [ ] bulk operation metadata 강화 (affectedIds)
+
+## 참고
+- 감사 RPC: `public.update_magazine_status` (트랜잭션 패턴 참고)
+- 현재 Next.js 유틸: `packages/web/lib/api/admin/audit-log.ts`
+EOF
+)"
+```
+
+- [ ] **Step 2: #153 생성 (entities/seed 실데이터 강화)**
+
+```bash
+gh issue create \
+  --repo decodedcorp/decoded \
+  --title "Admin entities/seed 서브라우트 실데이터 점검 및 empty state" \
+  --body "$(cat <<'EOF'
+## 배경
+#151 에서 `entities/{artists,brands,group-members}`와
+`seed/{candidates,post-images,post-spots}` 는 기본 동작 확인 완료.
+
+개별 페이지별 실데이터 검증과 empty state 추가는 별도 스코프로 이관.
+
+## 범위
+- [ ] 각 페이지 실데이터 흐름 재검증
+- [ ] 누락된 empty state UI 적용
+- [ ] 필요 시 리팩토링
+EOF
+)"
+```
+
+- [ ] **Step 3: #151 본문에 분리 이슈 링크**
+
+```bash
+# 본문을 수동 편집 혹은 댓글 추가
+gh issue comment 151 --repo decodedcorp/decoded --body "$(cat <<'EOF'
+분리 이슈:
+- #152 Rust API audit 통합
+- #153 entities/seed 실데이터 강화
+- Editorial 승인 워크플로우 — 추후 별도 이슈 생성
+
+이 PR(#224) 머지 후 #151은 클로즈 가능.
+EOF
+)"
+```
+
+- [ ] **Step 4: Commit (문서 링크 업데이트 있을 경우)**
+
+스펙 문서 §2.2에 새 이슈 번호 반영:
+
+```bash
+git add docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+git commit -m "docs(#151): 분리 이슈 #152/#153 링크 반영" --allow-empty
+```
+
+---
+
+## 머지 준비
+
+### Task 24: gstack `/cso` 보안 점검
+
+- [ ] **Step 1: cso skill 호출**
+
+```
+/cso
+```
+
+대상: admin route 신규 2개, RPC 함수, RLS 정책.
+
+- [ ] **Step 2: 지적사항 반영**
+
+---
+
+### Task 25: gstack `/review` 코드 리뷰
+
+- [ ] **Step 1: review 호출**
+
+```
+/review
+```
+
+- [ ] **Step 2: 지적사항 반영 + 커밋**
+
+---
+
+### Task 26: gstack `/qa` QA 실행
+
+- [ ] **Step 1: qa 호출**
+
+```
+/qa
+```
+
+admin 페이지 순회 + magazine approval 플로우 집중 확인.
+
+- [ ] **Step 2: 버그 수정 루프**
+
+---
+
+### Task 27: Draft PR → Ready for Review
+
+- [ ] **Step 1: 타입 체크/린트/테스트 모두 통과 확인**
+
+```bash
+cd packages/web && bun run type-check && bun run lint && bun test
+bun run test:e2e -- tests/admin/magazine-approval.spec.ts
+```
+
+- [ ] **Step 2: PR 설명 업데이트**
+
+```bash
+gh pr edit 224 --body "$(cat <<'EOF'
+## Summary
+- Empty state 4 페이지 (audit-log, content, editorial-candidates, monitoring)
+- Post Magazine 승인 UI/API/RPC 전체 신규
+- audit log 갭 일부 보완 (Next.js 한정)
+
+## 분리 이슈
+- #152 Rust API audit 통합
+- #153 entities/seed 실데이터 강화
+
+## 설계
+docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+
+## Test plan
+- [x] vitest 유닛 테스트 모두 pass
+- [x] Playwright E2E (magazine approval, reject, audit log) pass
+- [x] 로컬에서 수동 매거진 승인/거부 확인
+- [x] gstack /cso /review /qa 통과
+EOF
+)"
+```
+
+- [ ] **Step 3: Ready for review**
+
+```bash
+gh pr ready 224
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** — 각 Wave별 task:
+
+- Wave 0.5 → Task 1, 2 ✓
+- Wave 1 empty state → Task 3~6 ✓
+- Wave 2a DB → Task 7~9 ✓
+- Wave 2b API → Task 10~12 ✓
+- Wave 2c UI → Task 13~20 ✓
+- Wave 3 audit → Task 21, 22 ✓
+- 분리 이슈 → Task 23 ✓
+- 머지 준비 → Task 24~27 ✓
+
+**2. 타입 일관성** — `MagazineStatus`, `AdminMagazineListItem`, `AdminMagazineListResponse` Task 10에서 정의, 이후 Task 11~19에서 같은 이름 사용 ✓. RPC 파라미터 `p_magazine_id/p_new_status/p_admin_user_id/p_rejection_reason` Task 8, 12 일치 ✓.
+
+**3. Placeholder** — 각 step 실제 코드/커맨드 포함. Task 21/22는 "조사 후 적용"이지만 구체적 커맨드 + 패턴 제시. ✓
+
+**4. 파일명/경로** — 모두 절대 기준 상대 경로로 일관. `packages/web/...` 형식.

--- a/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+++ b/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
@@ -229,7 +229,7 @@ GRANT EXECUTE ON FUNCTION public.update_magazine_status TO authenticated;
 1. `createSupabaseServerClient()` 호출 시 service_role 키를 사용하는 admin 전용 변형이 있는지 확인
    - 없으면 **신규 `createAdminSupabaseClient()` 유틸** 생성 (service_role + 쿠키 미사용)
    - 파일: `packages/web/lib/supabase/admin-server.ts`
-2. 기존 `AdminEmptyState` 컴포넌트 props/variants 확인 (`packages/web/lib/components/admin/shared/AdminEmptyState.tsx` 존재 확인)
+2. 기존 `AdminEmptyState` 컴포넌트 props/variants 확인 (`packages/web/lib/components/admin/common/AdminEmptyState.tsx` 존재 확인)
 3. Rust API에 audit 관련 구조 존재 여부 재확인 (#152 범위 확정용)
 
 **산출물**: 코드 변경 없음. 조사 결과 스펙에 주석 형태로 남김 (본 문서 6절).
@@ -338,6 +338,7 @@ packages/web/lib/hooks/admin/
   LANGUAGE sql
   SECURITY DEFINER
   STABLE
+  SET search_path = public, pg_temp
   AS $$
     SELECT COALESCE((SELECT is_admin FROM public.users WHERE id = user_id), false);
   $$;
@@ -375,8 +376,8 @@ packages/web/lib/hooks/admin/
 - **실제 경로**: `packages/web/lib/components/admin/common/AdminEmptyState.tsx` (스펙 §5 Wave 0.5에 기재된 `shared/` 경로는 **오타** — `common/` 으로 정정 필요).
 - **Import 패턴**: `import { AdminEmptyState } from "@/lib/components/admin/common";` (배럴 export 사용).
 - **Props**: `icon`, `title`, `description`.
-- **기존 사용처 (5개)**: `server-logs`, `pipeline-logs`, `ai-cost`, `ai-audit` 페이지에서 동일 패턴으로 적용. (`audit-log`는 본 PR Wave 1에서 추가 예정.)
-- **Wave 1 가이드**: 기존 5개 페이지 어느 것이든 모범 예시로 사용. 새 패턴 도입 금지.
+- **기존 사용처 (4개)**: `app/admin/ai-audit/page.tsx`, `app/admin/ai-cost/page.tsx`, `app/admin/pipeline-logs/page.tsx`, `app/admin/server-logs/page.tsx`에서 동일 패턴으로 적용 (검증 명령: `grep -rln "AdminEmptyState" packages/web/app/admin/`). 컴포넌트 정의 파일과 배럴(`index.ts`)은 사용처 카운트에서 제외. (`audit-log`는 본 PR Wave 1에서 추가 예정.)
+- **Wave 1 가이드**: 기존 4개 페이지(`ai-audit`, `ai-cost`, `pipeline-logs`, `server-logs`) 어느 것이든 모범 예시로 사용. 새 패턴 도입 금지.
 
 ### 6.6 Rust audit 인프라
 

--- a/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+++ b/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
@@ -1,0 +1,436 @@
+# #151 Admin 실데이터 연동 잔여 범위 — 설계 스펙
+
+**Issue**: [#151](https://github.com/decodedcorp/decoded/issues/151)
+**Draft PR**: [#224](https://github.com/decodedcorp/decoded/pull/224)
+**Worktree**: `.worktrees/151-admin-real-data`
+**Branch**: `feature/151-admin-real-data`
+**Status**: Design v2 (architect + critic 리뷰 반영)
+**Estimated effort**: 6일 (코딩 5일 + 리뷰/QA 왕복 1일)
+
+---
+
+## 1. 배경
+
+### 1.1 이전 작업 상태
+
+- PR #147 (커밋 `80755a7a`)로 admin 페이지 5개의 mock→real 전환 및 empty state 완료:
+  `ai-audit`, `ai-cost`, `picks`, `pipeline-logs`, `server-logs`
+- Mock 데이터 생성기 5개 삭제 (~1,200 lines)
+- 이후 `review`도 완료. 총 **6페이지 완료**.
+
+### 1.2 탐색 결과 (3-agent 병렬 매핑)
+
+| 영역                                           | 상태                                                                                                                           |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Admin 페이지 실데이터                          | 13개 중 6개 완료, 4개(`audit-log`, `content`, `editorial-candidates`, `monitoring`)는 real API 연결됐으나 **empty state 미흡** |
+| `entities/*` (artists, brands, group-members)  | 실데이터 훅 사용 중 — 기능 동작 확인됨                                                                                         |
+| `seed/*` (candidates, post-images, post-spots) | GET route 동작 중                                                                                                              |
+| Audit log (Next.js)                            | DB(`warehouse.admin_audit_log`) + API + UI + `writeAuditLog()` 헬퍼 + 10개 엔드포인트 호출부 → **거의 완성**                   |
+| Audit log (Rust API)                           | **없음** — Rust 쪽 mutation은 감사 사각                                                                                        |
+| Post Magazine 승인 UI/API                      | **완전 없음** — `post_magazines.status` 필드만 존재 (draft/pending/published 값은 관행)                                        |
+| Editorial 승인                                 | 후보 생성만 있음. #151에서 **분리**                                                                                            |
+
+### 1.3 아키텍처 사실 (설계의 전제)
+
+1. **`createSupabaseServerClient`는 anon key + 쿠키 기반**. service_role 아님 (`packages/web/lib/supabase/server.ts:31`).
+   → admin mutation은 RLS 정책이 admin role을 허용하거나, service_role 클라이언트를 별도 사용해야 함.
+2. **Next.js route vs Rust route 혼재**:
+   - Next.js: `/api/admin/*`, `/api/v1/admin/audit-log/*`, `/api/v1/admin/posts/magazines/*` (신규)
+   - Rust: `/api/v1/admin/picks`, `/api/v1/admin/posts/:postId/status`, dashboard, monitoring, AI cost, pipeline logs, server logs 등
+   - `writeAuditLog()`는 **Next.js 전용**. Rust route 호출에는 적용 불가.
+3. **`post_magazines` 테이블**:
+   - `status varchar` — CHECK 제약 **없음** (`20260409075040_remote_schema.sql:416`)
+   - `published_at` — 존재하지만 현재 흐름에서 **populating 안 됨**
+   - `approved_by` — **존재하지 않음**
+   - RLS: `Allow public read` SELECT 정책만 있음, UPDATE/INSERT 정책 없음
+4. **Admin 쪽 Magazine 존재도 0**:
+   - `packages/web/app/admin/` 하위에 magazine 관련 파일 없음
+   - `packages/web/app/api/admin/` 하위에도 magazine 관련 route 없음
+   - `ContentTab` 타입이 `"posts" | "reports"` — `magazines` 추가 필요
+
+---
+
+## 2. 범위 결정
+
+### 2.1 이번 PR 포함
+
+| Wave                               | 산출물                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| **0.5 선행 조사**                  | RLS/클라이언트 확인, 기존 empty state 패턴 확인                                 |
+| **1 Empty state 4개**              | `audit-log`, `content`, `editorial-candidates`, `monitoring`                    |
+| **2 Magazine 승인 전체 빌드**      | Migration + RPC + API + UI + 훅 (2a/2b/2c로 세분)                               |
+| **3 Next.js audit 갭 확인 & 기록** | 실제 누락된 Next.js route에만 `writeAuditLog` 추가. 현재는 사실상 완성에 가까움 |
+
+### 2.2 #151에서 **분리**
+
+| 분리 이슈                                   | 사유                                                                         |
+| ------------------------------------------- | ---------------------------------------------------------------------------- |
+| **#152 Rust API audit 통합** (신규)         | `picks`, `post status` 등 Rust route의 audit은 Rust 서버 수정 필요. 별도 PR. |
+| **#153 entities/seed 실데이터 강화** (신규) | "점검"은 unbounded scope. 발견 시 개별 이슈화.                               |
+| **Editorial 승인 워크플로우** (추후 이슈)   | `editorial_posts` 테이블 신규 + 승인 흐름 = 별도 스펙.                       |
+| **Magazine 알림/rollback/역할 세분화**      | Wave 2 내 defer. 후속 이슈로.                                                |
+
+### 2.3 #151 종료 기준
+
+이 PR 머지 후 #151이 "closed"되기 위한 조건:
+
+- Wave 1/2/3 모두 머지
+- Issue body에 남은 작업(#152, #153, editorial 등) 링크 추가
+- PR 설명에 "이 PR로 끝나지 않는 항목" 섹션 명시
+
+---
+
+## 3. Magazine 상태 머신 (신규 정의)
+
+```typescript
+// packages/web/lib/api/admin/magazines.ts (신규)
+export type MagazineStatus =
+  | "draft" // 초안, 검토 대기 전
+  | "pending" // 검토 대기
+  | "published" // 승인 완료 + 공개
+  | "rejected"; // 거부됨 (사유 기록)
+```
+
+### 3.1 유효한 상태 전이
+
+| from        | to          | action    | 메타데이터                    |
+| ----------- | ----------- | --------- | ----------------------------- |
+| `draft`     | `pending`   | submit    | —                             |
+| `pending`   | `published` | approve   | `approved_by`, `published_at` |
+| `pending`   | `rejected`  | reject    | `rejection_reason`            |
+| `rejected`  | `pending`   | resubmit  | —                             |
+| `published` | `draft`     | unpublish | — (관리자 권한)               |
+
+### 3.2 금지된 전이
+
+- `draft → published` (pending을 거쳐야 함)
+- `draft → rejected`
+- `published → rejected` (unpublish 후 reject)
+
+---
+
+## 4. 데이터 모델 변경
+
+### 4.1 Migration: `20260417_XXXX_magazine_approval_fields.sql`
+
+```sql
+-- post_magazines 승인 흐름 지원
+ALTER TABLE public.post_magazines
+  ADD COLUMN IF NOT EXISTS approved_by UUID REFERENCES auth.users(id),
+  ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+
+-- status CHECK 제약
+ALTER TABLE public.post_magazines
+  ADD CONSTRAINT post_magazines_status_check
+  CHECK (status IN ('draft', 'pending', 'published', 'rejected'));
+
+-- 관리자 UPDATE 정책 (service_role은 RLS bypass, admin role도 허용)
+CREATE POLICY "admin_can_update_magazines"
+  ON public.post_magazines
+  FOR UPDATE
+  USING (public.is_admin(auth.uid()))
+  WITH CHECK (public.is_admin(auth.uid()));
+
+-- 기존 데이터 안전: NULL 상태 레코드는 'draft'로 백필
+UPDATE public.post_magazines SET status = 'draft' WHERE status IS NULL;
+```
+
+### 4.2 RPC: `update_magazine_status`
+
+트랜잭션 원자성 보장 (UPDATE + audit log INSERT 한 번에).
+
+```sql
+CREATE OR REPLACE FUNCTION public.update_magazine_status(
+  p_magazine_id UUID,
+  p_new_status VARCHAR,
+  p_admin_user_id UUID,
+  p_rejection_reason TEXT DEFAULT NULL
+) RETURNS SETOF public.post_magazines
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_before public.post_magazines;
+  v_after public.post_magazines;
+  v_action TEXT;
+BEGIN
+  SELECT * INTO v_before FROM public.post_magazines WHERE id = p_magazine_id FOR UPDATE;
+  IF v_before IS NULL THEN
+    RAISE EXCEPTION 'magazine_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 전이 검증
+  IF NOT (
+    (v_before.status = 'draft'     AND p_new_status = 'pending')  OR
+    (v_before.status = 'pending'   AND p_new_status = 'published') OR
+    (v_before.status = 'pending'   AND p_new_status = 'rejected')  OR
+    (v_before.status = 'rejected'  AND p_new_status = 'pending')   OR
+    (v_before.status = 'published' AND p_new_status = 'draft')
+  ) THEN
+    RAISE EXCEPTION 'invalid_transition: % -> %', v_before.status, p_new_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.post_magazines
+  SET status = p_new_status,
+      approved_by = CASE
+        WHEN p_new_status = 'published' THEN p_admin_user_id
+        ELSE approved_by
+      END,
+      published_at = CASE
+        WHEN p_new_status = 'published' THEN now()
+        ELSE published_at
+      END,
+      rejection_reason = CASE
+        WHEN p_new_status = 'rejected' THEN p_rejection_reason
+        ELSE NULL
+      END,
+      updated_at = now()
+  WHERE id = p_magazine_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE p_new_status
+    WHEN 'published' THEN 'magazine_approve'
+    WHEN 'rejected' THEN 'magazine_reject'
+    WHEN 'pending' THEN 'magazine_submit'
+    WHEN 'draft' THEN 'magazine_unpublish'
+    ELSE 'magazine_status_change'
+  END;
+
+  INSERT INTO warehouse.admin_audit_log (
+    admin_user_id, action, target_table, target_id,
+    before_state, after_state, metadata
+  ) VALUES (
+    p_admin_user_id, v_action, 'post_magazines', p_magazine_id,
+    row_to_json(v_before)::jsonb,
+    row_to_json(v_after)::jsonb,
+    jsonb_build_object('rejection_reason', p_rejection_reason)
+  );
+
+  RETURN QUERY SELECT * FROM public.post_magazines WHERE id = p_magazine_id;
+END;
+$$;
+
+-- admin만 실행
+REVOKE ALL ON FUNCTION public.update_magazine_status FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_magazine_status TO authenticated;
+```
+
+**근거**: `writeAuditLog()` 현재 패턴은 fire-and-forget (에러 swallow, `lib/api/admin/audit-log.ts:30-32`). Audit INSERT 실패 시 승인만 기록되고 감사 유실. RPC로 원자성 확보. 이 RPC는 향후 Rust 서버가 호출해도 같은 동작을 보장.
+
+---
+
+## 5. Wave 별 상세 설계
+
+### Wave 0.5 — 선행 조사 (0.5일)
+
+**조사 항목**:
+
+1. `createSupabaseServerClient()` 호출 시 service_role 키를 사용하는 admin 전용 변형이 있는지 확인
+   - 없으면 **신규 `createAdminSupabaseClient()` 유틸** 생성 (service_role + 쿠키 미사용)
+   - 파일: `packages/web/lib/supabase/admin-server.ts`
+2. 기존 `AdminEmptyState` 컴포넌트 props/variants 확인 (`packages/web/lib/components/admin/shared/AdminEmptyState.tsx` 존재 확인)
+3. Rust API에 audit 관련 구조 존재 여부 재확인 (#152 범위 확정용)
+
+**산출물**: 코드 변경 없음. 조사 결과 스펙에 주석 형태로 남김 (본 문서 6절).
+
+### Wave 1 — Empty state 4개 (1일)
+
+**대상 페이지 및 적용 위치**:
+| 페이지 | 기존 컴포넌트 | 변경 |
+|--------|---------------|------|
+| `app/admin/audit-log/page.tsx` | `AdminDataTable` | items.length===0 분기에 `AdminEmptyState` 렌더 |
+| `app/admin/content/page.tsx` | 탭 구조 (posts/reports) | 각 탭 내부 목록 empty 처리 |
+| `app/admin/editorial-candidates/page.tsx` | 후보 목록 | `AdminEmptyState` with "승인 대기 후보 없음" |
+| `app/admin/monitoring/page.tsx` | KPI + 차트 | 데이터 없을 때 KPI/차트 자리에 명시 메시지 (스켈레톤 아닌) |
+
+**기존 패턴 준수**: PR #147에서 완성된 5개 페이지와 동일한 `AdminEmptyState` 사용. 새 패턴 도입 금지.
+
+### Wave 2 — Magazine 승인 (3일)
+
+#### 2a — DB & RPC (0.5일)
+
+- `supabase/migrations/20260417_XXXX_magazine_approval_fields.sql` 작성 (§4.1)
+- `supabase/migrations/20260417_XXXX_update_magazine_status_rpc.sql` 작성 (§4.2)
+- 로컬 Supabase에 적용 + typegen 재실행 (`bun run supabase:types`)
+
+#### 2b — API route (1일)
+
+```
+packages/web/app/api/v1/admin/posts/magazines/
+  route.ts                              # GET list (status filter, pagination)
+  [id]/
+    status/
+      route.ts                          # PATCH status (RPC 호출)
+```
+
+**`GET /api/v1/admin/posts/magazines?status=pending&page=1&limit=20`**
+
+- `supabase.from("post_magazines").select(...).eq("status", status)`
+- anon client OK (SELECT 정책 허용)
+
+**`PATCH /api/v1/admin/posts/magazines/:id/status`**
+
+- body: `{ status: MagazineStatus, rejectionReason?: string }`
+- `checkIsAdmin()` → admin user id 획득
+- `createAdminSupabaseClient()` 사용 (service_role)
+- `supabase.rpc("update_magazine_status", { ... })`
+- 에러 매핑:
+  - `magazine_not_found` → 404
+  - `invalid_transition` → 409
+  - 기타 → 500
+
+#### 2c — UI (1.5일)
+
+**신규 파일**:
+
+```
+packages/web/lib/components/admin/magazines/
+  MagazineApprovalTable.tsx      # status/title/author/submitted_at/actions
+  MagazineStatusFilter.tsx       # All/Draft/Pending/Published/Rejected
+  RejectModal.tsx                # reason 입력 필수
+  MagazineActions.tsx            # Approve/Reject/Revert 버튼
+
+packages/web/lib/hooks/admin/
+  useAdminMagazineList.ts        # GET 훅
+  useUpdateMagazineStatus.ts     # PATCH mutation 훅
+```
+
+**기존 파일 수정**:
+
+- `packages/web/app/admin/content/page.tsx`: `ContentTab = "posts" | "reports" | "magazines"`, `TAB_OPTIONS`에 추가
+- 새 탭 `magazines` 렌더 시 `MagazineApprovalTable` + filter
+
+**UX 규칙**:
+
+- Reject 시 사유 **필수** (빈 문자열 차단, 클라이언트 검증 + 서버 검증)
+- Approve 후 토스트 + 목록 refetch
+- 낙관적 업데이트는 **하지 않음** (RPC 결과로 행 상태 갱신)
+
+### Wave 3 — Next.js audit 일관화 (0.5일)
+
+**실제 gap 조사** (critic 검증 결과 반영):
+
+- Next.js mutation route 중 `writeAuditLog` 누락:
+  - Wave 2에서 신규로 추가되는 magazine status → RPC가 처리하므로 자동 커버
+  - `reports-status` (Next.js route 여부 확인 필요)
+  - `post-images`, `post-spots` (조회만 있을 수 있음)
+- **Rust route(`picks` CRUD, `posts/status`)는 이 PR에서 다루지 않음** → #152로 이관
+
+**변경**: 누락된 Next.js route handler에 `writeAuditLog({ action, target_table, target_id, before, after, metadata })` 추가.
+
+---
+
+## 6. 조사 결과 기록 (Wave 0.5 완료 후 업데이트)
+
+> 이 섹션은 Wave 0.5 실행 후 채워집니다. 현재는 placeholder.
+
+- `createAdminSupabaseClient()` 존재 여부: (조사 전)
+- `AdminEmptyState` 사용 패턴: (조사 전)
+- Rust audit 인프라: (조사 전)
+
+---
+
+## 7. 테스트 전략
+
+### 7.1 Migration 검증
+
+- 로컬 Supabase에 적용 후 기존 레코드 status NOT NULL 확인
+- CHECK 제약 위반 케이스 수동 테스트
+- RPC 4가지 전이 수동 테스트 (approve/reject/submit/unpublish)
+
+### 7.2 Unit (vitest + RTL)
+
+- **Wave 1**: 각 empty state 분기 렌더 (items=[] / items=[...])
+- **Wave 2b**: API route handler
+  - approve happy path
+  - reject with reason
+  - invalid transition → 409
+  - not found → 404
+  - non-admin → 403
+- **Wave 2c**: `MagazineApprovalTable` 상호작용
+  - Reject 버튼 클릭 → 모달 열림, 사유 없이 제출 차단
+  - Approve 성공 후 mutation 호출 검증
+
+### 7.3 E2E (Playwright)
+
+- Admin 로그인 (service_role 쿠키 주입 — 기존 admin Playwright 셋업 재사용, 없으면 `packages/web/tests/admin/` 하위에 신규 작성)
+- Magazine 생성 (seed fixture) → status=pending
+- `/admin/content?tab=magazines` 접속 → pending 목록에 표시
+- Approve 클릭 → 성공 토스트 → 목록에서 사라짐 (Published 필터에선 등장)
+- `/admin/audit-log` 에서 `magazine_approve` 액션 레코드 확인
+
+### 7.4 수동 QA
+
+- gstack `/qa` 스킬로 실브라우저 머지 전 확인
+- 거부 사유 한글/영문 모두 테스트
+
+---
+
+## 8. 에러 핸들링
+
+| 레이어          | 에러                 | 처리                                                  |
+| --------------- | -------------------- | ----------------------------------------------------- |
+| RPC             | `magazine_not_found` | SQL 예외 → Next.js 404 응답                           |
+| RPC             | `invalid_transition` | SQL 예외 → Next.js 409 응답 + 에러 메시지 클라 노출   |
+| RPC             | DB 실패              | 트랜잭션 롤백 → Next.js 500                           |
+| API route       | non-admin            | `checkIsAdmin` 미들웨어 → 403                         |
+| Client mutation | 네트워크 오류        | React Query `onError` → 토스트 "요청 실패, 다시 시도" |
+| UI              | Reject 사유 빈 값    | 버튼 비활성화 + 인라인 에러                           |
+
+**원칙**: fire-and-forget 감사 쓰기 금지. RPC 내부 트랜잭션으로 보장.
+
+---
+
+## 9. 브랜치 / PR 전략
+
+- 현재 `feature/151-admin-real-data` 유지
+- Draft PR #224 재활용
+- 커밋 단위:
+  1. `feat(admin): wave 0.5 선행 조사 — admin supabase 유틸 추가`
+  2. `feat(admin): wave 1 empty state 4개 페이지 적용`
+  3. `feat(admin): wave 2a DB — magazine 승인 필드 + RPC`
+  4. `feat(admin): wave 2b API — magazine 승인 엔드포인트`
+  5. `feat(admin): wave 2c UI — magazine 승인 탭 + 테이블`
+  6. `feat(admin): wave 3 Next.js audit 갭 보완`
+  7. `docs(issue): #151 분리 이슈(#152/#153) 링크 및 완료 기준`
+- 리뷰 → **dev 브랜치로 머지 1 PR** (feature/151 → dev, main은 GIT-WORKFLOW 따라 dev→main PR로 별도 승격)
+- 후속: #152 (Rust audit), #153 (entities/seed 실데이터)
+
+---
+
+## 10. 하니스 배치
+
+| 단계             | Harness / Skill                       |
+| ---------------- | ------------------------------------- |
+| 설계 리뷰 (완료) | OMC `architect` + `critic` 병렬       |
+| Wave 1 병렬 구현 | OMC `/team` 또는 4개 Explore 에이전트 |
+| Wave 2 TDD 구현  | Superpowers `test-driven-development` |
+| Wave 2 UI 리뷰   | gstack `/design-review` (선택)        |
+| Security 체크    | gstack `/cso` (admin route)           |
+| 코드 리뷰        | gstack `/review`                      |
+| QA               | gstack `/qa` + Playwright skill       |
+
+---
+
+## 11. 위험과 완화
+
+| 위험                                                                          | 완화                                                                                   |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| RLS 정책이 `public.is_admin(uuid)` 함수 가정 — 존재하지 않으면 migration 실패 | Wave 0.5에서 존재 확인. 없으면 migration에 함수 정의 포함 or admin role 체크 방식 변경 |
+| Orval 자동 생성 API에 magazine 추가가 맞물릴 수 있음                          | magazine 승인은 Next.js route라 Orval 영향 없음. Rust 쪽은 #152에서 처리               |
+| `#148 editorial OG fix`가 QA 브랜치에만 있어 관련 컴포넌트 충돌 가능          | QA 머지 완료 후 dev → feature 리베이스                                                 |
+| Magazine seed 데이터 부재로 E2E 테스트 어려움                                 | Playwright setup에서 fixture seed 스크립트 작성                                        |
+| 마이그레이션 순서 꼬임 (RPC가 컬럼보다 먼저)                                  | Migration 파일명 타임스탬프로 순서 보장                                                |
+
+---
+
+## 12. 성공 기준 (완료 정의)
+
+- [ ] 4개 페이지 모두 empty state 렌더 검증
+- [ ] Magazine 승인 UI에서 pending→published, pending→rejected 모두 동작
+- [ ] `warehouse.admin_audit_log`에 각 액션 레코드 생성
+- [ ] E2E 테스트 통과
+- [ ] PR #224 머지
+- [ ] 이슈 #152, #153 생성 + #151 본문에 링크
+- [ ] `gstack /qa` 통과

--- a/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+++ b/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
@@ -321,13 +321,78 @@ packages/web/lib/hooks/admin/
 
 ---
 
-## 6. 조사 결과 기록 (Wave 0.5 완료 후 업데이트)
+## 6. 조사 결과 기록 (Wave 0.5 완료)
 
-> 이 섹션은 Wave 0.5 실행 후 채워집니다. 현재는 placeholder.
+> 2026-04-17 조사 완료. 후속 wave에서 이 결과를 전제로 진행.
 
-- `createAdminSupabaseClient()` 존재 여부: (조사 전)
-- `AdminEmptyState` 사용 패턴: (조사 전)
-- Rust audit 인프라: (조사 전)
+### 6.1 `is_admin` SQL 함수 존재 여부
+
+- **결론: 존재하지 않음** (`grep -rn "CREATE OR REPLACE FUNCTION.*is_admin\|CREATE FUNCTION.*is_admin" supabase/migrations/` → 0건)
+- 단 **`users.is_admin` boolean 컬럼**은 존재 (`20260409075040_remote_schema.sql:866`).
+- **영향**: §4.1 migration의 `USING (public.is_admin(auth.uid()))` 정책이 그대로 적용 시 실패함.
+- **결정**: Task 7 migration 파일에 `is_admin(uuid)` SQL 함수를 **반드시 포함**해야 함. 권장 정의:
+
+  ```sql
+  CREATE OR REPLACE FUNCTION public.is_admin(user_id UUID)
+  RETURNS BOOLEAN
+  LANGUAGE sql
+  SECURITY DEFINER
+  STABLE
+  AS $$
+    SELECT COALESCE((SELECT is_admin FROM public.users WHERE id = user_id), false);
+  $$;
+  REVOKE ALL ON FUNCTION public.is_admin(UUID) FROM PUBLIC;
+  GRANT EXECUTE ON FUNCTION public.is_admin(UUID) TO authenticated, service_role;
+  ```
+
+  - SECURITY DEFINER + STABLE: RLS 정책에서 호출 시 plan 캐시 가능
+  - `users.is_admin` 컬럼을 단일 진실원으로 사용 (TS 쪽 `checkIsAdmin`과 동일 의미)
+
+### 6.2 `post_magazines` RLS 정책 현황
+
+- `ENABLE ROW LEVEL SECURITY` 활성 (line 2686).
+- 정책: **`"Allow public read" FOR SELECT USING (true)` 단 1건**만 존재 (line 2427).
+- INSERT/UPDATE/DELETE 정책 **없음** → §4.1의 `admin_can_update_magazines` 정책 추가가 정확한 처방.
+- GRANT는 anon/authenticated/service_role 모두 ALL이지만 RLS가 막고 있음.
+
+### 6.3 `checkIsAdmin` 미들웨어 위치
+
+- **파일**: `packages/web/lib/supabase/admin.ts:19`
+- **시그니처**: `checkIsAdmin(supabase: SupabaseClient<Database>, userId: string): Promise<boolean>`
+- **동작**: `users` 테이블에서 `is_admin` 컬럼 조회, 에러/null/false 모두 false 반환.
+- **사용처**: 35+ admin route (proxy.ts, app/admin/layout.tsx, app/api/admin/**, app/api/v1/admin/**)에서 광범위 사용 중.
+- **Task 11/12 import 경로**: `import { checkIsAdmin } from "@/lib/supabase/admin";`
+
+### 6.4 `createAdminSupabaseClient` (service-role 클라이언트) 존재 여부
+
+- **결론: 존재하지 않음** (`grep -rn "createAdminSupabaseClient\|createAdminClient" packages/web` → 0건).
+- 현재 admin route는 모두 `createSupabaseServerClient()` (anon + 쿠키)만 사용.
+- **영향**: §5 Wave 0.5 산출물대로 `packages/web/lib/supabase/admin-server.ts`에 신규 service_role 유틸을 만들어야 함.
+- **단 Wave 2 한정 대안**: `update_magazine_status` RPC가 `SECURITY DEFINER`라면, anon 클라이언트로도 호출 가능. RPC 도입 시 service_role 클라이언트 신규 생성을 **선택 사항**으로 격하 가능 (단, RPC 내부에서 `checkIsAdmin(p_admin_user_id)` 검증을 권장).
+
+### 6.5 `AdminEmptyState` 사용 패턴
+
+- **실제 경로**: `packages/web/lib/components/admin/common/AdminEmptyState.tsx` (스펙 §5 Wave 0.5에 기재된 `shared/` 경로는 **오타** — `common/` 으로 정정 필요).
+- **Import 패턴**: `import { AdminEmptyState } from "@/lib/components/admin/common";` (배럴 export 사용).
+- **Props**: `icon`, `title`, `description`.
+- **기존 사용처 (5개)**: `server-logs`, `pipeline-logs`, `ai-cost`, `ai-audit` 페이지에서 동일 패턴으로 적용. (`audit-log`는 본 PR Wave 1에서 추가 예정.)
+- **Wave 1 가이드**: 기존 5개 페이지 어느 것이든 모범 예시로 사용. 새 패턴 도입 금지.
+
+### 6.6 Rust audit 인프라
+
+- `packages/api-server/src/` 트리에 `audit` 명칭의 파일/모듈 **없음** (`grep -rn "audit" packages/api-server/src/` → 0건, 관련 모듈 부재 확인).
+- 디렉토리 구성: `batch/ bin/ config.rs constants.rs domains/ entities/ error.rs grpc/ handlers.rs lib.rs main.rs metrics/ middleware/ observability/ openapi.rs router.rs services/ tests/ utils/`.
+- **결론**: Rust 쪽은 audit 인프라가 전무 → **#152 별도 이슈로 분리**한다는 §2.2 결정이 정확. 본 PR에서 다루지 않음.
+
+### 6.7 후속 task 영향 요약
+
+| 후속 Task              | 본 조사로 인한 변경                                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Task 7 (migration)     | **`is_admin(UUID)` 함수 정의를 migration 파일에 추가** (§6.1 정의 사용). `approved_by`/`rejection_reason` 추가는 동일. |
+| Task 7 (RLS 정책)      | `admin_can_update_magazines` 정책의 `public.is_admin(auth.uid())` 호출은 함수 추가 후 정상 동작.                       |
+| Task 11/12 (API route) | `import { checkIsAdmin } from "@/lib/supabase/admin"` 사용. service_role 클라이언트 신규 생성은 RPC 도입 시 선택.      |
+| Wave 1 (empty state)   | `AdminEmptyState` 경로는 `common/` (스펙 §5의 `shared/` 표기는 정정 필요). 기존 5개 사용처를 모범 예시로.              |
+| #152 분리 결정         | Rust audit 인프라 부재 재확인 → 별도 이슈 처리 결정 유지.                                                              |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
+++ b/docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md
@@ -65,8 +65,8 @@
 
 | 분리 이슈                                   | 사유                                                                         |
 | ------------------------------------------- | ---------------------------------------------------------------------------- |
-| **#152 Rust API audit 통합** (신규)         | `picks`, `post status` 등 Rust route의 audit은 Rust 서버 수정 필요. 별도 PR. |
-| **#153 entities/seed 실데이터 강화** (신규) | "점검"은 unbounded scope. 발견 시 개별 이슈화.                               |
+| **#237 Rust API audit 통합** (신규)         | `picks`, `post status` 등 Rust route의 audit은 Rust 서버 수정 필요. 별도 PR. |
+| **#238 entities/seed 실데이터 강화** (신규) | "점검"은 unbounded scope. 발견 시 개별 이슈화.                               |
 | **Editorial 승인 워크플로우** (추후 이슈)   | `editorial_posts` 테이블 신규 + 승인 흐름 = 별도 스펙.                       |
 | **Magazine 알림/rollback/역할 세분화**      | Wave 2 내 defer. 후속 이슈로.                                                |
 
@@ -75,7 +75,7 @@
 이 PR 머지 후 #151이 "closed"되기 위한 조건:
 
 - Wave 1/2/3 모두 머지
-- Issue body에 남은 작업(#152, #153, editorial 등) 링크 추가
+- Issue body에 남은 작업(#237, #238, editorial 등) 링크 추가
 - PR 설명에 "이 PR로 끝나지 않는 항목" 섹션 명시
 
 ---
@@ -230,7 +230,7 @@ GRANT EXECUTE ON FUNCTION public.update_magazine_status TO authenticated;
    - 없으면 **신규 `createAdminSupabaseClient()` 유틸** 생성 (service_role + 쿠키 미사용)
    - 파일: `packages/web/lib/supabase/admin-server.ts`
 2. 기존 `AdminEmptyState` 컴포넌트 props/variants 확인 (`packages/web/lib/components/admin/common/AdminEmptyState.tsx` 존재 확인)
-3. Rust API에 audit 관련 구조 존재 여부 재확인 (#152 범위 확정용)
+3. Rust API에 audit 관련 구조 존재 여부 재확인 (#237 범위 확정용)
 
 **산출물**: 코드 변경 없음. 조사 결과 스펙에 주석 형태로 남김 (본 문서 6절).
 
@@ -315,7 +315,7 @@ packages/web/lib/hooks/admin/
   - Wave 2에서 신규로 추가되는 magazine status → RPC가 처리하므로 자동 커버
   - `reports-status` (Next.js route 여부 확인 필요)
   - `post-images`, `post-spots` (조회만 있을 수 있음)
-- **Rust route(`picks` CRUD, `posts/status`)는 이 PR에서 다루지 않음** → #152로 이관
+- **Rust route(`picks` CRUD, `posts/status`)는 이 PR에서 다루지 않음** → #237로 이관
 
 **변경**: 누락된 Next.js route handler에 `writeAuditLog({ action, target_table, target_id, before, after, metadata })` 추가.
 
@@ -383,7 +383,7 @@ packages/web/lib/hooks/admin/
 
 - `packages/api-server/src/` 트리에 `audit` 명칭의 파일/모듈 **없음** (`grep -rn "audit" packages/api-server/src/` → 0건, 관련 모듈 부재 확인).
 - 디렉토리 구성: `batch/ bin/ config.rs constants.rs domains/ entities/ error.rs grpc/ handlers.rs lib.rs main.rs metrics/ middleware/ observability/ openapi.rs router.rs services/ tests/ utils/`.
-- **결론**: Rust 쪽은 audit 인프라가 전무 → **#152 별도 이슈로 분리**한다는 §2.2 결정이 정확. 본 PR에서 다루지 않음.
+- **결론**: Rust 쪽은 audit 인프라가 전무 → **#237 별도 이슈로 분리**한다는 §2.2 결정이 정확. 본 PR에서 다루지 않음.
 
 ### 6.7 후속 task 영향 요약
 
@@ -393,7 +393,7 @@ packages/web/lib/hooks/admin/
 | Task 7 (RLS 정책)      | `admin_can_update_magazines` 정책의 `public.is_admin(auth.uid())` 호출은 함수 추가 후 정상 동작.                       |
 | Task 11/12 (API route) | `import { checkIsAdmin } from "@/lib/supabase/admin"` 사용. service_role 클라이언트 신규 생성은 RPC 도입 시 선택.      |
 | Wave 1 (empty state)   | `AdminEmptyState` 경로는 `common/` (스펙 §5의 `shared/` 표기는 정정 필요). 기존 5개 사용처를 모범 예시로.              |
-| #152 분리 결정         | Rust audit 인프라 부재 재확인 → 별도 이슈 처리 결정 유지.                                                              |
+| #237 분리 결정         | Rust audit 인프라 부재 재확인 → 별도 이슈 처리 결정 유지.                                                              |
 
 ---
 
@@ -459,9 +459,9 @@ packages/web/lib/hooks/admin/
   4. `feat(admin): wave 2b API — magazine 승인 엔드포인트`
   5. `feat(admin): wave 2c UI — magazine 승인 탭 + 테이블`
   6. `feat(admin): wave 3 Next.js audit 갭 보완`
-  7. `docs(issue): #151 분리 이슈(#152/#153) 링크 및 완료 기준`
+  7. `docs(issue): #151 분리 이슈(#237/#238) 링크 및 완료 기준`
 - 리뷰 → **dev 브랜치로 머지 1 PR** (feature/151 → dev, main은 GIT-WORKFLOW 따라 dev→main PR로 별도 승격)
-- 후속: #152 (Rust audit), #153 (entities/seed 실데이터)
+- 후속: #237 (Rust audit), #238 (entities/seed 실데이터)
 
 ---
 
@@ -484,7 +484,7 @@ packages/web/lib/hooks/admin/
 | 위험                                                                          | 완화                                                                                   |
 | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
 | RLS 정책이 `public.is_admin(uuid)` 함수 가정 — 존재하지 않으면 migration 실패 | Wave 0.5에서 존재 확인. 없으면 migration에 함수 정의 포함 or admin role 체크 방식 변경 |
-| Orval 자동 생성 API에 magazine 추가가 맞물릴 수 있음                          | magazine 승인은 Next.js route라 Orval 영향 없음. Rust 쪽은 #152에서 처리               |
+| Orval 자동 생성 API에 magazine 추가가 맞물릴 수 있음                          | magazine 승인은 Next.js route라 Orval 영향 없음. Rust 쪽은 #237에서 처리               |
 | `#148 editorial OG fix`가 QA 브랜치에만 있어 관련 컴포넌트 충돌 가능          | QA 머지 완료 후 dev → feature 리베이스                                                 |
 | Magazine seed 데이터 부재로 E2E 테스트 어려움                                 | Playwright setup에서 fixture seed 스크립트 작성                                        |
 | 마이그레이션 순서 꼬임 (RPC가 컬럼보다 먼저)                                  | Migration 파일명 타임스탬프로 순서 보장                                                |
@@ -498,5 +498,5 @@ packages/web/lib/hooks/admin/
 - [ ] `warehouse.admin_audit_log`에 각 액션 레코드 생성
 - [ ] E2E 테스트 통과
 - [ ] PR #224 머지
-- [ ] 이슈 #152, #153 생성 + #151 본문에 링크
+- [ ] 이슈 #237, #238 생성 + #151 본문에 링크
 - [ ] `gstack /qa` 통과

--- a/packages/web/app/admin/audit-log/__tests__/page.test.tsx
+++ b/packages/web/app/admin/audit-log/__tests__/page.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * AuditLogPage empty state tests.
+ *
+ * Verifies that when the audit log returns no entries AND no filters are
+ * active, the page renders the shared <AdminEmptyState/> component instead
+ * of the data table. When filters are active or data exists, the table
+ * should be rendered as before.
+ */
+import React from "react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// --- Mocks for the data hook ---
+
+const useAuditLogListMock = vi.fn();
+
+vi.mock("@/lib/api/admin/audit-log-query", () => ({
+  useAuditLogList: (...args: unknown[]) => useAuditLogListMock(...args),
+}));
+
+// AuditDiffViewer is a heavyweight component; stub it out so we don't pull
+// non-essential deps (json diff libs etc.) into the unit test.
+vi.mock("@/lib/components/admin/audit-log/AuditDiffViewer", () => ({
+  AuditDiffViewer: () => <div data-testid="audit-diff-viewer-stub" />,
+}));
+
+import AuditLogPage from "../page";
+
+beforeEach(() => {
+  useAuditLogListMock.mockReset();
+});
+
+describe("AuditLogPage — empty state", () => {
+  test("renders AdminEmptyState when no data AND no filters active", () => {
+    useAuditLogListMock.mockReturnValue({
+      data: { data: [], pagination: undefined },
+      isLoading: false,
+    });
+
+    render(<AuditLogPage />);
+
+    // AdminEmptyState title from Task 3 spec
+    expect(screen.getByText("No audit log entries")).toBeInTheDocument();
+    // The data table's empty message should NOT be shown in the empty state
+    expect(
+      screen.queryByText("No audit log entries found")
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders the data table when there is at least one entry", () => {
+    useAuditLogListMock.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "row-1",
+            admin_user_id: "admin-1",
+            action: "create",
+            target_table: "artists",
+            target_id: "target-1",
+            before_state: null,
+            after_state: { name: "Foo" },
+            metadata: null,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        pagination: {
+          current_page: 1,
+          per_page: 30,
+          total_items: 1,
+          total_pages: 1,
+        },
+      },
+      isLoading: false,
+    });
+
+    render(<AuditLogPage />);
+
+    // The empty state title must NOT appear when rows are present
+    expect(screen.queryByText("No audit log entries")).not.toBeInTheDocument();
+    // Table is rendered: the row's truncated target_id from fixture appears
+    expect(screen.getByText("target-1")).toBeInTheDocument();
+  });
+
+  test("does NOT render empty state when data is empty but a filter is active", () => {
+    useAuditLogListMock.mockReturnValue({
+      data: { data: [], pagination: undefined },
+      isLoading: false,
+    });
+
+    render(<AuditLogPage />);
+
+    // Sanity: empty state is visible at first (no filters yet)
+    expect(screen.getByText("No audit log entries")).toBeInTheDocument();
+
+    // Activate the action filter — page state now has a non-empty filter
+    const actionSelect = screen.getAllByRole("combobox")[0]!;
+    fireEvent.change(actionSelect, { target: { value: "create" } });
+
+    // With a filter active, the empty state must NOT be shown; the table's
+    // own empty placeholder takes over instead.
+    expect(screen.queryByText("No audit log entries")).not.toBeInTheDocument();
+    expect(screen.getByText("No audit log entries found")).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/admin/audit-log/page.tsx
+++ b/packages/web/app/admin/audit-log/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState } from "react";
+import { ClipboardListIcon } from "lucide-react";
 import {
   AdminDataTable,
   type Column,
   AdminStatusBadge,
   AdminPagination,
+  AdminEmptyState,
 } from "@/lib/components/admin/common";
 import {
   useAuditLogList,
@@ -68,6 +70,9 @@ export default function AuditLogPage() {
 
   const entries = data?.data ?? [];
   const pagination = data?.pagination;
+
+  const hasFilter = Boolean(actionFilter || tableFilter || dateFrom || dateTo);
+  const isEmpty = !isLoading && entries.length === 0 && !hasFilter;
 
   const columns: Column<AuditLogEntry>[] = [
     {
@@ -229,61 +234,74 @@ export default function AuditLogPage() {
         )}
       </div>
 
-      {/* Table + inline expand */}
-      <div className="space-y-0">
-        <AdminDataTable
-          columns={columns}
-          data={entries}
-          rowKey={(row) => row.id}
-          isLoading={isLoading}
-          emptyMessage="No audit log entries found"
-          onRowClick={(row) =>
-            setExpandedId((prev) => (prev === row.id ? null : row.id))
-          }
-        />
+      {/* Empty state: no entries AND no active filter */}
+      {isEmpty ? (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+          <AdminEmptyState
+            icon={<ClipboardListIcon className="w-12 h-12" />}
+            title="No audit log entries"
+            description="Admin actions will appear here as they happen. Apply a filter or trigger an admin action to populate this log."
+          />
+        </div>
+      ) : (
+        <>
+          {/* Table + inline expand */}
+          <div className="space-y-0">
+            <AdminDataTable
+              columns={columns}
+              data={entries}
+              rowKey={(row) => row.id}
+              isLoading={isLoading}
+              emptyMessage="No audit log entries found"
+              onRowClick={(row) =>
+                setExpandedId((prev) => (prev === row.id ? null : row.id))
+              }
+            />
 
-        {/* Expanded detail rows rendered below table */}
-        {expandedId &&
-          (() => {
-            const entry = entries.find((e) => e.id === expandedId);
-            if (!entry) return null;
-            return (
-              <div className="border border-t-0 border-gray-200 dark:border-gray-800 rounded-b-xl p-4 space-y-3 bg-gray-50 dark:bg-gray-900/50">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                    State diff for{" "}
-                    <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 rounded">
-                      {entry.target_table}/{truncate(entry.target_id, 8)}
-                    </code>
-                  </span>
-                  <button
-                    onClick={() => setExpandedId(null)}
-                    className="text-xs text-gray-400 hover:text-gray-600"
-                  >
-                    Close
-                  </button>
-                </div>
-                <AuditDiffViewer
-                  before={entry.before_state}
-                  after={entry.after_state}
-                />
-                {entry.metadata && (
-                  <div className="text-xs font-mono text-gray-500 bg-gray-100 dark:bg-gray-800 rounded p-2">
-                    <span className="font-medium">Metadata: </span>
-                    {JSON.stringify(entry.metadata).slice(0, 200)}
+            {/* Expanded detail rows rendered below table */}
+            {expandedId &&
+              (() => {
+                const entry = entries.find((e) => e.id === expandedId);
+                if (!entry) return null;
+                return (
+                  <div className="border border-t-0 border-gray-200 dark:border-gray-800 rounded-b-xl p-4 space-y-3 bg-gray-50 dark:bg-gray-900/50">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        State diff for{" "}
+                        <code className="text-xs bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                          {entry.target_table}/{truncate(entry.target_id, 8)}
+                        </code>
+                      </span>
+                      <button
+                        onClick={() => setExpandedId(null)}
+                        className="text-xs text-gray-400 hover:text-gray-600"
+                      >
+                        Close
+                      </button>
+                    </div>
+                    <AuditDiffViewer
+                      before={entry.before_state}
+                      after={entry.after_state}
+                    />
+                    {entry.metadata && (
+                      <div className="text-xs font-mono text-gray-500 bg-gray-100 dark:bg-gray-800 rounded p-2">
+                        <span className="font-medium">Metadata: </span>
+                        {JSON.stringify(entry.metadata).slice(0, 200)}
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            );
-          })()}
-      </div>
+                );
+              })()}
+          </div>
 
-      {pagination && (
-        <AdminPagination
-          currentPage={pagination.current_page}
-          totalPages={pagination.total_pages}
-          onPageChange={setPage}
-        />
+          {pagination && (
+            <AdminPagination
+              currentPage={pagination.current_page}
+              totalPages={pagination.total_pages}
+              onPageChange={setPage}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/web/app/admin/audit-log/page.tsx
+++ b/packages/web/app/admin/audit-log/page.tsx
@@ -218,7 +218,7 @@ export default function AuditLogPage() {
           />
         </div>
 
-        {(actionFilter || tableFilter || dateFrom || dateTo) && (
+        {hasFilter && (
           <button
             onClick={() => {
               setActionFilter("");
@@ -240,7 +240,7 @@ export default function AuditLogPage() {
           <AdminEmptyState
             icon={<ClipboardListIcon className="w-12 h-12" />}
             title="No audit log entries"
-            description="Admin actions will appear here as they happen. Apply a filter or trigger an admin action to populate this log."
+            description="Admin actions will appear here as they happen."
           />
         </div>
       ) : (

--- a/packages/web/app/admin/content/__tests__/page.test.tsx
+++ b/packages/web/app/admin/content/__tests__/page.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * ContentManagementPage empty state tests.
+ *
+ * Verifies that when the posts/reports lists return no entries (and no
+ * filter is active), the page renders the shared <AdminEmptyState/>
+ * component for each tab. When data is present, the corresponding table
+ * is rendered instead.
+ */
+import React from "react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// --- Mocks for next/navigation (drives the active tab) ---
+
+const searchParamsRef = { current: new URLSearchParams() };
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsRef.current,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// --- Mocks for the data hooks ---
+
+const useAdminPostListMock = vi.fn();
+const useAdminReportListMock = vi.fn();
+
+vi.mock("@/lib/hooks/admin/useAdminPosts", () => ({
+  useAdminPostList: (...args: unknown[]) => useAdminPostListMock(...args),
+  useUpdatePostStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/lib/hooks/admin/useAdminReports", () => ({
+  useAdminReportList: (...args: unknown[]) => useAdminReportListMock(...args),
+  useUpdateReportStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+// AdminPostTable / ReportTable are not the unit under test — replace with
+// thin stubs so that the table's own "No posts found" / "No reports found"
+// fallbacks don't collide with the page-level empty state we're verifying.
+vi.mock("@/lib/components/admin/content/AdminPostTable", () => ({
+  AdminPostTable: ({ data }: { data: unknown[] }) => (
+    <div data-testid="admin-post-table" data-rows={data.length} />
+  ),
+}));
+
+vi.mock("@/lib/components/admin/content/ReportTable", () => ({
+  ReportTable: ({ data }: { data: unknown[] }) => (
+    <div data-testid="report-table" data-rows={data.length} />
+  ),
+}));
+
+import ContentManagementPage from "../page";
+
+beforeEach(() => {
+  useAdminPostListMock.mockReset();
+  useAdminReportListMock.mockReset();
+  searchParamsRef.current = new URLSearchParams();
+});
+
+describe("ContentManagementPage — posts tab empty state", () => {
+  test("renders AdminEmptyState when posts data is empty", () => {
+    searchParamsRef.current = new URLSearchParams();
+    useAdminPostListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+    useAdminReportListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+
+    render(<ContentManagementPage />);
+
+    expect(screen.getByText("No posts found")).toBeInTheDocument();
+    expect(
+      screen.getByText("Posts submitted by users will appear here.")
+    ).toBeInTheDocument();
+    // Table stub must not be rendered when empty state is up
+    expect(screen.queryByTestId("admin-post-table")).not.toBeInTheDocument();
+  });
+
+  test("renders AdminPostTable when posts data has rows", () => {
+    useAdminPostListMock.mockReturnValue({
+      data: {
+        data: [{ id: "p1" }],
+        pagination: { current_page: 1, total_pages: 1 },
+      },
+      isLoading: false,
+    });
+    useAdminReportListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+
+    render(<ContentManagementPage />);
+
+    expect(screen.getByTestId("admin-post-table")).toBeInTheDocument();
+    expect(screen.queryByText("No posts found")).not.toBeInTheDocument();
+  });
+});
+
+describe("ContentManagementPage — reports tab empty state", () => {
+  test("renders AdminEmptyState when reports data is empty", () => {
+    searchParamsRef.current = new URLSearchParams("tab=reports");
+    useAdminPostListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+    useAdminReportListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+
+    render(<ContentManagementPage />);
+
+    expect(screen.getByText("No reports to review")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "User-submitted reports will appear here for moderation."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("report-table")).not.toBeInTheDocument();
+  });
+
+  test("renders ReportTable when reports data has rows", () => {
+    searchParamsRef.current = new URLSearchParams("tab=reports");
+    useAdminPostListMock.mockReturnValue({
+      data: { data: [], pagination: { current_page: 1, total_pages: 1 } },
+      isLoading: false,
+    });
+    useAdminReportListMock.mockReturnValue({
+      data: {
+        data: [{ id: "r1" }],
+        pagination: { current_page: 1, total_pages: 1 },
+      },
+      isLoading: false,
+    });
+
+    render(<ContentManagementPage />);
+
+    expect(screen.getByTestId("report-table")).toBeInTheDocument();
+    expect(screen.queryByText("No reports to review")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/app/admin/content/page.tsx
+++ b/packages/web/app/admin/content/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { FileTextIcon, FlagIcon } from "lucide-react";
 import { useAdminPostList } from "@/lib/hooks/admin/useAdminPosts";
 import { useAdminReportList } from "@/lib/hooks/admin/useAdminReports";
 import { AdminPostTable } from "@/lib/components/admin/content/AdminPostTable";
@@ -9,6 +10,7 @@ import { AdminPostTableSkeleton } from "@/lib/components/admin/content/AdminPost
 import { PostStatusFilter } from "@/lib/components/admin/content/PostStatusFilter";
 import { ReportTable } from "@/lib/components/admin/content/ReportTable";
 import { Pagination } from "@/lib/components/admin/audit/Pagination";
+import { AdminEmptyState } from "@/lib/components/admin/common";
 import type { PostStatus } from "@/lib/api/admin/posts";
 import type { ReportStatus } from "@/lib/api/admin/reports";
 
@@ -155,16 +157,24 @@ function ContentManagementContent() {
           {postListQuery.isLoading ? (
             <AdminPostTableSkeleton />
           ) : postListQuery.data ? (
-            <>
-              <AdminPostTable data={postListQuery.data.data} />
-              {postListQuery.data.pagination.total_pages > 1 && (
-                <Pagination
-                  currentPage={postListQuery.data.pagination.current_page}
-                  totalPages={postListQuery.data.pagination.total_pages}
-                  onPageChange={handlePageChange}
-                />
-              )}
-            </>
+            postListQuery.data.data.length === 0 && !postStatus ? (
+              <AdminEmptyState
+                icon={<FileTextIcon className="w-12 h-12" />}
+                title="No posts found"
+                description="Posts submitted by users will appear here."
+              />
+            ) : (
+              <>
+                <AdminPostTable data={postListQuery.data.data} />
+                {postListQuery.data.pagination.total_pages > 1 && (
+                  <Pagination
+                    currentPage={postListQuery.data.pagination.current_page}
+                    totalPages={postListQuery.data.pagination.total_pages}
+                    onPageChange={handlePageChange}
+                  />
+                )}
+              </>
+            )
           ) : (
             <AdminPostTableSkeleton />
           )}
@@ -210,16 +220,24 @@ function ContentManagementContent() {
           {reportListQuery.isLoading ? (
             <AdminPostTableSkeleton />
           ) : reportListQuery.data ? (
-            <>
-              <ReportTable data={reportListQuery.data.data} />
-              {reportListQuery.data.pagination.total_pages > 1 && (
-                <Pagination
-                  currentPage={reportListQuery.data.pagination.current_page}
-                  totalPages={reportListQuery.data.pagination.total_pages}
-                  onPageChange={handlePageChange}
-                />
-              )}
-            </>
+            reportListQuery.data.data.length === 0 && !reportStatus ? (
+              <AdminEmptyState
+                icon={<FlagIcon className="w-12 h-12" />}
+                title="No reports to review"
+                description="User-submitted reports will appear here for moderation."
+              />
+            ) : (
+              <>
+                <ReportTable data={reportListQuery.data.data} />
+                {reportListQuery.data.pagination.total_pages > 1 && (
+                  <Pagination
+                    currentPage={reportListQuery.data.pagination.current_page}
+                    totalPages={reportListQuery.data.pagination.total_pages}
+                    onPageChange={handlePageChange}
+                  />
+                )}
+              </>
+            )
           ) : (
             <AdminPostTableSkeleton />
           )}

--- a/packages/web/app/admin/content/page.tsx
+++ b/packages/web/app/admin/content/page.tsx
@@ -158,11 +158,13 @@ function ContentManagementContent() {
             <AdminPostTableSkeleton />
           ) : postListQuery.data ? (
             postListQuery.data.data.length === 0 && !postStatus ? (
-              <AdminEmptyState
-                icon={<FileTextIcon className="w-12 h-12" />}
-                title="No posts found"
-                description="Posts submitted by users will appear here."
-              />
+              <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+                <AdminEmptyState
+                  icon={<FileTextIcon className="w-12 h-12" />}
+                  title="No posts found"
+                  description="Posts submitted by users will appear here."
+                />
+              </div>
             ) : (
               <>
                 <AdminPostTable data={postListQuery.data.data} />
@@ -221,11 +223,13 @@ function ContentManagementContent() {
             <AdminPostTableSkeleton />
           ) : reportListQuery.data ? (
             reportListQuery.data.data.length === 0 && !reportStatus ? (
-              <AdminEmptyState
-                icon={<FlagIcon className="w-12 h-12" />}
-                title="No reports to review"
-                description="User-submitted reports will appear here for moderation."
-              />
+              <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+                <AdminEmptyState
+                  icon={<FlagIcon className="w-12 h-12" />}
+                  title="No reports to review"
+                  description="User-submitted reports will appear here for moderation."
+                />
+              </div>
             ) : (
               <>
                 <ReportTable data={reportListQuery.data.data} />

--- a/packages/web/app/admin/content/page.tsx
+++ b/packages/web/app/admin/content/page.tsx
@@ -1,26 +1,38 @@
 "use client";
 
-import { useCallback, Suspense } from "react";
+import { useCallback, useState, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { FileTextIcon, FlagIcon } from "lucide-react";
+import { FileTextIcon, FlagIcon, BookOpenIcon } from "lucide-react";
 import { useAdminPostList } from "@/lib/hooks/admin/useAdminPosts";
 import { useAdminReportList } from "@/lib/hooks/admin/useAdminReports";
+import { useAdminMagazineList } from "@/lib/hooks/admin/useAdminMagazineList";
+import { useUpdateMagazineStatus } from "@/lib/hooks/admin/useUpdateMagazineStatus";
 import { AdminPostTable } from "@/lib/components/admin/content/AdminPostTable";
 import { AdminPostTableSkeleton } from "@/lib/components/admin/content/AdminPostTableSkeleton";
 import { PostStatusFilter } from "@/lib/components/admin/content/PostStatusFilter";
 import { ReportTable } from "@/lib/components/admin/content/ReportTable";
+import {
+  MagazineApprovalTable,
+  MagazineStatusFilter,
+  RejectModal,
+} from "@/lib/components/admin/magazines";
 import { Pagination } from "@/lib/components/admin/audit/Pagination";
 import { AdminEmptyState } from "@/lib/components/admin/common";
 import type { PostStatus } from "@/lib/api/admin/posts";
 import type { ReportStatus } from "@/lib/api/admin/reports";
+import {
+  isValidMagazineStatus,
+  type MagazineStatus,
+} from "@/lib/api/admin/magazines";
 
 // ─── Tab types ───────────────────────────────────────────────────────────────
 
-type ContentTab = "posts" | "reports";
+type ContentTab = "posts" | "reports" | "magazines";
 
 const TAB_OPTIONS: { label: string; value: ContentTab }[] = [
   { label: "Posts", value: "posts" },
   { label: "Reports", value: "reports" },
+  { label: "Magazines", value: "magazines" },
 ];
 
 const REPORT_STATUS_OPTIONS: {
@@ -35,6 +47,90 @@ const REPORT_STATUS_OPTIONS: {
   { label: "Dismissed", value: "dismissed", dotColor: "bg-gray-400" },
 ];
 
+// ─── Magazine tab ────────────────────────────────────────────────────────────
+
+interface MagazinesTabProps {
+  status: MagazineStatus | undefined;
+  page: number;
+  onStatusChange: (next: MagazineStatus | undefined) => void;
+  onPageChange: (page: number) => void;
+}
+
+function MagazinesTab({
+  status,
+  page,
+  onStatusChange,
+  onPageChange,
+}: MagazinesTabProps) {
+  const [rejectTargetId, setRejectTargetId] = useState<string | null>(null);
+
+  const limit = 20;
+  const listQuery = useAdminMagazineList({ status, page, limit });
+  const mutation = useUpdateMagazineStatus();
+
+  const handleApprove = (id: string) =>
+    mutation.mutate({ id, status: "published" });
+  const handleReject = (id: string) => setRejectTargetId(id);
+  const handleRevert = (id: string) => mutation.mutate({ id, status: "draft" });
+
+  const handleConfirmReject = (reason: string) => {
+    if (!rejectTargetId) return;
+    mutation.mutate(
+      { id: rejectTargetId, status: "rejected", rejectionReason: reason },
+      { onSuccess: () => setRejectTargetId(null) }
+    );
+  };
+
+  const items = listQuery.data?.data ?? [];
+  const total = listQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const isEmpty = !listQuery.isLoading && items.length === 0;
+
+  return (
+    <div className="space-y-4">
+      <MagazineStatusFilter value={status} onChange={onStatusChange} />
+
+      {listQuery.isLoading ? (
+        <AdminPostTableSkeleton />
+      ) : isEmpty ? (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+          <AdminEmptyState
+            icon={<BookOpenIcon className="w-12 h-12" />}
+            title="No magazines in this bucket"
+            description="Magazines matching the current filter will appear here."
+          />
+        </div>
+      ) : (
+        <>
+          <MagazineApprovalTable
+            items={items}
+            onApprove={handleApprove}
+            onReject={handleReject}
+            onRevert={handleRevert}
+            mutatingId={
+              mutation.isPending ? (mutation.variables?.id ?? null) : null
+            }
+          />
+          {totalPages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={onPageChange}
+            />
+          )}
+        </>
+      )}
+
+      <RejectModal
+        open={!!rejectTargetId}
+        onClose={() => setRejectTargetId(null)}
+        onSubmit={handleConfirmReject}
+        submitting={mutation.isPending}
+      />
+    </div>
+  );
+}
+
 // ─── Inner content ───────────────────────────────────────────────────────────
 
 function ContentManagementContent() {
@@ -45,16 +141,21 @@ function ContentManagementContent() {
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
   const statusParam = searchParams.get("status");
 
-  // Posts state
   const postStatus =
     currentTab === "posts" && statusParam
       ? (statusParam as PostStatus)
       : undefined;
 
-  // Reports state
   const reportStatus =
     currentTab === "reports" && statusParam
       ? (statusParam as ReportStatus)
+      : undefined;
+
+  const magazineStatus =
+    currentTab === "magazines" &&
+    statusParam &&
+    isValidMagazineStatus(statusParam)
+      ? statusParam
       : undefined;
 
   const postListQuery = useAdminPostList({
@@ -109,6 +210,13 @@ function ContentManagementContent() {
     [updateUrl]
   );
 
+  const handleMagazineStatusChange = useCallback(
+    (status: MagazineStatus | undefined) => {
+      updateUrl({ status, page: "1" });
+    },
+    [updateUrl]
+  );
+
   const handlePageChange = useCallback(
     (page: number) => {
       updateUrl({ page: page.toString() });
@@ -123,7 +231,7 @@ function ContentManagementContent() {
           Content Management
         </h1>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-          Manage post visibility, status, and reports
+          Manage post visibility, status, reports, and magazine approval
         </p>
       </div>
 
@@ -246,6 +354,16 @@ function ContentManagementContent() {
             <AdminPostTableSkeleton />
           )}
         </>
+      )}
+
+      {/* Magazines tab */}
+      {currentTab === "magazines" && (
+        <MagazinesTab
+          status={magazineStatus}
+          page={currentPage}
+          onStatusChange={handleMagazineStatusChange}
+          onPageChange={handlePageChange}
+        />
       )}
     </div>
   );

--- a/packages/web/app/admin/editorial-candidates/__tests__/page.test.tsx
+++ b/packages/web/app/admin/editorial-candidates/__tests__/page.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * EditorialCandidatesPage empty state tests.
+ *
+ * Verifies that when the candidates list is empty, the page renders the
+ * shared <AdminEmptyState/> component (wrapped in a card container) instead
+ * of the table's own placeholder. When data is present, the table is
+ * rendered as before.
+ *
+ * The page has no filters — only pagination — so a simple length===0 check
+ * drives the empty state.
+ */
+import React from "react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// --- Mocks for next/navigation ---
+
+const searchParamsRef = { current: new URLSearchParams() };
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsRef.current,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// --- Mocks for the data hooks ---
+
+const useEditorialCandidatesMock = vi.fn();
+const useGenerateEditorialMock = vi.fn();
+
+vi.mock("@/lib/hooks/admin/useEditorialCandidates", () => ({
+  useEditorialCandidates: (...args: unknown[]) =>
+    useEditorialCandidatesMock(...args),
+  useGenerateEditorial: (...args: unknown[]) =>
+    useGenerateEditorialMock(...args),
+}));
+
+// CandidateTable is not the unit under test — replace with a thin stub so
+// that its own "No eligible posts found" placeholder doesn't collide with
+// the page-level empty state we're verifying.
+vi.mock("@/lib/components/admin/editorial/CandidateTable", () => ({
+  CandidateTable: ({ data }: { data: unknown[] }) => (
+    <div data-testid="candidate-table" data-rows={data.length} />
+  ),
+  CandidateTableSkeleton: () => <div data-testid="candidate-table-skeleton" />,
+}));
+
+import EditorialCandidatesPage from "../page";
+
+beforeEach(() => {
+  useEditorialCandidatesMock.mockReset();
+  useGenerateEditorialMock.mockReset();
+  useGenerateEditorialMock.mockReturnValue({
+    mutate: vi.fn(),
+    isError: false,
+    isSuccess: false,
+    error: null,
+  });
+  searchParamsRef.current = new URLSearchParams();
+});
+
+describe("EditorialCandidatesPage — empty state", () => {
+  test("renders AdminEmptyState when candidates list is empty", () => {
+    useEditorialCandidatesMock.mockReturnValue({
+      data: { data: [], total: 0, page: 1, per_page: 20 },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<EditorialCandidatesPage />);
+
+    expect(screen.getByText("No editorial candidates")).toBeInTheDocument();
+    // CandidateTable stub must not be rendered when empty state is up
+    expect(screen.queryByTestId("candidate-table")).not.toBeInTheDocument();
+  });
+
+  test("renders CandidateTable when at least one candidate exists", () => {
+    useEditorialCandidatesMock.mockReturnValue({
+      data: {
+        data: [
+          {
+            id: "post-1",
+            image_url: "https://example.com/img.jpg",
+            title: "Post 1",
+            artist_name: "Artist",
+            group_name: null,
+            context: null,
+            spot_count: 4,
+            min_solutions_per_spot: 1,
+            total_solution_count: 6,
+            view_count: 100,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+        page: 1,
+        per_page: 20,
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<EditorialCandidatesPage />);
+
+    expect(screen.getByTestId("candidate-table")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No editorial candidates")
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders skeleton while loading (empty state must not appear)", () => {
+    useEditorialCandidatesMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<EditorialCandidatesPage />);
+
+    expect(screen.getByTestId("candidate-table-skeleton")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No editorial candidates")
+    ).not.toBeInTheDocument();
+  });
+
+  test("does not render empty state on error (skeleton fallback shown)", () => {
+    useEditorialCandidatesMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<EditorialCandidatesPage />);
+
+    expect(
+      screen.queryByText("No editorial candidates")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("candidate-table-skeleton")).toBeInTheDocument();
+  });
+});

--- a/packages/web/app/admin/editorial-candidates/page.tsx
+++ b/packages/web/app/admin/editorial-candidates/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { Sparkles } from "lucide-react";
 import {
   useEditorialCandidates,
   useGenerateEditorial,
@@ -11,6 +12,7 @@ import {
   CandidateTableSkeleton,
 } from "@/lib/components/admin/editorial/CandidateTable";
 import { Pagination } from "@/lib/components/admin/audit/Pagination";
+import { AdminEmptyState } from "@/lib/components/admin/common";
 
 function EditorialCandidatesContent() {
   const searchParams = useSearchParams();
@@ -104,21 +106,31 @@ function EditorialCandidatesContent() {
       {candidatesQuery.isLoading || candidatesQuery.isError ? (
         <CandidateTableSkeleton />
       ) : candidatesQuery.data ? (
-        <>
-          <CandidateTable
-            data={candidatesQuery.data.data}
-            onGenerate={handleGenerate}
-            generatingId={generatingId}
-          />
-
-          {totalPages > 1 && (
-            <Pagination
-              currentPage={currentPage}
-              totalPages={totalPages}
-              onPageChange={handlePageChange}
+        candidatesQuery.data.data.length === 0 ? (
+          <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+            <AdminEmptyState
+              icon={<Sparkles className="w-12 h-12" />}
+              title="No editorial candidates"
+              description="Posts with 4+ spots and at least 1 solution per spot will appear here as candidates for editorial promotion."
             />
-          )}
-        </>
+          </div>
+        ) : (
+          <>
+            <CandidateTable
+              data={candidatesQuery.data.data}
+              onGenerate={handleGenerate}
+              generatingId={generatingId}
+            />
+
+            {totalPages > 1 && (
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+              />
+            )}
+          </>
+        )
       ) : (
         <CandidateTableSkeleton />
       )}

--- a/packages/web/app/admin/monitoring/__tests__/page.test.tsx
+++ b/packages/web/app/admin/monitoring/__tests__/page.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * MonitoringPage empty state tests.
+ *
+ * The monitoring dashboard renders three sections (KPI cards, charts,
+ * endpoint table). When the metrics snapshot reports no traffic at all
+ * (no `current` data + empty `history` + empty `endpoints`), the page
+ * should surface a single shared <AdminEmptyState/> wrapped in a card
+ * container instead of empty KPI/chart placeholders.
+ *
+ * When ANY data is present, the regular widgets are rendered.
+ */
+import React from "react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// --- Mocks for the data hook ---
+
+const useMonitoringMetricsMock = vi.fn();
+
+vi.mock("@/lib/hooks/admin/useMonitoring", () => ({
+  useMonitoringMetrics: (...args: unknown[]) =>
+    useMonitoringMetricsMock(...args),
+}));
+
+// Stub the heavy chart/table widgets so their internal placeholders
+// don't collide with the page-level empty state under test.
+vi.mock("@/lib/components/admin/monitoring/MetricsKPICards", () => ({
+  MetricsKPICards: ({ data }: { data: { total_requests: number } }) => (
+    <div data-testid="kpi-cards" data-total={data.total_requests} />
+  ),
+  MetricsKPICardsSkeleton: () => <div data-testid="kpi-cards-skeleton" />,
+}));
+
+vi.mock("@/lib/components/admin/monitoring/LatencyChart", () => ({
+  LatencyChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="latency-chart" data-points={data.length} />
+  ),
+  LatencyChartSkeleton: () => <div data-testid="latency-chart-skeleton" />,
+}));
+
+vi.mock("@/lib/components/admin/monitoring/ThroughputChart", () => ({
+  ThroughputChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="throughput-chart" data-points={data.length} />
+  ),
+  ThroughputChartSkeleton: () => (
+    <div data-testid="throughput-chart-skeleton" />
+  ),
+}));
+
+vi.mock("@/lib/components/admin/monitoring/EndpointTable", () => ({
+  EndpointTable: ({ data }: { data: unknown[] }) => (
+    <div data-testid="endpoint-table" data-rows={data.length} />
+  ),
+  EndpointTableSkeleton: () => <div data-testid="endpoint-table-skeleton" />,
+}));
+
+import MonitoringPage from "../page";
+
+beforeEach(() => {
+  useMonitoringMetricsMock.mockReset();
+});
+
+describe("MonitoringPage — empty state", () => {
+  test("renders AdminEmptyState when metrics snapshot has no traffic", () => {
+    useMonitoringMetricsMock.mockReturnValue({
+      data: {
+        uptime_seconds: 0,
+        total_requests: 0,
+        total_errors: 0,
+        current: undefined,
+        history: [],
+        endpoints: [],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MonitoringPage />);
+
+    expect(screen.getByText("No monitoring data yet")).toBeInTheDocument();
+    // Widgets must not render when the page-level empty state is up.
+    expect(screen.queryByTestId("kpi-cards")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("latency-chart")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("throughput-chart")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("endpoint-table")).not.toBeInTheDocument();
+  });
+
+  test("renders KPI/charts/table when metrics contain data", () => {
+    useMonitoringMetricsMock.mockReturnValue({
+      data: {
+        uptime_seconds: 3600,
+        total_requests: 1234,
+        total_errors: 2,
+        current: {
+          rpm: 12,
+          error_count: 0,
+          error_rate: 0,
+          p50_ms: 30,
+          p95_ms: 90,
+          p99_ms: 150,
+        },
+        history: [
+          {
+            timestamp: 1_700_000_000,
+            rpm: 12,
+            error_count: 0,
+            p50_ms: 30,
+            p95_ms: 90,
+            p99_ms: 150,
+          },
+        ],
+        endpoints: [
+          { path: "/api/v1/posts", rpm: 6, error_rate: 0, p95_ms: 80 },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<MonitoringPage />);
+
+    expect(screen.getByTestId("kpi-cards")).toBeInTheDocument();
+    expect(screen.getByTestId("latency-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("throughput-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("endpoint-table")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No monitoring data yet")
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders skeletons while loading (empty state must not appear)", () => {
+    useMonitoringMetricsMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    render(<MonitoringPage />);
+
+    expect(screen.getByTestId("kpi-cards-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("latency-chart-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("throughput-chart-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("endpoint-table-skeleton")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No monitoring data yet")
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders error banner on error (no empty state)", () => {
+    useMonitoringMetricsMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(<MonitoringPage />);
+
+    expect(
+      screen.getByText(/Failed to load monitoring metrics/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No monitoring data yet")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/app/admin/monitoring/page.tsx
+++ b/packages/web/app/admin/monitoring/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { ActivityIcon } from "lucide-react";
 import { useMonitoringMetrics } from "@/lib/hooks/admin/useMonitoring";
+import { AdminEmptyState } from "@/lib/components/admin/common";
 import {
   MetricsKPICards,
   MetricsKPICardsSkeleton,
@@ -31,6 +33,15 @@ export default function MonitoringPage() {
     );
   }
 
+  // Snapshot has no traffic at all (no current sample, no history bucket,
+  // no per-endpoint row). Show a single shared empty state instead of
+  // four empty widgets stacked on top of each other.
+  const isEmpty =
+    !!data &&
+    !data.current &&
+    data.history.length === 0 &&
+    data.endpoints.length === 0;
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -42,33 +53,45 @@ export default function MonitoringPage() {
         )}
       </div>
 
-      {/* KPI Cards */}
-      {isLoading || !data ? (
-        <MetricsKPICardsSkeleton />
+      {isEmpty ? (
+        <div className="border border-gray-200 dark:border-gray-700 rounded-lg">
+          <AdminEmptyState
+            icon={<ActivityIcon className="w-12 h-12" />}
+            title="No monitoring data yet"
+            description="Backend traffic metrics will appear here once the API server starts handling requests. The dashboard auto-refreshes every 15 seconds."
+          />
+        </div>
       ) : (
-        <MetricsKPICards data={data} />
-      )}
+        <>
+          {/* KPI Cards */}
+          {isLoading || !data ? (
+            <MetricsKPICardsSkeleton />
+          ) : (
+            <MetricsKPICards data={data} />
+          )}
 
-      {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {isLoading || !data ? (
-          <>
-            <LatencyChartSkeleton />
-            <ThroughputChartSkeleton />
-          </>
-        ) : (
-          <>
-            <LatencyChart data={data.history} />
-            <ThroughputChart data={data.history} />
-          </>
-        )}
-      </div>
+          {/* Charts */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {isLoading || !data ? (
+              <>
+                <LatencyChartSkeleton />
+                <ThroughputChartSkeleton />
+              </>
+            ) : (
+              <>
+                <LatencyChart data={data.history} />
+                <ThroughputChart data={data.history} />
+              </>
+            )}
+          </div>
 
-      {/* Endpoint Table */}
-      {isLoading || !data ? (
-        <EndpointTableSkeleton />
-      ) : (
-        <EndpointTable data={data.endpoints} />
+          {/* Endpoint Table */}
+          {isLoading || !data ? (
+            <EndpointTableSkeleton />
+          ) : (
+            <EndpointTable data={data.endpoints} />
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/web/app/api/v1/admin/picks/[pickId]/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/picks/[pickId]/__tests__/route.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const checkIsAdmin = vi.fn();
+const writeAuditLogMock = vi.fn();
+const preSingle = vi.fn();
+const updateSingle = vi.fn();
+const deleteFn = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdmin(...args),
+}));
+
+vi.mock("@/lib/api/admin/audit-log", () => ({
+  writeAuditLog: (...args: unknown[]) => writeAuditLogMock(...args),
+}));
+
+let fromCallCount = 0;
+let secondChainMode: "update" | "delete" = "update";
+
+vi.mock("@/lib/supabase/server", () => {
+  function createPreChain() {
+    const chain: Record<string, unknown> = {};
+    ["select", "eq"].forEach((m) => {
+      chain[m] = () => chain;
+    });
+    chain.maybeSingle = (...args: unknown[]) => preSingle(...args);
+    return chain;
+  }
+  function createUpdateChain() {
+    const chain: Record<string, unknown> = {};
+    ["update", "eq", "select"].forEach((m) => {
+      chain[m] = () => chain;
+    });
+    chain.single = (...args: unknown[]) => updateSingle(...args);
+    return chain;
+  }
+  function createDeleteChain() {
+    const chain: Record<string, unknown> = {};
+    chain.delete = () => chain;
+    chain.eq = (...args: unknown[]) => deleteFn(...args);
+    return chain;
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: {
+        getUser: async () => ({ data: { user: { id: "admin-1" } } }),
+      },
+      from: () => {
+        fromCallCount++;
+        if (fromCallCount === 1) return createPreChain();
+        return secondChainMode === "delete"
+          ? createDeleteChain()
+          : createUpdateChain();
+      },
+    }),
+  };
+});
+
+function makePatchRequest(body: unknown) {
+  return new Request("http://localhost/api/v1/admin/picks/pick-1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+function makeDeleteRequest() {
+  return new Request("http://localhost/api/v1/admin/picks/pick-1", {
+    method: "DELETE",
+  }) as unknown as import("next/server").NextRequest;
+}
+
+beforeEach(() => {
+  checkIsAdmin.mockReset();
+  writeAuditLogMock.mockReset();
+  preSingle.mockReset();
+  updateSingle.mockReset();
+  deleteFn.mockReset();
+  fromCallCount = 0;
+});
+
+describe("PATCH /api/v1/admin/picks/:pickId", () => {
+  beforeEach(() => {
+    secondChainMode = "update";
+  });
+
+  it("returns 403 when caller is not admin", async () => {
+    checkIsAdmin.mockResolvedValue(false);
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest({ note: "x" }), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+    expect(res.status).toBe(403);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("writes pick_update audit with before/after and changed fields", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({
+      data: { id: "pick-1", note: "old" },
+      error: null,
+    });
+    updateSingle.mockResolvedValue({
+      data: { id: "pick-1", note: "new" },
+      error: null,
+    });
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest({ note: "new" }), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminUserId: "admin-1",
+        action: "pick_update",
+        targetTable: "decoded_picks",
+        targetId: "pick-1",
+        metadata: { fields: ["note"] },
+      })
+    );
+  });
+
+  it("skips audit on update error", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({
+      data: { id: "pick-1" },
+      error: null,
+    });
+    updateSingle.mockResolvedValue({ data: null, error: { message: "boom" } });
+
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makePatchRequest({ note: "x" }), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/v1/admin/picks/:pickId", () => {
+  beforeEach(() => {
+    secondChainMode = "delete";
+  });
+
+  it("returns 403 when caller is not admin", async () => {
+    checkIsAdmin.mockResolvedValue(false);
+    const { DELETE } = await import("../route");
+    const res = await DELETE(makeDeleteRequest(), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+    expect(res.status).toBe(403);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("writes pick_delete audit with captured beforeState", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({
+      data: { id: "pick-1", post_id: "p1" },
+      error: null,
+    });
+    deleteFn.mockResolvedValue({ error: null });
+
+    const { DELETE } = await import("../route");
+    const res = await DELETE(makeDeleteRequest(), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "pick_delete",
+        targetTable: "decoded_picks",
+        targetId: "pick-1",
+        beforeState: { id: "pick-1", post_id: "p1" },
+        afterState: null,
+      })
+    );
+  });
+
+  it("skips audit when delete errors", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({
+      data: { id: "pick-1" },
+      error: null,
+    });
+    deleteFn.mockResolvedValue({ error: { message: "boom" } });
+
+    const { DELETE } = await import("../route");
+    const res = await DELETE(makeDeleteRequest(), {
+      params: Promise.resolve({ pickId: "pick-1" }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
+++ b/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
@@ -65,7 +65,9 @@ export async function PATCH(
         : null;
   }
   if ("post_id" in body) {
-    if (typeof body.post_id !== "string" || body.post_id.length === 0) {
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (typeof body.post_id !== "string" || !uuidRegex.test(body.post_id)) {
       return NextResponse.json({ error: "invalid_post_id" }, { status: 400 });
     }
     updates.post_id = body.post_id;

--- a/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
+++ b/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
@@ -27,13 +27,49 @@ export async function PATCH(
   }
 
   const { pickId } = await params;
-  const body = await request.json();
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (rawBody === null || typeof rawBody !== "object") {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+  const body = rawBody as Record<string, unknown>;
   const updates: Record<string, unknown> = {};
 
-  if ("note" in body) updates.note = body.note;
-  if ("is_active" in body) updates.is_active = body.is_active;
-  if ("curated_by" in body) updates.curated_by = body.curated_by;
-  if ("post_id" in body) updates.post_id = body.post_id;
+  if ("note" in body) {
+    if (body.note !== null && typeof body.note !== "string") {
+      return NextResponse.json({ error: "invalid_note" }, { status: 400 });
+    }
+    updates.note =
+      typeof body.note === "string" ? body.note.slice(0, 2000) : null;
+  }
+  if ("is_active" in body) {
+    if (typeof body.is_active !== "boolean") {
+      return NextResponse.json({ error: "invalid_is_active" }, { status: 400 });
+    }
+    updates.is_active = body.is_active;
+  }
+  if ("curated_by" in body) {
+    if (body.curated_by !== null && typeof body.curated_by !== "string") {
+      return NextResponse.json(
+        { error: "invalid_curated_by" },
+        { status: 400 }
+      );
+    }
+    updates.curated_by =
+      typeof body.curated_by === "string"
+        ? body.curated_by.slice(0, 200)
+        : null;
+  }
+  if ("post_id" in body) {
+    if (typeof body.post_id !== "string" || body.post_id.length === 0) {
+      return NextResponse.json({ error: "invalid_post_id" }, { status: 400 });
+    }
+    updates.post_id = body.post_id;
+  }
 
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: "No fields to update" }, { status: 400 });
@@ -53,7 +89,8 @@ export async function PATCH(
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/picks] update error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   await writeAuditLog({
@@ -106,7 +143,8 @@ export async function DELETE(
     .eq("id", pickId);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/picks] delete error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   await writeAuditLog({

--- a/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
+++ b/packages/web/app/api/v1/admin/picks/[pickId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { checkIsAdmin } from "@/lib/supabase/admin";
+import { writeAuditLog } from "@/lib/api/admin/audit-log";
 
 /**
  * PATCH /api/v1/admin/picks/:pickId
@@ -38,6 +39,12 @@ export async function PATCH(
     return NextResponse.json({ error: "No fields to update" }, { status: 400 });
   }
 
+  const { data: before } = await supabase
+    .from("decoded_picks")
+    .select("*")
+    .eq("id", pickId)
+    .maybeSingle();
+
   const { data, error } = await supabase
     .from("decoded_picks")
     .update(updates)
@@ -48,6 +55,16 @@ export async function PATCH(
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
+
+  await writeAuditLog({
+    adminUserId: user.id,
+    action: "pick_update",
+    targetTable: "decoded_picks",
+    targetId: pickId,
+    beforeState: before ?? null,
+    afterState: data,
+    metadata: { fields: Object.keys(updates) },
+  });
 
   return NextResponse.json(data);
 }
@@ -77,6 +94,12 @@ export async function DELETE(
 
   const { pickId } = await params;
 
+  const { data: before } = await supabase
+    .from("decoded_picks")
+    .select("*")
+    .eq("id", pickId)
+    .maybeSingle();
+
   const { error } = await supabase
     .from("decoded_picks")
     .delete()
@@ -85,6 +108,15 @@ export async function DELETE(
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
+
+  await writeAuditLog({
+    adminUserId: user.id,
+    action: "pick_delete",
+    targetTable: "decoded_picks",
+    targetId: pickId,
+    beforeState: before ?? null,
+    afterState: null,
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/packages/web/app/api/v1/admin/picks/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/picks/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const checkIsAdmin = vi.fn();
+const upsertSingle = vi.fn();
+const preSingle = vi.fn();
+const writeAuditLogMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdmin(...args),
+}));
+
+vi.mock("@/lib/api/admin/audit-log", () => ({
+  writeAuditLog: (...args: unknown[]) => writeAuditLogMock(...args),
+}));
+
+vi.mock("@/lib/supabase/server", () => {
+  // Two distinct chains: one for the pre-read (maybeSingle) and one for the upsert (single).
+  function createPreChain() {
+    const chain: Record<string, unknown> = {};
+    ["select", "eq"].forEach((m) => {
+      chain[m] = () => chain;
+    });
+    chain.maybeSingle = (...args: unknown[]) => preSingle(...args);
+    return chain;
+  }
+  function createUpsertChain() {
+    const chain: Record<string, unknown> = {};
+    ["upsert", "select"].forEach((m) => {
+      chain[m] = () => chain;
+    });
+    chain.single = (...args: unknown[]) => upsertSingle(...args);
+    return chain;
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: {
+        getUser: async () => ({ data: { user: { id: "admin-1" } } }),
+      },
+      from: () => {
+        // Alternate between pre-read (first call) and upsert (second call).
+        fromCallCount++;
+        return fromCallCount === 1 ? createPreChain() : createUpsertChain();
+      },
+    }),
+  };
+});
+
+let fromCallCount = 0;
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/api/v1/admin/picks", {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as unknown as import("next/server").NextRequest;
+}
+
+beforeEach(() => {
+  checkIsAdmin.mockReset();
+  upsertSingle.mockReset();
+  preSingle.mockReset();
+  writeAuditLogMock.mockReset();
+  fromCallCount = 0;
+});
+
+describe("POST /api/v1/admin/picks", () => {
+  it("returns 403 when caller is not admin", async () => {
+    checkIsAdmin.mockResolvedValue(false);
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest({ post_id: "p1" }));
+    expect(res.status).toBe(403);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("writes pick_create audit on new date slot", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({ data: null, error: null });
+    upsertSingle.mockResolvedValue({
+      data: { id: "pick-1", post_id: "p1" },
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest({ post_id: "p1" }));
+
+    expect(res.status).toBe(201);
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminUserId: "admin-1",
+        action: "pick_create",
+        targetTable: "decoded_picks",
+        targetId: "pick-1",
+      })
+    );
+  });
+
+  it("writes pick_update audit when slot already occupied", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({
+      data: { id: "pick-old", post_id: "p_old" },
+      error: null,
+    });
+    upsertSingle.mockResolvedValue({
+      data: { id: "pick-old", post_id: "p1" },
+      error: null,
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest({ post_id: "p1" }));
+
+    expect(res.status).toBe(201);
+    expect(writeAuditLogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "pick_update" })
+    );
+  });
+
+  it("does not write audit log when insert errors", async () => {
+    checkIsAdmin.mockResolvedValue(true);
+    preSingle.mockResolvedValue({ data: null, error: null });
+    upsertSingle.mockResolvedValue({
+      data: null,
+      error: { message: "db boom" },
+    });
+
+    const { POST } = await import("../route");
+    const res = await POST(makeRequest({ post_id: "p1" }));
+
+    expect(res.status).toBe(500);
+    expect(writeAuditLogMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/v1/admin/picks/route.ts
+++ b/packages/web/app/api/v1/admin/picks/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { checkIsAdmin } from "@/lib/supabase/admin";
+import { writeAuditLog } from "@/lib/api/admin/audit-log";
 
 /**
  * GET /api/v1/admin/picks
@@ -95,12 +96,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "post_id is required" }, { status: 400 });
   }
 
+  const resolvedPickDate = pick_date || new Date().toISOString().slice(0, 10);
+
+  // Capture pre-state for upsert (null if pick_date slot was empty).
+  const { data: before } = await supabase
+    .from("decoded_picks")
+    .select("*")
+    .eq("pick_date", resolvedPickDate)
+    .maybeSingle();
+
   const { data, error } = await supabase
     .from("decoded_picks")
     .upsert(
       {
         post_id,
-        pick_date: pick_date || new Date().toISOString().slice(0, 10),
+        pick_date: resolvedPickDate,
         note: note || null,
         curated_by: curated_by || "editor",
       },
@@ -112,6 +122,15 @@ export async function POST(request: NextRequest) {
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
+
+  await writeAuditLog({
+    adminUserId: user.id,
+    action: before ? "pick_update" : "pick_create",
+    targetTable: "decoded_picks",
+    targetId: data.id,
+    beforeState: before ?? null,
+    afterState: data,
+  });
 
   return NextResponse.json(data, { status: 201 });
 }

--- a/packages/web/app/api/v1/admin/picks/route.ts
+++ b/packages/web/app/api/v1/admin/picks/route.ts
@@ -43,7 +43,8 @@ export async function GET(request: NextRequest) {
     .range(from, to);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/picks] list error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   return NextResponse.json({
@@ -120,7 +121,8 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/picks] upsert error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   await writeAuditLog({

--- a/packages/web/app/api/v1/admin/posts/magazines/[id]/status/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/[id]/status/__tests__/route.test.ts
@@ -141,16 +141,80 @@ describe("PATCH /api/v1/admin/posts/magazines/[id]/status", () => {
     expect(body.error).toBe("invalid_transition");
   });
 
-  it("maps unknown RPC error to 500", async () => {
+  it("maps unknown RPC error to 500 with generic message", async () => {
     checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
     rpc.mockResolvedValue({
       data: null,
-      error: { message: "kaboom" },
+      error: { message: "kaboom — raw db internals" },
     });
     const { PATCH } = await import("../route");
     const res = await PATCH(makeRequest({ status: "published" }), {
       params: Promise.resolve({ id: "m1" }),
     });
     expect(res.status).toBe(500);
+    const body = await res.json();
+    // Must not leak raw DB message to client.
+    expect(body.error).toBe("internal_error");
+    expect(body).not.toHaveProperty("message");
+  });
+
+  it("maps caller_not_admin from RPC to 403", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "caller_not_admin", code: "P0003" },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("forbidden");
+  });
+
+  it("maps caller_mismatch from RPC to 403", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "caller_mismatch", code: "P0003" },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects rejection_reason longer than 2000 chars before RPC", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    const { PATCH } = await import("../route");
+    const tooLong = "x".repeat(2001);
+    const res = await PATCH(
+      makeRequest({ status: "rejected", rejectionReason: tooLong }),
+      { params: Promise.resolve({ id: "m1" }) }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("rejection_reason_too_long");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("maps rejection_reason_too_long from RPC (defense-in-depth) to 400", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "rejection_reason_too_long", code: "P0001" },
+    });
+    const { PATCH } = await import("../route");
+    // Route pre-check won't fire (reason within limit), so the RPC
+    // branch is the one exercised.
+    const res = await PATCH(
+      makeRequest({ status: "rejected", rejectionReason: "ok" }),
+      { params: Promise.resolve({ id: "m1" }) }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("rejection_reason_too_long");
   });
 });

--- a/packages/web/app/api/v1/admin/posts/magazines/[id]/status/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/[id]/status/__tests__/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const checkIsAdmin = vi.fn();
+const rpc = vi.fn();
+
+vi.mock("@/lib/api/admin/auth", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdmin(...args),
+}));
+
+vi.mock("@/lib/supabase/admin-server", () => ({
+  createAdminSupabaseClient: () => ({ rpc }),
+}));
+
+function makeRequest(body: unknown) {
+  return new Request("http://localhost/x", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/v1/admin/posts/magazines/[id]/status", () => {
+  beforeEach(() => {
+    checkIsAdmin.mockReset();
+    rpc.mockReset();
+  });
+
+  it("returns 403 when not admin", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: false });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on invalid_json body", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    const { PATCH } = await import("../route");
+    const req = new Request("http://localhost/x", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: "{not-json",
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "m1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_json");
+  });
+
+  it("rejects invalid status with 400", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "foo" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_status");
+  });
+
+  it("requires rejection_reason when rejecting (empty string)", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest({ status: "rejected", rejectionReason: "   " }),
+      { params: Promise.resolve({ id: "m1" }) }
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("rejection_reason_required");
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("approves pending → published via RPC", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: [{ id: "m1", status: "published" }],
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("update_magazine_status", {
+      p_magazine_id: "m1",
+      p_new_status: "published",
+      p_admin_user_id: "admin-1",
+    });
+  });
+
+  it("passes rejection_reason through RPC", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: [{ id: "m1", status: "rejected" }],
+      error: null,
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(
+      makeRequest({ status: "rejected", rejectionReason: "low quality" }),
+      { params: Promise.resolve({ id: "m1" }) }
+    );
+    expect(res.status).toBe(200);
+    expect(rpc).toHaveBeenCalledWith("update_magazine_status", {
+      p_magazine_id: "m1",
+      p_new_status: "rejected",
+      p_admin_user_id: "admin-1",
+      p_rejection_reason: "low quality",
+    });
+  });
+
+  it("maps magazine_not_found to 404", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "magazine_not_found", code: "P0002" },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("maps invalid_transition to 409", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: {
+        message: "invalid_transition: draft -> published",
+        code: "P0001",
+      },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_transition");
+  });
+
+  it("maps unknown RPC error to 500", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rpc.mockResolvedValue({
+      data: null,
+      error: { message: "kaboom" },
+    });
+    const { PATCH } = await import("../route");
+    const res = await PATCH(makeRequest({ status: "published" }), {
+      params: Promise.resolve({ id: "m1" }),
+    });
+    expect(res.status).toBe(500);
+  });
+});

--- a/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
@@ -54,6 +54,13 @@ export async function PATCH(
         { status: 400 }
       );
     }
+    if (reason.length > 2000) {
+      return NextResponse.json(
+        { error: "rejection_reason_too_long" },
+        { status: 400 }
+      );
+    }
+    body.rejectionReason = reason;
   }
 
   const supabase = createAdminSupabaseClient();
@@ -88,7 +95,20 @@ export async function PATCH(
         { status: 400 }
       );
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    if (error.message?.includes("rejection_reason_too_long")) {
+      return NextResponse.json(
+        { error: "rejection_reason_too_long" },
+        { status: 400 }
+      );
+    }
+    if (
+      error.message?.includes("caller_not_admin") ||
+      error.message?.includes("caller_mismatch")
+    ) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    console.error("[admin/magazines/status] RPC error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   return NextResponse.json({ data }, { status: 200 });

--- a/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+import { createAdminSupabaseClient } from "@/lib/supabase/admin-server";
+import { checkIsAdmin } from "@/lib/api/admin/auth";
+import { isValidMagazineStatus } from "@/lib/api/admin/magazines";
+
+interface PatchBody {
+  status: string;
+  rejectionReason?: string;
+}
+
+/**
+ * PATCH /api/v1/admin/posts/magazines/[id]/status
+ *
+ * update_magazine_status RPC를 호출해 상태 전환 + audit log를 원자적으로 처리.
+ * Body: { status, rejectionReason? }.
+ *
+ * 오류 매핑:
+ * - magazine_not_found → 404
+ * - invalid_transition: a -> b → 409
+ * - rejection_reason_required → 400 (서버측 중복 가드)
+ * - 나머지 → 500
+ */
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await checkIsAdmin();
+  if (!auth.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  let body: PatchBody;
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (
+    !body ||
+    typeof body.status !== "string" ||
+    !isValidMagazineStatus(body.status)
+  ) {
+    return NextResponse.json({ error: "invalid_status" }, { status: 400 });
+  }
+
+  if (body.status === "rejected") {
+    const reason = body.rejectionReason?.trim();
+    if (!reason) {
+      return NextResponse.json(
+        { error: "rejection_reason_required" },
+        { status: 400 }
+      );
+    }
+  }
+
+  const supabase = createAdminSupabaseClient();
+  const rpcArgs: {
+    p_magazine_id: string;
+    p_new_status: string;
+    p_admin_user_id: string;
+    p_rejection_reason?: string;
+  } = {
+    p_magazine_id: id,
+    p_new_status: body.status,
+    p_admin_user_id: auth.userId,
+  };
+  if (body.rejectionReason !== undefined) {
+    rpcArgs.p_rejection_reason = body.rejectionReason;
+  }
+  const { data, error } = await supabase.rpc("update_magazine_status", rpcArgs);
+
+  if (error) {
+    if (error.message?.includes("magazine_not_found")) {
+      return NextResponse.json({ error: "not_found" }, { status: 404 });
+    }
+    if (error.message?.includes("invalid_transition")) {
+      return NextResponse.json(
+        { error: "invalid_transition", message: error.message },
+        { status: 409 }
+      );
+    }
+    if (error.message?.includes("rejection_reason_required")) {
+      return NextResponse.json(
+        { error: "rejection_reason_required" },
+        { status: 400 }
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data }, { status: 200 });
+}

--- a/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/[id]/status/route.ts
@@ -84,8 +84,17 @@ export async function PATCH(
       return NextResponse.json({ error: "not_found" }, { status: 404 });
     }
     if (error.message?.includes("invalid_transition")) {
+      // Parse "invalid_transition: <from> -> <to>" into structured fields so
+      // we don't leak the raw PostgreSQL exception prefix to the client.
+      const match = error.message.match(
+        /invalid_transition:\s*(\w+)\s*->\s*(\w+)/
+      );
       return NextResponse.json(
-        { error: "invalid_transition", message: error.message },
+        {
+          error: "invalid_transition",
+          from: match?.[1] ?? null,
+          to: match?.[2] ?? null,
+        },
         { status: 409 }
       );
     }

--- a/packages/web/app/api/v1/admin/posts/magazines/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const checkIsAdmin = vi.fn();
+const rangeFn = vi.fn();
+
+vi.mock("@/lib/api/admin/auth", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdmin(...args),
+}));
+
+vi.mock("@/lib/supabase/server", () => {
+  const chain: Record<string, unknown> = {};
+  ["select", "eq", "order"].forEach((m) => {
+    chain[m] = () => chain;
+  });
+  chain.range = (...args: unknown[]) => rangeFn(...args);
+  return {
+    createSupabaseServerClient: async () => ({
+      from: () => chain,
+    }),
+  };
+});
+
+function makeRequest(url: string) {
+  return new Request(url);
+}
+
+describe("GET /api/v1/admin/posts/magazines", () => {
+  beforeEach(() => {
+    checkIsAdmin.mockReset();
+    rangeFn.mockReset();
+  });
+
+  it("returns 403 when not admin", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: false });
+    const { GET } = await import("../route");
+    const res = await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines")
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on invalid status", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    const { GET } = await import("../route");
+    const res = await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines?status=foo")
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_status");
+  });
+
+  it("returns list with pending filter", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rangeFn.mockResolvedValue({
+      data: [
+        {
+          id: "m1",
+          title: "t",
+          status: "pending",
+          author_id: "u1",
+          submitted_at: "2026-04-17T00:00:00Z",
+          published_at: null,
+          rejection_reason: null,
+          approved_by: null,
+        },
+      ],
+      count: 1,
+      error: null,
+    });
+    const { GET } = await import("../route");
+    const res = await GET(
+      makeRequest(
+        "http://localhost/api/v1/admin/posts/magazines?status=pending&page=2&limit=10"
+      )
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(1);
+    expect(body.page).toBe(2);
+    expect(body.limit).toBe(10);
+    expect(body.data).toHaveLength(1);
+    expect(rangeFn).toHaveBeenCalledWith(10, 19);
+  });
+
+  it("returns 500 when query errors", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rangeFn.mockResolvedValue({
+      data: null,
+      count: null,
+      error: { message: "db boom" },
+    });
+    const { GET } = await import("../route");
+    const res = await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines")
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("clamps limit to 100 max and 1 min", async () => {
+    checkIsAdmin.mockResolvedValue({ isAdmin: true, userId: "admin-1" });
+    rangeFn.mockResolvedValue({ data: [], count: 0, error: null });
+    const { GET } = await import("../route");
+    await GET(
+      makeRequest("http://localhost/api/v1/admin/posts/magazines?limit=9999")
+    );
+    expect(rangeFn).toHaveBeenCalledWith(0, 99);
+  });
+});

--- a/packages/web/app/api/v1/admin/posts/magazines/route.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/api/admin/auth";
+import {
+  MAGAZINE_STATUSES,
+  isValidMagazineStatus,
+  type AdminMagazineListResponse,
+} from "@/lib/api/admin/magazines";
+
+/**
+ * GET /api/v1/admin/posts/magazines
+ *
+ * Admin magazine 목록 (페이지네이션 + status 필터).
+ * Query: ?status=draft|pending|published|rejected&page=1&limit=20
+ */
+export async function GET(req: Request) {
+  const auth = await checkIsAdmin();
+  if (!auth.isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const status = url.searchParams.get("status");
+  const page = Math.max(1, parseInt(url.searchParams.get("page") ?? "1", 10));
+  const limit = Math.min(
+    100,
+    Math.max(1, parseInt(url.searchParams.get("limit") ?? "20", 10))
+  );
+
+  if (status && !isValidMagazineStatus(status)) {
+    return NextResponse.json(
+      {
+        error: "invalid_status",
+        validStatuses: MAGAZINE_STATUSES,
+      },
+      { status: 400 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  let query = supabase
+    .from("post_magazines")
+    .select(
+      "id,title,status,keyword,subtitle,published_at,rejection_reason,approved_by,created_at,updated_at",
+      { count: "exact" }
+    );
+
+  if (status) query = query.eq("status", status);
+
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const { data, count, error } = await query
+    .order("created_at", { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const response: AdminMagazineListResponse = {
+    data: (data ?? []) as AdminMagazineListResponse["data"],
+    total: count ?? 0,
+    page,
+    limit,
+  };
+  return NextResponse.json(response);
+}

--- a/packages/web/app/api/v1/admin/posts/magazines/route.ts
+++ b/packages/web/app/api/v1/admin/posts/magazines/route.ts
@@ -55,7 +55,8 @@ export async function GET(req: Request) {
     .range(from, to);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    console.error("[admin/magazines] list error:", error.message);
+    return NextResponse.json({ error: "internal_error" }, { status: 500 });
   }
 
   const response: AdminMagazineListResponse = {

--- a/packages/web/lib/api/admin/__tests__/auth.test.ts
+++ b/packages/web/lib/api/admin/__tests__/auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getUser = vi.fn();
+const dbCheckIsAdmin = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser },
+  }),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => dbCheckIsAdmin(...args),
+}));
+
+describe("checkIsAdmin (api wrapper)", () => {
+  beforeEach(() => {
+    getUser.mockReset();
+    dbCheckIsAdmin.mockReset();
+  });
+
+  it("returns { isAdmin: false } when no user session", async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    const { checkIsAdmin } = await import("../auth");
+    const res = await checkIsAdmin();
+    expect(res.isAdmin).toBe(false);
+    expect(res.userId).toBeUndefined();
+    expect(dbCheckIsAdmin).not.toHaveBeenCalled();
+  });
+
+  it("returns { isAdmin: true, userId } when db says admin", async () => {
+    getUser.mockResolvedValue({ data: { user: { id: "u-1" } } });
+    dbCheckIsAdmin.mockResolvedValue(true);
+    const { checkIsAdmin } = await import("../auth");
+    const res = await checkIsAdmin();
+    expect(res).toEqual({ isAdmin: true, userId: "u-1" });
+  });
+
+  it("returns { isAdmin: false } when user exists but not admin", async () => {
+    getUser.mockResolvedValue({ data: { user: { id: "u-2" } } });
+    dbCheckIsAdmin.mockResolvedValue(false);
+    const { checkIsAdmin } = await import("../auth");
+    const res = await checkIsAdmin();
+    expect(res.isAdmin).toBe(false);
+    expect(res.userId).toBeUndefined();
+  });
+});

--- a/packages/web/lib/api/admin/__tests__/magazines.test.ts
+++ b/packages/web/lib/api/admin/__tests__/magazines.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAGAZINE_STATUSES,
+  isValidMagazineStatus,
+  type MagazineStatus,
+} from "../magazines";
+
+describe("MagazineStatus", () => {
+  it("exports all 4 statuses", () => {
+    expect(MAGAZINE_STATUSES).toEqual([
+      "draft",
+      "pending",
+      "published",
+      "rejected",
+    ]);
+  });
+
+  it("isValidMagazineStatus returns true for valid", () => {
+    expect(isValidMagazineStatus("pending")).toBe(true);
+    expect(isValidMagazineStatus("published")).toBe(true);
+    expect(isValidMagazineStatus("draft")).toBe(true);
+    expect(isValidMagazineStatus("rejected")).toBe(true);
+  });
+
+  it("isValidMagazineStatus returns false for invalid", () => {
+    expect(isValidMagazineStatus("foo")).toBe(false);
+    expect(isValidMagazineStatus("")).toBe(false);
+    expect(isValidMagazineStatus("PUBLISHED")).toBe(false);
+  });
+
+  it("MagazineStatus type narrows correctly", () => {
+    const value: string = "pending";
+    if (isValidMagazineStatus(value)) {
+      const narrowed: MagazineStatus = value;
+      expect(narrowed).toBe("pending");
+    }
+  });
+});

--- a/packages/web/lib/api/admin/audit-log.ts
+++ b/packages/web/lib/api/admin/audit-log.ts
@@ -28,6 +28,12 @@ export async function writeAuditLog(entry: AuditLogEntry) {
     });
 
   if (error) {
+    // TODO(#237): surface this to the caller or retry. Today picks CRUD
+    // writes audit as a fire-and-forget step after the mutation commits,
+    // so a failed audit insert leaves a silent gap in the log. The
+    // magazine status path avoids this by wrapping mutation + audit in
+    // update_magazine_status() RPC. Fold picks into the same pattern
+    // when Rust audit integration lands.
     console.error("[audit-log] Failed to write:", error.message);
   }
 }

--- a/packages/web/lib/api/admin/auth.ts
+++ b/packages/web/lib/api/admin/auth.ts
@@ -1,0 +1,24 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin as dbCheckIsAdmin } from "@/lib/supabase/admin";
+
+/**
+ * Route handler용 어드민 인증 래퍼.
+ *
+ * 세션 유저 + users.is_admin 플래그를 한 번에 확인하고 표준화된 결과를
+ * 반환한다. `@/lib/supabase/admin.checkIsAdmin(supabase, userId)`를
+ * 내부에서 호출한다.
+ *
+ * @returns `{ isAdmin: true, userId }` 어드민일 때, 그렇지 않으면 `{ isAdmin: false }`.
+ */
+export async function checkIsAdmin(): Promise<
+  { isAdmin: true; userId: string } | { isAdmin: false; userId?: undefined }
+> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { isAdmin: false };
+
+  const ok = await dbCheckIsAdmin(supabase, user.id);
+  return ok ? { isAdmin: true, userId: user.id } : { isAdmin: false };
+}

--- a/packages/web/lib/api/admin/magazines.ts
+++ b/packages/web/lib/api/admin/magazines.ts
@@ -1,0 +1,32 @@
+export const MAGAZINE_STATUSES = [
+  "draft",
+  "pending",
+  "published",
+  "rejected",
+] as const;
+
+export type MagazineStatus = (typeof MAGAZINE_STATUSES)[number];
+
+export function isValidMagazineStatus(s: string): s is MagazineStatus {
+  return (MAGAZINE_STATUSES as readonly string[]).includes(s);
+}
+
+export interface AdminMagazineListItem {
+  id: string;
+  title: string;
+  status: MagazineStatus;
+  keyword: string | null;
+  subtitle: string | null;
+  published_at: string | null;
+  rejection_reason: string | null;
+  approved_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminMagazineListResponse {
+  data: AdminMagazineListItem[];
+  total: number;
+  page: number;
+  limit: number;
+}

--- a/packages/web/lib/components/admin/magazines/MagazineActions.tsx
+++ b/packages/web/lib/components/admin/magazines/MagazineActions.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { MagazineStatus } from "@/lib/api/admin/magazines";
+
+interface Props {
+  status: MagazineStatus;
+  disabled?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+  onRevert: () => void;
+}
+
+/**
+ * Inline action buttons per magazine row.
+ *
+ * - pending: Approve + Reject
+ * - published: Unpublish (revert → draft)
+ * - draft / rejected: none
+ */
+export function MagazineActions({
+  status,
+  disabled,
+  onApprove,
+  onReject,
+  onRevert,
+}: Props) {
+  if (status === "pending") {
+    return (
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onApprove}
+          className="px-3 py-1.5 text-xs font-medium bg-emerald-600 text-white rounded hover:bg-emerald-700 disabled:opacity-50"
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onReject}
+          className="px-3 py-1.5 text-xs font-medium bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+        >
+          Reject
+        </button>
+      </div>
+    );
+  }
+
+  if (status === "published") {
+    return (
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onRevert}
+          className="px-3 py-1.5 text-xs font-medium bg-amber-500 text-white rounded hover:bg-amber-600 disabled:opacity-50"
+        >
+          Unpublish
+        </button>
+      </div>
+    );
+  }
+
+  return <span className="text-xs text-gray-400">—</span>;
+}

--- a/packages/web/lib/components/admin/magazines/MagazineApprovalTable.tsx
+++ b/packages/web/lib/components/admin/magazines/MagazineApprovalTable.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { AdminMagazineListItem } from "@/lib/api/admin/magazines";
+import { MagazineActions } from "./MagazineActions";
+
+interface Props {
+  items: AdminMagazineListItem[];
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+  onRevert: (id: string) => void;
+  mutatingId?: string | null;
+}
+
+const STATUS_DOT: Record<AdminMagazineListItem["status"], string> = {
+  draft: "bg-gray-400",
+  pending: "bg-yellow-400",
+  published: "bg-emerald-400",
+  rejected: "bg-red-400",
+};
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return "—";
+  }
+}
+
+export function MagazineApprovalTable({
+  items,
+  onApprove,
+  onReject,
+  onRevert,
+  mutatingId,
+}: Props) {
+  return (
+    <div className="overflow-x-auto border border-gray-200 dark:border-gray-800 rounded-lg">
+      <table className="w-full text-sm">
+        <thead className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/50">
+          <tr>
+            <th className="px-4 py-3 font-medium">Title</th>
+            <th className="px-4 py-3 font-medium">Keyword</th>
+            <th className="px-4 py-3 font-medium">Submitted</th>
+            <th className="px-4 py-3 font-medium">Status</th>
+            <th className="px-4 py-3 font-medium text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((m) => (
+            <tr
+              key={m.id}
+              className="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900/50"
+            >
+              <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">
+                {m.title || "Untitled"}
+                {m.subtitle ? (
+                  <div className="text-xs text-gray-500 dark:text-gray-400 font-normal truncate max-w-sm">
+                    {m.subtitle}
+                  </div>
+                ) : null}
+              </td>
+              <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+                {m.keyword ?? "—"}
+              </td>
+              <td className="px-4 py-3 text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                {formatDate(m.created_at)}
+              </td>
+              <td className="px-4 py-3">
+                <span className="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 capitalize">
+                  <span
+                    className={`w-1.5 h-1.5 rounded-full ${STATUS_DOT[m.status]}`}
+                    aria-hidden="true"
+                  />
+                  {m.status}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-right">
+                <MagazineActions
+                  status={m.status}
+                  disabled={mutatingId === m.id}
+                  onApprove={() => onApprove(m.id)}
+                  onReject={() => onReject(m.id)}
+                  onRevert={() => onRevert(m.id)}
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/magazines/MagazineStatusFilter.tsx
+++ b/packages/web/lib/components/admin/magazines/MagazineStatusFilter.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  MAGAZINE_STATUSES,
+  type MagazineStatus,
+} from "@/lib/api/admin/magazines";
+
+interface Props {
+  value: MagazineStatus | undefined;
+  onChange: (next: MagazineStatus | undefined) => void;
+}
+
+const STATUS_DOT: Record<MagazineStatus, string> = {
+  draft: "bg-gray-400",
+  pending: "bg-yellow-400",
+  published: "bg-emerald-400",
+  rejected: "bg-red-400",
+};
+
+export function MagazineStatusFilter({ value, onChange }: Props) {
+  return (
+    <div
+      className="flex gap-2 flex-wrap"
+      role="group"
+      aria-label="Filter by magazine status"
+    >
+      <button
+        type="button"
+        onClick={() => onChange(undefined)}
+        aria-pressed={value === undefined}
+        className={[
+          "px-3 py-1.5 rounded-full text-sm transition-colors",
+          value === undefined
+            ? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-medium"
+            : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700",
+        ].join(" ")}
+      >
+        All
+      </button>
+      {MAGAZINE_STATUSES.map((s) => {
+        const isActive = value === s;
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onChange(s)}
+            aria-pressed={isActive}
+            className={[
+              "px-3 py-1.5 rounded-full text-sm capitalize transition-colors flex items-center gap-1.5",
+              isActive
+                ? "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 font-medium"
+                : "bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700",
+            ].join(" ")}
+          >
+            <span
+              className={`w-1.5 h-1.5 rounded-full shrink-0 ${STATUS_DOT[s]}`}
+              aria-hidden="true"
+            />
+            {s}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/magazines/RejectModal.tsx
+++ b/packages/web/lib/components/admin/magazines/RejectModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   open: boolean;
@@ -11,11 +11,23 @@ interface Props {
 
 export function RejectModal({ open, onClose, onSubmit, submitting }: Props) {
   const [reason, setReason] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Reset reason when modal closes so the next open starts clean.
   useEffect(() => {
     if (!open) setReason("");
   }, [open]);
+
+  // Focus the textarea when opened and handle Escape-to-close.
+  useEffect(() => {
+    if (!open) return;
+    textareaRef.current?.focus();
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && !submitting) onClose();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, submitting, onClose]);
 
   if (!open) return null;
 
@@ -28,6 +40,11 @@ export function RejectModal({ open, onClose, onSubmit, submitting }: Props) {
       aria-modal="true"
       aria-labelledby="reject-modal-title"
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={(e) => {
+        // Backdrop click closes when not submitting. Inner dialog stops
+        // propagation so only true backdrop hits close.
+        if (e.target === e.currentTarget && !submitting) onClose();
+      }}
     >
       <div className="bg-white dark:bg-gray-900 rounded-lg p-6 w-full max-w-md shadow-xl">
         <h2
@@ -44,11 +61,13 @@ export function RejectModal({ open, onClose, onSubmit, submitting }: Props) {
         </label>
         <textarea
           id="reject-reason"
+          ref={textareaRef}
           className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-2 min-h-[100px] text-sm focus:outline-none focus:ring-2 focus:ring-gray-500"
           value={reason}
           onChange={(e) => setReason(e.target.value)}
           placeholder="Explain why this magazine is rejected"
           disabled={submitting}
+          maxLength={2000}
         />
         <div className="flex justify-end gap-2 mt-4">
           <button

--- a/packages/web/lib/components/admin/magazines/RejectModal.tsx
+++ b/packages/web/lib/components/admin/magazines/RejectModal.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => void;
+  submitting?: boolean;
+}
+
+export function RejectModal({ open, onClose, onSubmit, submitting }: Props) {
+  const [reason, setReason] = useState("");
+
+  // Reset reason when modal closes so the next open starts clean.
+  useEffect(() => {
+    if (!open) setReason("");
+  }, [open]);
+
+  if (!open) return null;
+
+  const trimmed = reason.trim();
+  const canSubmit = trimmed.length > 0 && !submitting;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reject-modal-title"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+    >
+      <div className="bg-white dark:bg-gray-900 rounded-lg p-6 w-full max-w-md shadow-xl">
+        <h2
+          id="reject-modal-title"
+          className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4"
+        >
+          Reject Magazine
+        </h2>
+        <label
+          htmlFor="reject-reason"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+        >
+          Reason <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="reject-reason"
+          className="w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-2 min-h-[100px] text-sm focus:outline-none focus:ring-2 focus:ring-gray-500"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Explain why this magazine is rejected"
+          disabled={submitting}
+        />
+        <div className="flex justify-end gap-2 mt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => canSubmit && onSubmit(trimmed)}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-sm text-white bg-red-600 rounded hover:bg-red-700 disabled:opacity-50"
+          >
+            Reject
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/lib/components/admin/magazines/__tests__/MagazineActions.test.tsx
+++ b/packages/web/lib/components/admin/magazines/__tests__/MagazineActions.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MagazineActions } from "../MagazineActions";
+
+describe("MagazineActions", () => {
+  it("renders Approve + Reject for pending", () => {
+    render(
+      <MagazineActions
+        status="pending"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: /approve/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /unpublish/i })).toBeNull();
+  });
+
+  it("renders Unpublish only for published", () => {
+    render(
+      <MagazineActions
+        status="published"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.queryByRole("button", { name: /approve/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /unpublish/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders placeholder for draft and rejected", () => {
+    const { rerender } = render(
+      <MagazineActions
+        status="draft"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+    rerender(
+      <MagazineActions
+        status="rejected"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("fires onApprove / onReject callbacks", () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    render(
+      <MagazineActions
+        status="pending"
+        onApprove={onApprove}
+        onReject={onReject}
+        onRevert={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reject/i }));
+    expect(onApprove).toHaveBeenCalledOnce();
+    expect(onReject).toHaveBeenCalledOnce();
+  });
+
+  it("fires onRevert when Unpublish clicked", () => {
+    const onRevert = vi.fn();
+    render(
+      <MagazineActions
+        status="published"
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={onRevert}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unpublish/i }));
+    expect(onRevert).toHaveBeenCalledOnce();
+  });
+
+  it("honors disabled prop", () => {
+    render(
+      <MagazineActions
+        status="pending"
+        disabled
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /approve/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeDisabled();
+  });
+});

--- a/packages/web/lib/components/admin/magazines/__tests__/MagazineApprovalTable.test.tsx
+++ b/packages/web/lib/components/admin/magazines/__tests__/MagazineApprovalTable.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MagazineApprovalTable } from "../MagazineApprovalTable";
+import type { AdminMagazineListItem } from "@/lib/api/admin/magazines";
+
+const baseItem: AdminMagazineListItem = {
+  id: "m1",
+  title: "Sample Magazine",
+  status: "pending",
+  keyword: "spring",
+  subtitle: "A seasonal preview",
+  published_at: null,
+  rejection_reason: null,
+  approved_by: null,
+  created_at: "2026-04-17T10:00:00Z",
+  updated_at: "2026-04-17T10:00:00Z",
+};
+
+describe("MagazineApprovalTable", () => {
+  it("renders title, keyword and status", () => {
+    render(
+      <MagazineApprovalTable
+        items={[baseItem]}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.getByText("Sample Magazine")).toBeInTheDocument();
+    expect(screen.getByText("spring")).toBeInTheDocument();
+    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+  });
+
+  it("fires onApprove with item id", () => {
+    const onApprove = vi.fn();
+    render(
+      <MagazineApprovalTable
+        items={[baseItem]}
+        onApprove={onApprove}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /approve/i }));
+    expect(onApprove).toHaveBeenCalledWith("m1");
+  });
+
+  it("fires onReject and onRevert with item id per row status", () => {
+    const onReject = vi.fn();
+    const onRevert = vi.fn();
+    const items: AdminMagazineListItem[] = [
+      baseItem,
+      { ...baseItem, id: "m2", status: "published" },
+    ];
+    render(
+      <MagazineApprovalTable
+        items={items}
+        onApprove={() => {}}
+        onReject={onReject}
+        onRevert={onRevert}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /reject/i }));
+    fireEvent.click(screen.getByRole("button", { name: /unpublish/i }));
+    expect(onReject).toHaveBeenCalledWith("m1");
+    expect(onRevert).toHaveBeenCalledWith("m2");
+  });
+
+  it("disables row actions for mutatingId match", () => {
+    render(
+      <MagazineApprovalTable
+        items={[baseItem]}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+        mutatingId="m1"
+      />
+    );
+    expect(screen.getByRole("button", { name: /approve/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /reject/i })).toBeDisabled();
+  });
+
+  it("falls back to placeholders for missing fields", () => {
+    const bare: AdminMagazineListItem = {
+      ...baseItem,
+      title: "",
+      keyword: null,
+      subtitle: null,
+    };
+    render(
+      <MagazineApprovalTable
+        items={[bare]}
+        onApprove={() => {}}
+        onReject={() => {}}
+        onRevert={() => {}}
+      />
+    );
+    expect(screen.getByText("Untitled")).toBeInTheDocument();
+    // keyword cell shows em-dash fallback
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/lib/components/admin/magazines/__tests__/MagazineStatusFilter.test.tsx
+++ b/packages/web/lib/components/admin/magazines/__tests__/MagazineStatusFilter.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MagazineStatusFilter } from "../MagazineStatusFilter";
+
+describe("MagazineStatusFilter", () => {
+  it("renders All + 4 status buttons", () => {
+    render(<MagazineStatusFilter value={undefined} onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: /^all$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /pending/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /published/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /draft/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /rejected/i })
+    ).toBeInTheDocument();
+  });
+
+  it("calls onChange with selected status when a status button is clicked", () => {
+    const onChange = vi.fn();
+    render(<MagazineStatusFilter value={undefined} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /pending/i }));
+    expect(onChange).toHaveBeenCalledWith("pending");
+  });
+
+  it("calls onChange with undefined when All is clicked", () => {
+    const onChange = vi.fn();
+    render(<MagazineStatusFilter value="pending" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /^all$/i }));
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("marks the active button with aria-pressed", () => {
+    render(<MagazineStatusFilter value="pending" onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: /pending/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /^all$/i })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+});

--- a/packages/web/lib/components/admin/magazines/__tests__/RejectModal.test.tsx
+++ b/packages/web/lib/components/admin/magazines/__tests__/RejectModal.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { RejectModal } from "../RejectModal";
+
+describe("RejectModal", () => {
+  it("does not render when open=false", () => {
+    render(<RejectModal open={false} onClose={() => {}} onSubmit={() => {}} />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("renders dialog with required reason field when open", () => {
+    render(<RejectModal open onClose={() => {}} onSubmit={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("disables Reject button when reason is empty", () => {
+    render(<RejectModal open onClose={() => {}} onSubmit={() => {}} />);
+    expect(screen.getByRole("button", { name: /^reject$/i })).toBeDisabled();
+  });
+
+  it("enables Reject after typing non-empty reason", () => {
+    render(<RejectModal open onClose={() => {}} onSubmit={() => {}} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "off-topic" },
+    });
+    expect(
+      screen.getByRole("button", { name: /^reject$/i })
+    ).not.toBeDisabled();
+  });
+
+  it("calls onSubmit with trimmed reason", () => {
+    const onSubmit = vi.fn();
+    render(<RejectModal open onClose={() => {}} onSubmit={onSubmit} />);
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "  off-topic  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^reject$/i }));
+    expect(onSubmit).toHaveBeenCalledWith("off-topic");
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(<RejectModal open onClose={onClose} onSubmit={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables form while submitting", () => {
+    render(
+      <RejectModal open onClose={() => {}} onSubmit={() => {}} submitting />
+    );
+    // textarea filled to ensure Reject would otherwise enable
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "off-topic" },
+    });
+    expect(screen.getByRole("button", { name: /^reject$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/packages/web/lib/components/admin/magazines/index.ts
+++ b/packages/web/lib/components/admin/magazines/index.ts
@@ -1,0 +1,4 @@
+export { MagazineApprovalTable } from "./MagazineApprovalTable";
+export { MagazineStatusFilter } from "./MagazineStatusFilter";
+export { MagazineActions } from "./MagazineActions";
+export { RejectModal } from "./RejectModal";

--- a/packages/web/lib/hooks/admin/__tests__/useAdminMagazineList.test.tsx
+++ b/packages/web/lib/hooks/admin/__tests__/useAdminMagazineList.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAdminMagazineList } from "../useAdminMagazineList";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useAdminMagazineList", () => {
+  it("fetches magazines with status filter + pagination", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], total: 0, page: 1, limit: 20 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(
+      () => useAdminMagazineList({ status: "pending", page: 1, limit: 20 }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("status=pending"),
+      expect.anything()
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("page=1"),
+      expect.anything()
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("limit=20"),
+      expect.anything()
+    );
+  });
+
+  it("omits status query param when undefined", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [], total: 0, page: 1, limit: 20 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAdminMagazineList(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain("status=");
+  });
+
+  it("throws on non-OK HTTP response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: "forbidden" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAdminMagazineList(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/packages/web/lib/hooks/admin/__tests__/useUpdateMagazineStatus.test.tsx
+++ b/packages/web/lib/hooks/admin/__tests__/useUpdateMagazineStatus.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUpdateMagazineStatus } from "../useUpdateMagazineStatus";
+
+let client: QueryClient;
+let invalidateSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  client = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  invalidateSpy = vi.fn();
+  client.invalidateQueries = invalidateSpy as never;
+});
+
+function makeWrapper() {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useUpdateMagazineStatus", () => {
+  it("PATCHes status and invalidates admin magazines list", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "m1", status: "published" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useUpdateMagazineStatus(), {
+      wrapper: makeWrapper(),
+    });
+    result.current.mutate({ id: "m1", status: "published" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/admin/posts/magazines/m1/status",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "published" }),
+      })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["admin", "magazines"] })
+    );
+  });
+
+  it("includes rejectionReason in body when provided", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: "m1", status: "rejected" }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useUpdateMagazineStatus(), {
+      wrapper: makeWrapper(),
+    });
+    result.current.mutate({
+      id: "m1",
+      status: "rejected",
+      rejectionReason: "off-topic",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      status: "rejected",
+      rejectionReason: "off-topic",
+    });
+  });
+
+  it("throws Error with server message on non-OK", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "invalid_transition: draft -> published" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useUpdateMagazineStatus(), {
+      wrapper: makeWrapper(),
+    });
+    result.current.mutate({ id: "m1", status: "published" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toContain(
+      "invalid_transition"
+    );
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/lib/hooks/admin/useAdminMagazineList.ts
+++ b/packages/web/lib/hooks/admin/useAdminMagazineList.ts
@@ -1,0 +1,47 @@
+/**
+ * React Query hook for admin magazine list.
+ *
+ * GET /api/v1/admin/posts/magazines?status=&page=&limit=
+ */
+import {
+  useQuery,
+  keepPreviousData,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  AdminMagazineListResponse,
+  MagazineStatus,
+} from "@/lib/api/admin/magazines";
+
+interface UseAdminMagazineListParams {
+  status?: MagazineStatus;
+  page?: number;
+  limit?: number;
+}
+
+export function useAdminMagazineList(
+  params: UseAdminMagazineListParams = {}
+): UseQueryResult<AdminMagazineListResponse> {
+  const { status, page = 1, limit = 20 } = params;
+
+  return useQuery<AdminMagazineListResponse>({
+    queryKey: ["admin", "magazines", "list", { status, page, limit }],
+    queryFn: async ({ signal }) => {
+      const qs = new URLSearchParams();
+      if (status) qs.set("status", status);
+      qs.set("page", String(page));
+      qs.set("limit", String(limit));
+
+      const res = await fetch(`/api/v1/admin/posts/magazines?${qs}`, {
+        credentials: "include",
+        signal,
+      });
+      if (!res.ok) {
+        throw new Error(`Admin magazines fetch failed: HTTP ${res.status}`);
+      }
+      return (await res.json()) as AdminMagazineListResponse;
+    },
+    staleTime: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts
+++ b/packages/web/lib/hooks/admin/useUpdateMagazineStatus.ts
@@ -1,0 +1,50 @@
+/**
+ * React Query mutation hook for magazine status updates.
+ *
+ * PATCH /api/v1/admin/posts/magazines/:id/status
+ * Invalidates the ["admin", "magazines"] query family on success.
+ */
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { MagazineStatus } from "@/lib/api/admin/magazines";
+
+export interface UpdateMagazineStatusInput {
+  id: string;
+  status: MagazineStatus;
+  rejectionReason?: string;
+}
+
+export function useUpdateMagazineStatus() {
+  const qc = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: UpdateMagazineStatusInput) => {
+      const body: Record<string, unknown> = { status: input.status };
+      if (input.rejectionReason !== undefined) {
+        body.rejectionReason = input.rejectionReason;
+      }
+
+      const res = await fetch(
+        `/api/v1/admin/posts/magazines/${input.id}/status`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(body),
+        }
+      );
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          message?: string;
+        };
+        throw new Error(
+          errBody.error ?? errBody.message ?? `HTTP ${res.status}`
+        );
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "magazines"] });
+    },
+  });
+}

--- a/packages/web/lib/supabase/__tests__/admin-server.test.ts
+++ b/packages/web/lib/supabase/__tests__/admin-server.test.ts
@@ -45,4 +45,34 @@ describe("createAdminSupabaseClient", () => {
     const client = createAdminSupabaseClient();
     expect(client).toBeDefined();
   });
+
+  it("passes service_role key and disables session to createClient", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+
+    const { createClient } = await import("@supabase/supabase-js");
+    const { createAdminSupabaseClient } = await import("../admin-server");
+    createAdminSupabaseClient();
+
+    expect(createClient).toHaveBeenCalledWith(
+      "https://test.supabase.co",
+      "test-service-role",
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          persistSession: false,
+          autoRefreshToken: false,
+        }),
+      })
+    );
+  });
+
+  it("throws when SUPABASE_SERVICE_ROLE_KEY is empty string", async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "";
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+
+    const { createAdminSupabaseClient } = await import("../admin-server");
+    expect(() => createAdminSupabaseClient()).toThrow(
+      /SUPABASE_SERVICE_ROLE_KEY/
+    );
+  });
 });

--- a/packages/web/lib/supabase/__tests__/admin-server.test.ts
+++ b/packages/web/lib/supabase/__tests__/admin-server.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({ mocked: true })),
+}));
+
+describe("createAdminSupabaseClient", () => {
+  let originalServiceRoleKey: string | undefined;
+  let originalSupabaseUrl: string | undefined;
+
+  beforeEach(() => {
+    originalServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    originalSupabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalServiceRoleKey === undefined) {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = originalServiceRoleKey;
+    }
+    if (originalSupabaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = originalSupabaseUrl;
+    }
+  });
+
+  it("throws when SUPABASE_SERVICE_ROLE_KEY is missing", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    const { createAdminSupabaseClient } = await import("../admin-server");
+    expect(() => createAdminSupabaseClient()).toThrow(
+      /SUPABASE_SERVICE_ROLE_KEY/
+    );
+  });
+
+  it("returns client when env set", async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://test.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role";
+
+    const { createAdminSupabaseClient } = await import("../admin-server");
+    const client = createAdminSupabaseClient();
+    expect(client).toBeDefined();
+  });
+});

--- a/packages/web/lib/supabase/admin-server.ts
+++ b/packages/web/lib/supabase/admin-server.ts
@@ -1,0 +1,24 @@
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "./types";
+import { getEnv } from "./env";
+
+const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL");
+
+/**
+ * Server-only Supabase client with service_role key.
+ *
+ * Bypasses RLS. Use ONLY in admin-authenticated route handlers
+ * after `checkIsAdmin()` has verified the caller. Never import
+ * from a Client Component or expose the returned client to the browser.
+ */
+export function createAdminSupabaseClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is not set. Admin mutations require service_role."
+    );
+  }
+  return createClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+}

--- a/packages/web/lib/supabase/admin-server.ts
+++ b/packages/web/lib/supabase/admin-server.ts
@@ -2,16 +2,17 @@ import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 import { getEnv } from "./env";
 
-const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL");
-
 /**
  * Server-only Supabase client with service_role key.
  *
  * Bypasses RLS. Use ONLY in admin-authenticated route handlers
  * after `checkIsAdmin()` has verified the caller. Never import
  * from a Client Component or expose the returned client to the browser.
+ *
+ * @throws Error if SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL is missing.
  */
 export function createAdminSupabaseClient() {
+  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL");
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!serviceRoleKey) {
     throw new Error(

--- a/packages/web/lib/supabase/types.ts
+++ b/packages/web/lib/supabase/types.ts
@@ -4,2449 +4,2539 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
-  // Allows to automatically instantiate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "14.1";
-  };
   public: {
     Tables: {
       agent_sessions: {
         Row: {
-          created_at: string;
-          id: string;
-          keywords: Json | null;
-          last_message_at: string | null;
-          magazine_id: string | null;
-          message_count: number | null;
-          metadata: Json | null;
-          status: string;
-          thread_id: string;
-          updated_at: string;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          keywords: Json | null
+          last_message_at: string | null
+          magazine_id: string | null
+          message_count: number | null
+          metadata: Json | null
+          status: string
+          thread_id: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          keywords?: Json | null;
-          last_message_at?: string | null;
-          magazine_id?: string | null;
-          message_count?: number | null;
-          metadata?: Json | null;
-          status?: string;
-          thread_id: string;
-          updated_at?: string;
-          user_id: string;
-        };
+          created_at?: string
+          id?: string
+          keywords?: Json | null
+          last_message_at?: string | null
+          magazine_id?: string | null
+          message_count?: number | null
+          metadata?: Json | null
+          status?: string
+          thread_id: string
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          keywords?: Json | null;
-          last_message_at?: string | null;
-          magazine_id?: string | null;
-          message_count?: number | null;
-          metadata?: Json | null;
-          status?: string;
-          thread_id?: string;
-          updated_at?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          keywords?: Json | null
+          last_message_at?: string | null
+          magazine_id?: string | null
+          message_count?: number | null
+          metadata?: Json | null
+          status?: string
+          thread_id?: string
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "agent_sessions_magazine_id_fkey";
-            columns: ["magazine_id"];
-            isOneToOne: false;
-            referencedRelation: "magazines";
-            referencedColumns: ["id"];
+            foreignKeyName: "agent_sessions_magazine_id_fkey"
+            columns: ["magazine_id"]
+            isOneToOne: false
+            referencedRelation: "magazines"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "agent_sessions_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "agent_sessions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       badges: {
         Row: {
-          created_at: string;
-          criteria: Json;
-          description: string | null;
-          icon_url: string | null;
-          id: string;
-          name: string;
-          rarity: string;
-          type: string;
-          updated_at: string;
-        };
+          created_at: string
+          criteria: Json
+          description: string | null
+          icon_url: string | null
+          id: string
+          name: string
+          rarity: string
+          type: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          criteria: Json;
-          description?: string | null;
-          icon_url?: string | null;
-          id: string;
-          name: string;
-          rarity?: string;
-          type: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          criteria: Json
+          description?: string | null
+          icon_url?: string | null
+          id: string
+          name: string
+          rarity?: string
+          type: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          criteria?: Json;
-          description?: string | null;
-          icon_url?: string | null;
-          id?: string;
-          name?: string;
-          rarity?: string;
-          type?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          criteria?: Json
+          description?: string | null
+          icon_url?: string | null
+          id?: string
+          name?: string
+          rarity?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       categories: {
         Row: {
-          code: string;
-          color_hex: string | null;
-          created_at: string;
-          description: Json | null;
-          display_order: number;
-          icon_url: string | null;
-          id: string;
-          is_active: boolean;
-          name: Json;
-          updated_at: string;
-        };
+          code: string
+          color_hex: string | null
+          created_at: string
+          description: Json | null
+          display_order: number
+          icon_url: string | null
+          id: string
+          is_active: boolean
+          name: Json
+          updated_at: string
+        }
         Insert: {
-          code: string;
-          color_hex?: string | null;
-          created_at?: string;
-          description?: Json | null;
-          display_order?: number;
-          icon_url?: string | null;
-          id: string;
-          is_active?: boolean;
-          name: Json;
-          updated_at?: string;
-        };
+          code: string
+          color_hex?: string | null
+          created_at?: string
+          description?: Json | null
+          display_order?: number
+          icon_url?: string | null
+          id: string
+          is_active?: boolean
+          name: Json
+          updated_at?: string
+        }
         Update: {
-          code?: string;
-          color_hex?: string | null;
-          created_at?: string;
-          description?: Json | null;
-          display_order?: number;
-          icon_url?: string | null;
-          id?: string;
-          is_active?: boolean;
-          name?: Json;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          code?: string
+          color_hex?: string | null
+          created_at?: string
+          description?: Json | null
+          display_order?: number
+          icon_url?: string | null
+          id?: string
+          is_active?: boolean
+          name?: Json
+          updated_at?: string
+        }
+        Relationships: []
+      }
       checkpoint_blobs: {
         Row: {
-          blob: string | null;
-          channel: string;
-          checkpoint_ns: string;
-          thread_id: string;
-          type: string;
-          version: string;
-        };
+          blob: string | null
+          channel: string
+          checkpoint_ns: string
+          thread_id: string
+          type: string
+          version: string
+        }
         Insert: {
-          blob?: string | null;
-          channel: string;
-          checkpoint_ns?: string;
-          thread_id: string;
-          type: string;
-          version: string;
-        };
+          blob?: string | null
+          channel: string
+          checkpoint_ns?: string
+          thread_id: string
+          type: string
+          version: string
+        }
         Update: {
-          blob?: string | null;
-          channel?: string;
-          checkpoint_ns?: string;
-          thread_id?: string;
-          type?: string;
-          version?: string;
-        };
-        Relationships: [];
-      };
+          blob?: string | null
+          channel?: string
+          checkpoint_ns?: string
+          thread_id?: string
+          type?: string
+          version?: string
+        }
+        Relationships: []
+      }
       checkpoint_migrations: {
         Row: {
-          v: number;
-        };
+          v: number
+        }
         Insert: {
-          v: number;
-        };
+          v: number
+        }
         Update: {
-          v?: number;
-        };
-        Relationships: [];
-      };
+          v?: number
+        }
+        Relationships: []
+      }
       checkpoint_writes: {
         Row: {
-          blob: string;
-          channel: string;
-          checkpoint_id: string;
-          checkpoint_ns: string;
-          idx: number;
-          task_id: string;
-          task_path: string;
-          thread_id: string;
-          type: string | null;
-        };
+          blob: string
+          channel: string
+          checkpoint_id: string
+          checkpoint_ns: string
+          idx: number
+          task_id: string
+          task_path: string
+          thread_id: string
+          type: string | null
+        }
         Insert: {
-          blob: string;
-          channel: string;
-          checkpoint_id: string;
-          checkpoint_ns?: string;
-          idx: number;
-          task_id: string;
-          task_path?: string;
-          thread_id: string;
-          type?: string | null;
-        };
+          blob: string
+          channel: string
+          checkpoint_id: string
+          checkpoint_ns?: string
+          idx: number
+          task_id: string
+          task_path?: string
+          thread_id: string
+          type?: string | null
+        }
         Update: {
-          blob?: string;
-          channel?: string;
-          checkpoint_id?: string;
-          checkpoint_ns?: string;
-          idx?: number;
-          task_id?: string;
-          task_path?: string;
-          thread_id?: string;
-          type?: string | null;
-        };
-        Relationships: [];
-      };
+          blob?: string
+          channel?: string
+          checkpoint_id?: string
+          checkpoint_ns?: string
+          idx?: number
+          task_id?: string
+          task_path?: string
+          thread_id?: string
+          type?: string | null
+        }
+        Relationships: []
+      }
       checkpoints: {
         Row: {
-          checkpoint: Json;
-          checkpoint_id: string;
-          checkpoint_ns: string;
-          metadata: Json;
-          parent_checkpoint_id: string | null;
-          thread_id: string;
-          type: string | null;
-        };
+          checkpoint: Json
+          checkpoint_id: string
+          checkpoint_ns: string
+          metadata: Json
+          parent_checkpoint_id: string | null
+          thread_id: string
+          type: string | null
+        }
         Insert: {
-          checkpoint: Json;
-          checkpoint_id: string;
-          checkpoint_ns?: string;
-          metadata?: Json;
-          parent_checkpoint_id?: string | null;
-          thread_id: string;
-          type?: string | null;
-        };
+          checkpoint: Json
+          checkpoint_id: string
+          checkpoint_ns?: string
+          metadata?: Json
+          parent_checkpoint_id?: string | null
+          thread_id: string
+          type?: string | null
+        }
         Update: {
-          checkpoint?: Json;
-          checkpoint_id?: string;
-          checkpoint_ns?: string;
-          metadata?: Json;
-          parent_checkpoint_id?: string | null;
-          thread_id?: string;
-          type?: string | null;
-        };
-        Relationships: [];
-      };
+          checkpoint?: Json
+          checkpoint_id?: string
+          checkpoint_ns?: string
+          metadata?: Json
+          parent_checkpoint_id?: string | null
+          thread_id?: string
+          type?: string | null
+        }
+        Relationships: []
+      }
       click_logs: {
         Row: {
-          created_at: string;
-          id: string;
-          ip_address: string;
-          referrer: string | null;
-          solution_id: string;
-          user_agent: string | null;
-          user_id: string | null;
-        };
+          created_at: string
+          id: string
+          ip_address: string
+          referrer: string | null
+          solution_id: string
+          user_agent: string | null
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          ip_address: string;
-          referrer?: string | null;
-          solution_id: string;
-          user_agent?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id: string
+          ip_address: string
+          referrer?: string | null
+          solution_id: string
+          user_agent?: string | null
+          user_id?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          ip_address?: string;
-          referrer?: string | null;
-          solution_id?: string;
-          user_agent?: string | null;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id?: string
+          ip_address?: string
+          referrer?: string | null
+          solution_id?: string
+          user_agent?: string | null
+          user_id?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_click_logs_solution_id";
-            columns: ["solution_id"];
-            isOneToOne: false;
-            referencedRelation: "solutions";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_click_logs_solution_id"
+            columns: ["solution_id"]
+            isOneToOne: false
+            referencedRelation: "solutions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_click_logs_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_click_logs_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       comments: {
         Row: {
-          content: string;
-          created_at: string;
-          id: string;
-          parent_id: string | null;
-          post_id: string;
-          updated_at: string;
-          user_id: string;
-        };
+          content: string
+          created_at: string
+          id: string
+          parent_id: string | null
+          post_id: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          content: string;
-          created_at?: string;
-          id: string;
-          parent_id?: string | null;
-          post_id: string;
-          updated_at?: string;
-          user_id: string;
-        };
+          content: string
+          created_at?: string
+          id: string
+          parent_id?: string | null
+          post_id: string
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          content?: string;
-          created_at?: string;
-          id?: string;
-          parent_id?: string | null;
-          post_id?: string;
-          updated_at?: string;
-          user_id?: string;
-        };
+          content?: string
+          created_at?: string
+          id?: string
+          parent_id?: string | null
+          post_id?: string
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_comments_parent_id";
-            columns: ["parent_id"];
-            isOneToOne: false;
-            referencedRelation: "comments";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_comments_parent_id"
+            columns: ["parent_id"]
+            isOneToOne: false
+            referencedRelation: "comments"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_comments_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_comments_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_comments_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_comments_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_comments_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_comments_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       content_reports: {
         Row: {
-          created_at: string;
-          details: string | null;
-          id: string;
-          reason: string;
-          reporter_id: string;
-          resolution: string | null;
-          reviewed_by: string | null;
-          status: string;
-          target_id: string;
-          target_type: string;
-          updated_at: string;
-        };
+          created_at: string
+          details: string | null
+          id: string
+          reason: string
+          reporter_id: string
+          resolution: string | null
+          reviewed_by: string | null
+          status: string
+          target_id: string
+          target_type: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          details?: string | null;
-          id?: string;
-          reason: string;
-          reporter_id: string;
-          resolution?: string | null;
-          reviewed_by?: string | null;
-          status?: string;
-          target_id: string;
-          target_type?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          details?: string | null
+          id?: string
+          reason: string
+          reporter_id: string
+          resolution?: string | null
+          reviewed_by?: string | null
+          status?: string
+          target_id: string
+          target_type?: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          details?: string | null;
-          id?: string;
-          reason?: string;
-          reporter_id?: string;
-          resolution?: string | null;
-          reviewed_by?: string | null;
-          status?: string;
-          target_id?: string;
-          target_type?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          details?: string | null
+          id?: string
+          reason?: string
+          reporter_id?: string
+          resolution?: string | null
+          reviewed_by?: string | null
+          status?: string
+          target_id?: string
+          target_type?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       credit_transactions: {
         Row: {
-          action_type: string;
-          amount: number;
-          created_at: string;
-          id: string;
-          reference_id: string | null;
-          status: string;
-          user_id: string;
-        };
+          action_type: string
+          amount: number
+          created_at: string
+          id: string
+          reference_id: string | null
+          status: string
+          user_id: string
+        }
         Insert: {
-          action_type: string;
-          amount: number;
-          created_at?: string;
-          id: string;
-          reference_id?: string | null;
-          status?: string;
-          user_id: string;
-        };
+          action_type: string
+          amount: number
+          created_at?: string
+          id: string
+          reference_id?: string | null
+          status?: string
+          user_id: string
+        }
         Update: {
-          action_type?: string;
-          amount?: number;
-          created_at?: string;
-          id?: string;
-          reference_id?: string | null;
-          status?: string;
-          user_id?: string;
-        };
+          action_type?: string
+          amount?: number
+          created_at?: string
+          id?: string
+          reference_id?: string | null
+          status?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "credit_transactions_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "credit_transactions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       curation_posts: {
         Row: {
-          curation_id: string;
-          display_order: number;
-          post_id: string;
-        };
+          curation_id: string
+          display_order: number
+          post_id: string
+        }
         Insert: {
-          curation_id: string;
-          display_order?: number;
-          post_id: string;
-        };
+          curation_id: string
+          display_order?: number
+          post_id: string
+        }
         Update: {
-          curation_id?: string;
-          display_order?: number;
-          post_id?: string;
-        };
+          curation_id?: string
+          display_order?: number
+          post_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_curation_posts_curation_id";
-            columns: ["curation_id"];
-            isOneToOne: false;
-            referencedRelation: "curations";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_curation_posts_curation_id"
+            columns: ["curation_id"]
+            isOneToOne: false
+            referencedRelation: "curations"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_curation_posts_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_curation_posts_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_curation_posts_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_curation_posts_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       curations: {
         Row: {
-          cover_image_url: string | null;
-          created_at: string;
-          description: string | null;
-          display_order: number;
-          id: string;
-          is_active: boolean;
-          title: string;
-          updated_at: string;
-        };
+          cover_image_url: string | null
+          created_at: string
+          description: string | null
+          display_order: number
+          id: string
+          is_active: boolean
+          title: string
+          updated_at: string
+        }
         Insert: {
-          cover_image_url?: string | null;
-          created_at: string;
-          description?: string | null;
-          display_order?: number;
-          id: string;
-          is_active?: boolean;
-          title: string;
-          updated_at: string;
-        };
+          cover_image_url?: string | null
+          created_at: string
+          description?: string | null
+          display_order?: number
+          id: string
+          is_active?: boolean
+          title: string
+          updated_at: string
+        }
         Update: {
-          cover_image_url?: string | null;
-          created_at?: string;
-          description?: string | null;
-          display_order?: number;
-          id?: string;
-          is_active?: boolean;
-          title?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          cover_image_url?: string | null
+          created_at?: string
+          description?: string | null
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       decoded_picks: {
         Row: {
-          created_at: string;
-          curated_by: string;
-          id: string;
-          is_active: boolean;
-          note: string | null;
-          pick_date: string;
-          post_id: string;
-        };
+          created_at: string
+          curated_by: string
+          id: string
+          is_active: boolean
+          note: string | null
+          pick_date: string
+          post_id: string
+        }
         Insert: {
-          created_at?: string;
-          curated_by?: string;
-          id?: string;
-          is_active?: boolean;
-          note?: string | null;
-          pick_date?: string;
-          post_id: string;
-        };
+          created_at?: string
+          curated_by?: string
+          id?: string
+          is_active?: boolean
+          note?: string | null
+          pick_date?: string
+          post_id: string
+        }
         Update: {
-          created_at?: string;
-          curated_by?: string;
-          id?: string;
-          is_active?: boolean;
-          note?: string | null;
-          pick_date?: string;
-          post_id?: string;
-        };
+          created_at?: string
+          curated_by?: string
+          id?: string
+          is_active?: boolean
+          note?: string | null
+          pick_date?: string
+          post_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "decoded_picks_post_id_fkey";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "decoded_picks_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "decoded_picks_post_id_fkey";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "decoded_picks_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       earnings: {
         Row: {
-          affiliate_platform: string | null;
-          amount: number;
-          created_at: string;
-          currency: string;
-          id: string;
-          solution_id: string;
-          status: string;
-          user_id: string;
-        };
+          affiliate_platform: string | null
+          amount: number
+          created_at: string
+          currency: string
+          id: string
+          solution_id: string
+          status: string
+          user_id: string
+        }
         Insert: {
-          affiliate_platform?: string | null;
-          amount: number;
-          created_at?: string;
-          currency?: string;
-          id: string;
-          solution_id: string;
-          status?: string;
-          user_id: string;
-        };
+          affiliate_platform?: string | null
+          amount: number
+          created_at?: string
+          currency?: string
+          id: string
+          solution_id: string
+          status?: string
+          user_id: string
+        }
         Update: {
-          affiliate_platform?: string | null;
-          amount?: number;
-          created_at?: string;
-          currency?: string;
-          id?: string;
-          solution_id?: string;
-          status?: string;
-          user_id?: string;
-        };
+          affiliate_platform?: string | null
+          amount?: number
+          created_at?: string
+          currency?: string
+          id?: string
+          solution_id?: string
+          status?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_earnings_solution_id";
-            columns: ["solution_id"];
-            isOneToOne: false;
-            referencedRelation: "solutions";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_earnings_solution_id"
+            columns: ["solution_id"]
+            isOneToOne: false
+            referencedRelation: "solutions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_earnings_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_earnings_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       embeddings: {
         Row: {
-          content_text: string;
-          created_at: string | null;
-          embedding: string;
-          entity_id: string;
-          entity_type: string;
-          id: string;
-        };
+          content_text: string
+          created_at: string | null
+          embedding: string
+          entity_id: string
+          entity_type: string
+          id: string
+        }
         Insert: {
-          content_text: string;
-          created_at?: string | null;
-          embedding: string;
-          entity_id: string;
-          entity_type: string;
-          id?: string;
-        };
+          content_text: string
+          created_at?: string | null
+          embedding: string
+          entity_id: string
+          entity_type: string
+          id?: string
+        }
         Update: {
-          content_text?: string;
-          created_at?: string | null;
-          embedding?: string;
-          entity_id?: string;
-          entity_type?: string;
-          id?: string;
-        };
-        Relationships: [];
-      };
+          content_text?: string
+          created_at?: string | null
+          embedding?: string
+          entity_id?: string
+          entity_type?: string
+          id?: string
+        }
+        Relationships: []
+      }
       failed_batch_items: {
         Row: {
-          batch_id: string;
-          created_at: string;
-          error_message: string | null;
-          id: string;
-          item_id: string;
-          next_retry_at: string;
-          retry_count: number;
-          status: string;
-          updated_at: string;
-          url: string;
-        };
+          batch_id: string
+          created_at: string
+          error_message: string | null
+          id: string
+          item_id: string
+          next_retry_at: string
+          retry_count: number
+          status: string
+          updated_at: string
+          url: string
+        }
         Insert: {
-          batch_id: string;
-          created_at?: string;
-          error_message?: string | null;
-          id: string;
-          item_id: string;
-          next_retry_at: string;
-          retry_count?: number;
-          status: string;
-          updated_at?: string;
-          url: string;
-        };
+          batch_id: string
+          created_at?: string
+          error_message?: string | null
+          id: string
+          item_id: string
+          next_retry_at: string
+          retry_count?: number
+          status: string
+          updated_at?: string
+          url: string
+        }
         Update: {
-          batch_id?: string;
-          created_at?: string;
-          error_message?: string | null;
-          id?: string;
-          item_id?: string;
-          next_retry_at?: string;
-          retry_count?: number;
-          status?: string;
-          updated_at?: string;
-          url?: string;
-        };
-        Relationships: [];
-      };
+          batch_id?: string
+          created_at?: string
+          error_message?: string | null
+          id?: string
+          item_id?: string
+          next_retry_at?: string
+          retry_count?: number
+          status?: string
+          updated_at?: string
+          url?: string
+        }
+        Relationships: []
+      }
       magazine_posts: {
         Row: {
-          magazine_id: string;
-          post_id: string;
-          section_index: number;
-        };
+          magazine_id: string
+          post_id: string
+          section_index: number
+        }
         Insert: {
-          magazine_id: string;
-          post_id: string;
-          section_index?: number;
-        };
+          magazine_id: string
+          post_id: string
+          section_index?: number
+        }
         Update: {
-          magazine_id?: string;
-          post_id?: string;
-          section_index?: number;
-        };
+          magazine_id?: string
+          post_id?: string
+          section_index?: number
+        }
         Relationships: [
           {
-            foreignKeyName: "magazine_posts_magazine_id_fkey";
-            columns: ["magazine_id"];
-            isOneToOne: false;
-            referencedRelation: "magazines";
-            referencedColumns: ["id"];
+            foreignKeyName: "magazine_posts_magazine_id_fkey"
+            columns: ["magazine_id"]
+            isOneToOne: false
+            referencedRelation: "magazines"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "magazine_posts_post_id_fkey";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "magazine_posts_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "magazine_posts_post_id_fkey";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "magazine_posts_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       magazines: {
         Row: {
-          agent_version: string | null;
-          artists: Json | null;
-          cover_image_url: string | null;
-          created_at: string;
-          generation_log: Json | null;
-          id: string;
-          keywords: Json;
-          published_at: string | null;
-          published_by: string | null;
-          review_notes: string | null;
-          reviewed_at: string | null;
-          reviewed_by: string | null;
-          spec: Json;
-          status: string;
-          subtitle: string | null;
-          theme: string | null;
-          title: string;
-          updated_at: string;
-        };
+          agent_version: string | null
+          artists: Json | null
+          cover_image_url: string | null
+          created_at: string
+          generation_log: Json | null
+          id: string
+          keywords: Json
+          published_at: string | null
+          published_by: string | null
+          review_notes: string | null
+          reviewed_at: string | null
+          reviewed_by: string | null
+          spec: Json
+          status: string
+          subtitle: string | null
+          theme: string | null
+          title: string
+          updated_at: string
+        }
         Insert: {
-          agent_version?: string | null;
-          artists?: Json | null;
-          cover_image_url?: string | null;
-          created_at?: string;
-          generation_log?: Json | null;
-          id?: string;
-          keywords?: Json;
-          published_at?: string | null;
-          published_by?: string | null;
-          review_notes?: string | null;
-          reviewed_at?: string | null;
-          reviewed_by?: string | null;
-          spec?: Json;
-          status?: string;
-          subtitle?: string | null;
-          theme?: string | null;
-          title: string;
-          updated_at?: string;
-        };
+          agent_version?: string | null
+          artists?: Json | null
+          cover_image_url?: string | null
+          created_at?: string
+          generation_log?: Json | null
+          id?: string
+          keywords?: Json
+          published_at?: string | null
+          published_by?: string | null
+          review_notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          spec?: Json
+          status?: string
+          subtitle?: string | null
+          theme?: string | null
+          title: string
+          updated_at?: string
+        }
         Update: {
-          agent_version?: string | null;
-          artists?: Json | null;
-          cover_image_url?: string | null;
-          created_at?: string;
-          generation_log?: Json | null;
-          id?: string;
-          keywords?: Json;
-          published_at?: string | null;
-          published_by?: string | null;
-          review_notes?: string | null;
-          reviewed_at?: string | null;
-          reviewed_by?: string | null;
-          spec?: Json;
-          status?: string;
-          subtitle?: string | null;
-          theme?: string | null;
-          title?: string;
-          updated_at?: string;
-        };
+          agent_version?: string | null
+          artists?: Json | null
+          cover_image_url?: string | null
+          created_at?: string
+          generation_log?: Json | null
+          id?: string
+          keywords?: Json
+          published_at?: string | null
+          published_by?: string | null
+          review_notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          spec?: Json
+          status?: string
+          subtitle?: string | null
+          theme?: string | null
+          title?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "magazines_published_by_fkey";
-            columns: ["published_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "magazines_published_by_fkey"
+            columns: ["published_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "magazines_reviewed_by_fkey";
-            columns: ["reviewed_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "magazines_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       point_logs: {
         Row: {
-          activity_type: string;
-          created_at: string;
-          description: string | null;
-          id: string;
-          points: number;
-          ref_id: string | null;
-          ref_type: string | null;
-          user_id: string;
-        };
+          activity_type: string
+          created_at: string
+          description: string | null
+          id: string
+          points: number
+          ref_id: string | null
+          ref_type: string | null
+          user_id: string
+        }
         Insert: {
-          activity_type: string;
-          created_at?: string;
-          description?: string | null;
-          id: string;
-          points: number;
-          ref_id?: string | null;
-          ref_type?: string | null;
-          user_id: string;
-        };
+          activity_type: string
+          created_at?: string
+          description?: string | null
+          id: string
+          points: number
+          ref_id?: string | null
+          ref_type?: string | null
+          user_id: string
+        }
         Update: {
-          activity_type?: string;
-          created_at?: string;
-          description?: string | null;
-          id?: string;
-          points?: number;
-          ref_id?: string | null;
-          ref_type?: string | null;
-          user_id?: string;
-        };
+          activity_type?: string
+          created_at?: string
+          description?: string | null
+          id?: string
+          points?: number
+          ref_id?: string | null
+          ref_type?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_point_logs_user";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_point_logs_user"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       post_likes: {
         Row: {
-          created_at: string;
-          id: string;
-          post_id: string;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          post_id: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          post_id: string;
-          user_id: string;
-        };
+          created_at?: string
+          id: string
+          post_id: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          post_id?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_post_likes_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_post_likes_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_post_likes_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_post_likes_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_post_likes_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_post_likes_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
+      post_magazine_news_references: {
+        Row: {
+          created_at: string
+          credibility_score: number
+          id: string
+          matched_item: string | null
+          og_description: string | null
+          og_image: string | null
+          og_site_name: string | null
+          og_title: string | null
+          post_magazine_id: string
+          relevance_score: number
+          source: string
+          summary: string | null
+          title: string
+          url: string
+        }
+        Insert: {
+          created_at?: string
+          credibility_score?: number
+          id?: string
+          matched_item?: string | null
+          og_description?: string | null
+          og_image?: string | null
+          og_site_name?: string | null
+          og_title?: string | null
+          post_magazine_id: string
+          relevance_score?: number
+          source: string
+          summary?: string | null
+          title: string
+          url: string
+        }
+        Update: {
+          created_at?: string
+          credibility_score?: number
+          id?: string
+          matched_item?: string | null
+          og_description?: string | null
+          og_image?: string | null
+          og_site_name?: string | null
+          og_title?: string | null
+          post_magazine_id?: string
+          relevance_score?: number
+          source?: string
+          summary?: string | null
+          title?: string
+          url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "post_magazine_news_references_post_magazine_id_fkey"
+            columns: ["post_magazine_id"]
+            isOneToOne: false
+            referencedRelation: "post_magazines"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       post_magazines: {
         Row: {
-          created_at: string;
-          error_log: Json | null;
-          id: string;
-          keyword: string | null;
-          layout_json: Json | null;
-          published_at: string | null;
-          review_summary: string | null;
-          status: string;
-          subtitle: string | null;
-          title: string;
-          updated_at: string;
-        };
+          approved_by: string | null
+          created_at: string
+          error_log: Json | null
+          id: string
+          keyword: string | null
+          layout_json: Json | null
+          published_at: string | null
+          rejection_reason: string | null
+          review_summary: string | null
+          status: string
+          subtitle: string | null
+          title: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          error_log?: Json | null;
-          id?: string;
-          keyword?: string | null;
-          layout_json?: Json | null;
-          published_at?: string | null;
-          review_summary?: string | null;
-          status?: string;
-          subtitle?: string | null;
-          title?: string;
-          updated_at?: string;
-        };
+          approved_by?: string | null
+          created_at?: string
+          error_log?: Json | null
+          id?: string
+          keyword?: string | null
+          layout_json?: Json | null
+          published_at?: string | null
+          rejection_reason?: string | null
+          review_summary?: string | null
+          status?: string
+          subtitle?: string | null
+          title?: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          error_log?: Json | null;
-          id?: string;
-          keyword?: string | null;
-          layout_json?: Json | null;
-          published_at?: string | null;
-          review_summary?: string | null;
-          status?: string;
-          subtitle?: string | null;
-          title?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          approved_by?: string | null
+          created_at?: string
+          error_log?: Json | null
+          id?: string
+          keyword?: string | null
+          layout_json?: Json | null
+          published_at?: string | null
+          rejection_reason?: string | null
+          review_summary?: string | null
+          status?: string
+          subtitle?: string | null
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       posts: {
         Row: {
-          ai_summary: string | null;
-          artist_id: string | null;
-          artist_name: string | null;
-          context: string | null;
-          created_at: string;
-          created_with_solutions: boolean | null;
-          group_id: string | null;
-          group_name: string | null;
-          id: string;
-          image_height: number | null;
-          image_url: string;
-          image_width: number | null;
-          media_metadata: Json | null;
-          media_type: string;
-          post_magazine_id: string | null;
-          status: string;
-          style_tags: Json | null;
-          title: string | null;
-          trending_score: number | null;
-          updated_at: string;
-          user_id: string;
-          view_count: number;
-        };
+          ai_summary: string | null
+          artist_id: string | null
+          artist_name: string | null
+          context: string | null
+          created_at: string
+          created_with_solutions: boolean | null
+          group_id: string | null
+          group_name: string | null
+          id: string
+          image_height: number | null
+          image_url: string
+          image_width: number | null
+          media_metadata: Json | null
+          media_type: string
+          post_magazine_id: string | null
+          status: string
+          style_tags: Json | null
+          title: string | null
+          trending_score: number | null
+          updated_at: string
+          user_id: string
+          view_count: number
+        }
         Insert: {
-          ai_summary?: string | null;
-          artist_id?: string | null;
-          artist_name?: string | null;
-          context?: string | null;
-          created_at?: string;
-          created_with_solutions?: boolean | null;
-          group_id?: string | null;
-          group_name?: string | null;
-          id: string;
-          image_height?: number | null;
-          image_url: string;
-          image_width?: number | null;
-          media_metadata?: Json | null;
-          media_type: string;
-          post_magazine_id?: string | null;
-          status?: string;
-          style_tags?: Json | null;
-          title?: string | null;
-          trending_score?: number | null;
-          updated_at?: string;
-          user_id: string;
-          view_count?: number;
-        };
+          ai_summary?: string | null
+          artist_id?: string | null
+          artist_name?: string | null
+          context?: string | null
+          created_at?: string
+          created_with_solutions?: boolean | null
+          group_id?: string | null
+          group_name?: string | null
+          id: string
+          image_height?: number | null
+          image_url: string
+          image_width?: number | null
+          media_metadata?: Json | null
+          media_type: string
+          post_magazine_id?: string | null
+          status?: string
+          style_tags?: Json | null
+          title?: string | null
+          trending_score?: number | null
+          updated_at?: string
+          user_id: string
+          view_count?: number
+        }
         Update: {
-          ai_summary?: string | null;
-          artist_id?: string | null;
-          artist_name?: string | null;
-          context?: string | null;
-          created_at?: string;
-          created_with_solutions?: boolean | null;
-          group_id?: string | null;
-          group_name?: string | null;
-          id?: string;
-          image_height?: number | null;
-          image_url?: string;
-          image_width?: number | null;
-          media_metadata?: Json | null;
-          media_type?: string;
-          post_magazine_id?: string | null;
-          status?: string;
-          style_tags?: Json | null;
-          title?: string | null;
-          trending_score?: number | null;
-          updated_at?: string;
-          user_id?: string;
-          view_count?: number;
-        };
+          ai_summary?: string | null
+          artist_id?: string | null
+          artist_name?: string | null
+          context?: string | null
+          created_at?: string
+          created_with_solutions?: boolean | null
+          group_id?: string | null
+          group_name?: string | null
+          id?: string
+          image_height?: number | null
+          image_url?: string
+          image_width?: number | null
+          media_metadata?: Json | null
+          media_type?: string
+          post_magazine_id?: string | null
+          status?: string
+          style_tags?: Json | null
+          title?: string | null
+          trending_score?: number | null
+          updated_at?: string
+          user_id?: string
+          view_count?: number
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_posts_post_magazine_id";
-            columns: ["post_magazine_id"];
-            isOneToOne: false;
-            referencedRelation: "post_magazines";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_posts_post_magazine_id"
+            columns: ["post_magazine_id"]
+            isOneToOne: false
+            referencedRelation: "post_magazines"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_posts_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_posts_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       processed_batches: {
         Row: {
-          batch_id: string;
-          created_at: string;
-          failed_count: number;
-          partial_count: number;
-          processing_time_ms: number;
-          processing_timestamp: string;
-          success_count: number;
-          total_count: number;
-        };
+          batch_id: string
+          created_at: string
+          failed_count: number
+          partial_count: number
+          processing_time_ms: number
+          processing_timestamp: string
+          success_count: number
+          total_count: number
+        }
         Insert: {
-          batch_id: string;
-          created_at?: string;
-          failed_count: number;
-          partial_count: number;
-          processing_time_ms: number;
-          processing_timestamp: string;
-          success_count: number;
-          total_count: number;
-        };
+          batch_id: string
+          created_at?: string
+          failed_count: number
+          partial_count: number
+          processing_time_ms: number
+          processing_timestamp: string
+          success_count: number
+          total_count: number
+        }
         Update: {
-          batch_id?: string;
-          created_at?: string;
-          failed_count?: number;
-          partial_count?: number;
-          processing_time_ms?: number;
-          processing_timestamp?: string;
-          success_count?: number;
-          total_count?: number;
-        };
-        Relationships: [];
-      };
+          batch_id?: string
+          created_at?: string
+          failed_count?: number
+          partial_count?: number
+          processing_time_ms?: number
+          processing_timestamp?: string
+          success_count?: number
+          total_count?: number
+        }
+        Relationships: []
+      }
       saved_posts: {
         Row: {
-          created_at: string;
-          id: string;
-          post_id: string;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          post_id: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          post_id: string;
-          user_id: string;
-        };
+          created_at?: string
+          id: string
+          post_id: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          post_id?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          post_id?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_saved_posts_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_saved_posts_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_saved_posts_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_saved_posts_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_saved_posts_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_saved_posts_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       seaql_migrations: {
         Row: {
-          applied_at: number;
-          version: string;
-        };
+          applied_at: number
+          version: string
+        }
         Insert: {
-          applied_at: number;
-          version: string;
-        };
+          applied_at: number
+          version: string
+        }
         Update: {
-          applied_at?: number;
-          version?: string;
-        };
-        Relationships: [];
-      };
+          applied_at?: number
+          version?: string
+        }
+        Relationships: []
+      }
       search_logs: {
         Row: {
-          created_at: string;
-          filters: Json | null;
-          id: string;
-          query: string;
-          user_id: string | null;
-        };
+          created_at: string
+          filters: Json | null
+          id: string
+          query: string
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          filters?: Json | null;
-          id: string;
-          query: string;
-          user_id?: string | null;
-        };
+          created_at?: string
+          filters?: Json | null
+          id: string
+          query: string
+          user_id?: string | null
+        }
         Update: {
-          created_at?: string;
-          filters?: Json | null;
-          id?: string;
-          query?: string;
-          user_id?: string | null;
-        };
+          created_at?: string
+          filters?: Json | null
+          id?: string
+          query?: string
+          user_id?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_search_logs_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_search_logs_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       settlements: {
         Row: {
-          amount: number;
-          bank_info: Json | null;
-          created_at: string;
-          currency: string;
-          id: string;
-          processed_at: string | null;
-          status: string;
-          user_id: string;
-        };
+          amount: number
+          bank_info: Json | null
+          created_at: string
+          currency: string
+          id: string
+          processed_at: string | null
+          status: string
+          user_id: string
+        }
         Insert: {
-          amount: number;
-          bank_info?: Json | null;
-          created_at?: string;
-          currency?: string;
-          id: string;
-          processed_at?: string | null;
-          status?: string;
-          user_id: string;
-        };
+          amount: number
+          bank_info?: Json | null
+          created_at?: string
+          currency?: string
+          id: string
+          processed_at?: string | null
+          status?: string
+          user_id: string
+        }
         Update: {
-          amount?: number;
-          bank_info?: Json | null;
-          created_at?: string;
-          currency?: string;
-          id?: string;
-          processed_at?: string | null;
-          status?: string;
-          user_id?: string;
-        };
+          amount?: number
+          bank_info?: Json | null
+          created_at?: string
+          currency?: string
+          id?: string
+          processed_at?: string | null
+          status?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_settlements_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_settlements_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       solutions: {
         Row: {
-          accurate_count: number;
-          adopted_at: string | null;
-          affiliate_url: string | null;
-          brand_id: string | null;
-          click_count: number;
-          comment: string | null;
-          created_at: string;
-          description: string | null;
-          different_count: number;
-          id: string;
-          is_adopted: boolean;
-          is_verified: boolean;
-          keywords: Json | null;
-          link_type: string | null;
-          match_type: string | null;
-          metadata: Json | null;
-          original_url: string | null;
-          price_amount: number | null;
-          price_currency: string | null;
-          purchase_count: number;
-          qna: Json | null;
-          spot_id: string;
-          status: string;
-          thumbnail_url: string | null;
-          title: string;
-          updated_at: string;
-          user_id: string;
-        };
+          accurate_count: number
+          adopted_at: string | null
+          affiliate_url: string | null
+          brand_id: string | null
+          click_count: number
+          comment: string | null
+          created_at: string
+          description: string | null
+          different_count: number
+          id: string
+          is_adopted: boolean
+          is_verified: boolean
+          keywords: Json | null
+          link_type: string | null
+          match_type: string | null
+          metadata: Json | null
+          original_url: string | null
+          price_amount: number | null
+          price_currency: string | null
+          purchase_count: number
+          qna: Json | null
+          spot_id: string
+          status: string
+          thumbnail_url: string | null
+          title: string
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          accurate_count?: number;
-          adopted_at?: string | null;
-          affiliate_url?: string | null;
-          brand_id?: string | null;
-          click_count?: number;
-          comment?: string | null;
-          created_at?: string;
-          description?: string | null;
-          different_count?: number;
-          id: string;
-          is_adopted?: boolean;
-          is_verified?: boolean;
-          keywords?: Json | null;
-          link_type?: string | null;
-          match_type?: string | null;
-          metadata?: Json | null;
-          original_url?: string | null;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          purchase_count?: number;
-          qna?: Json | null;
-          spot_id: string;
-          status?: string;
-          thumbnail_url?: string | null;
-          title: string;
-          updated_at?: string;
-          user_id: string;
-        };
+          accurate_count?: number
+          adopted_at?: string | null
+          affiliate_url?: string | null
+          brand_id?: string | null
+          click_count?: number
+          comment?: string | null
+          created_at?: string
+          description?: string | null
+          different_count?: number
+          id: string
+          is_adopted?: boolean
+          is_verified?: boolean
+          keywords?: Json | null
+          link_type?: string | null
+          match_type?: string | null
+          metadata?: Json | null
+          original_url?: string | null
+          price_amount?: number | null
+          price_currency?: string | null
+          purchase_count?: number
+          qna?: Json | null
+          spot_id: string
+          status?: string
+          thumbnail_url?: string | null
+          title: string
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          accurate_count?: number;
-          adopted_at?: string | null;
-          affiliate_url?: string | null;
-          brand_id?: string | null;
-          click_count?: number;
-          comment?: string | null;
-          created_at?: string;
-          description?: string | null;
-          different_count?: number;
-          id?: string;
-          is_adopted?: boolean;
-          is_verified?: boolean;
-          keywords?: Json | null;
-          link_type?: string | null;
-          match_type?: string | null;
-          metadata?: Json | null;
-          original_url?: string | null;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          purchase_count?: number;
-          qna?: Json | null;
-          spot_id?: string;
-          status?: string;
-          thumbnail_url?: string | null;
-          title?: string;
-          updated_at?: string;
-          user_id?: string;
-        };
+          accurate_count?: number
+          adopted_at?: string | null
+          affiliate_url?: string | null
+          brand_id?: string | null
+          click_count?: number
+          comment?: string | null
+          created_at?: string
+          description?: string | null
+          different_count?: number
+          id?: string
+          is_adopted?: boolean
+          is_verified?: boolean
+          keywords?: Json | null
+          link_type?: string | null
+          match_type?: string | null
+          metadata?: Json | null
+          original_url?: string | null
+          price_amount?: number | null
+          price_currency?: string | null
+          purchase_count?: number
+          qna?: Json | null
+          spot_id?: string
+          status?: string
+          thumbnail_url?: string | null
+          title?: string
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_solutions_spot_id";
-            columns: ["spot_id"];
-            isOneToOne: false;
-            referencedRelation: "spots";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_solutions_spot_id"
+            columns: ["spot_id"]
+            isOneToOne: false
+            referencedRelation: "spots"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_solutions_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_solutions_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       spots: {
         Row: {
-          created_at: string;
-          id: string;
-          position_left: string;
-          position_top: string;
-          post_id: string;
-          status: string;
-          subcategory_id: string | null;
-          updated_at: string;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          position_left: string
+          position_top: string
+          post_id: string
+          status: string
+          subcategory_id: string | null
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          position_left: string;
-          position_top: string;
-          post_id: string;
-          status?: string;
-          subcategory_id?: string | null;
-          updated_at?: string;
-          user_id: string;
-        };
+          created_at?: string
+          id: string
+          position_left: string
+          position_top: string
+          post_id: string
+          status?: string
+          subcategory_id?: string | null
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          position_left?: string;
-          position_top?: string;
-          post_id?: string;
-          status?: string;
-          subcategory_id?: string | null;
-          updated_at?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          position_left?: string
+          position_top?: string
+          post_id?: string
+          status?: string
+          subcategory_id?: string | null
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_spots_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "explore_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_spots_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "explore_posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_spots_post_id";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_spots_post_id"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_spots_subcategory_id";
-            columns: ["subcategory_id"];
-            isOneToOne: false;
-            referencedRelation: "subcategories";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_spots_subcategory_id"
+            columns: ["subcategory_id"]
+            isOneToOne: false
+            referencedRelation: "subcategories"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_spots_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_spots_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       subcategories: {
         Row: {
-          category_id: string;
-          code: string;
-          created_at: string;
-          description: Json | null;
-          display_order: number;
-          id: string;
-          is_active: boolean;
-          name: Json;
-          updated_at: string;
-        };
+          category_id: string
+          code: string
+          created_at: string
+          description: Json | null
+          display_order: number
+          id: string
+          is_active: boolean
+          name: Json
+          updated_at: string
+        }
         Insert: {
-          category_id: string;
-          code: string;
-          created_at?: string;
-          description?: Json | null;
-          display_order?: number;
-          id: string;
-          is_active?: boolean;
-          name: Json;
-          updated_at?: string;
-        };
+          category_id: string
+          code: string
+          created_at?: string
+          description?: Json | null
+          display_order?: number
+          id: string
+          is_active?: boolean
+          name: Json
+          updated_at?: string
+        }
         Update: {
-          category_id?: string;
-          code?: string;
-          created_at?: string;
-          description?: Json | null;
-          display_order?: number;
-          id?: string;
-          is_active?: boolean;
-          name?: Json;
-          updated_at?: string;
-        };
+          category_id?: string
+          code?: string
+          created_at?: string
+          description?: Json | null
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          name?: Json
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_subcategories_category_id";
-            columns: ["category_id"];
-            isOneToOne: false;
-            referencedRelation: "categories";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_subcategories_category_id"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       synonyms: {
         Row: {
-          canonical: string;
-          created_at: string;
-          id: string;
-          is_active: boolean;
-          synonyms: string[];
-          type: string;
-          updated_at: string;
-        };
+          canonical: string
+          created_at: string
+          id: string
+          is_active: boolean
+          synonyms: string[]
+          type: string
+          updated_at: string
+        }
         Insert: {
-          canonical: string;
-          created_at?: string;
-          id: string;
-          is_active?: boolean;
-          synonyms: string[];
-          type: string;
-          updated_at?: string;
-        };
+          canonical: string
+          created_at?: string
+          id: string
+          is_active?: boolean
+          synonyms: string[]
+          type: string
+          updated_at?: string
+        }
         Update: {
-          canonical?: string;
-          created_at?: string;
-          id?: string;
-          is_active?: boolean;
-          synonyms?: string[];
-          type?: string;
-          updated_at?: string;
-        };
-        Relationships: [];
-      };
+          canonical?: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          synonyms?: string[]
+          type?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_badges: {
         Row: {
-          badge_id: string;
-          earned_at: string;
-          user_id: string;
-        };
+          badge_id: string
+          earned_at: string
+          user_id: string
+        }
         Insert: {
-          badge_id: string;
-          earned_at?: string;
-          user_id: string;
-        };
+          badge_id: string
+          earned_at?: string
+          user_id: string
+        }
         Update: {
-          badge_id?: string;
-          earned_at?: string;
-          user_id?: string;
-        };
+          badge_id?: string
+          earned_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_user_badges_badge_id";
-            columns: ["badge_id"];
-            isOneToOne: false;
-            referencedRelation: "badges";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_user_badges_badge_id"
+            columns: ["badge_id"]
+            isOneToOne: false
+            referencedRelation: "badges"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_user_badges_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_user_badges_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       user_collections: {
         Row: {
-          created_at: string;
-          id: string;
-          is_pinned: boolean;
-          magazine_id: string;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          is_pinned: boolean
+          magazine_id: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          is_pinned?: boolean;
-          magazine_id: string;
-          user_id: string;
-        };
+          created_at?: string
+          id: string
+          is_pinned?: boolean
+          magazine_id: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          is_pinned?: boolean;
-          magazine_id?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          is_pinned?: boolean
+          magazine_id?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_collections_magazine_id_fkey";
-            columns: ["magazine_id"];
-            isOneToOne: false;
-            referencedRelation: "user_magazines";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_collections_magazine_id_fkey"
+            columns: ["magazine_id"]
+            isOneToOne: false
+            referencedRelation: "user_magazines"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "user_collections_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_collections_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       user_events: {
         Row: {
-          created_at: string;
-          entity_id: string | null;
-          event_type: string;
-          id: string;
-          metadata: Json | null;
-          page_path: string;
-          session_id: string;
-          user_id: string;
-        };
+          created_at: string
+          entity_id: string | null
+          event_type: string
+          id: string
+          metadata: Json | null
+          page_path: string
+          session_id: string
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          entity_id?: string | null;
-          event_type: string;
-          id?: string;
-          metadata?: Json | null;
-          page_path: string;
-          session_id: string;
-          user_id: string;
-        };
+          created_at?: string
+          entity_id?: string | null
+          event_type: string
+          id?: string
+          metadata?: Json | null
+          page_path: string
+          session_id: string
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          entity_id?: string | null;
-          event_type?: string;
-          id?: string;
-          metadata?: Json | null;
-          page_path?: string;
-          session_id?: string;
-          user_id?: string;
-        };
+          created_at?: string
+          entity_id?: string | null
+          event_type?: string
+          id?: string
+          metadata?: Json | null
+          page_path?: string
+          session_id?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_events_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       user_follows: {
         Row: {
-          created_at: string;
-          follower_id: string;
-          following_id: string;
-        };
+          created_at: string
+          follower_id: string
+          following_id: string
+        }
         Insert: {
-          created_at?: string;
-          follower_id: string;
-          following_id: string;
-        };
+          created_at?: string
+          follower_id: string
+          following_id: string
+        }
         Update: {
-          created_at?: string;
-          follower_id?: string;
-          following_id?: string;
-        };
-        Relationships: [];
-      };
+          created_at?: string
+          follower_id?: string
+          following_id?: string
+        }
+        Relationships: []
+      }
       user_magazines: {
         Row: {
-          created_at: string;
-          created_by: string;
-          id: string;
-          layout_json: Json | null;
-          magazine_type: string;
-          theme_palette: Json | null;
-          title: string;
-          updated_at: string;
-        };
+          created_at: string
+          created_by: string
+          id: string
+          layout_json: Json | null
+          magazine_type: string
+          theme_palette: Json | null
+          title: string
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          created_by: string;
-          id: string;
-          layout_json?: Json | null;
-          magazine_type: string;
-          theme_palette?: Json | null;
-          title: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          created_by: string
+          id: string
+          layout_json?: Json | null
+          magazine_type: string
+          theme_palette?: Json | null
+          title: string
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          created_by?: string;
-          id?: string;
-          layout_json?: Json | null;
-          magazine_type?: string;
-          theme_palette?: Json | null;
-          title?: string;
-          updated_at?: string;
-        };
+          created_at?: string
+          created_by?: string
+          id?: string
+          layout_json?: Json | null
+          magazine_type?: string
+          theme_palette?: Json | null
+          title?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_magazines_created_by_fkey";
-            columns: ["created_by"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_magazines_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       user_social_accounts: {
         Row: {
-          access_token: string;
-          created_at: string;
-          id: string;
-          last_synced_at: string | null;
-          provider: string;
-          provider_user_id: string;
-          refresh_token: string | null;
-          updated_at: string;
-          user_id: string;
-        };
+          access_token: string
+          created_at: string
+          id: string
+          last_synced_at: string | null
+          provider: string
+          provider_user_id: string
+          refresh_token: string | null
+          updated_at: string
+          user_id: string
+        }
         Insert: {
-          access_token: string;
-          created_at?: string;
-          id: string;
-          last_synced_at?: string | null;
-          provider: string;
-          provider_user_id: string;
-          refresh_token?: string | null;
-          updated_at?: string;
-          user_id: string;
-        };
+          access_token: string
+          created_at?: string
+          id: string
+          last_synced_at?: string | null
+          provider: string
+          provider_user_id: string
+          refresh_token?: string | null
+          updated_at?: string
+          user_id: string
+        }
         Update: {
-          access_token?: string;
-          created_at?: string;
-          id?: string;
-          last_synced_at?: string | null;
-          provider?: string;
-          provider_user_id?: string;
-          refresh_token?: string | null;
-          updated_at?: string;
-          user_id?: string;
-        };
+          access_token?: string
+          created_at?: string
+          id?: string
+          last_synced_at?: string | null
+          provider?: string
+          provider_user_id?: string
+          refresh_token?: string | null
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_social_accounts_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_social_accounts_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       user_tryon_history: {
         Row: {
-          created_at: string;
-          id: string;
-          image_url: string;
-          style_combination: Json | null;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          image_url: string
+          style_combination: Json | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          image_url: string;
-          style_combination?: Json | null;
-          user_id: string;
-        };
+          created_at?: string
+          id?: string
+          image_url: string
+          style_combination?: Json | null
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          image_url?: string;
-          style_combination?: Json | null;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          image_url?: string
+          style_combination?: Json | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "user_tryon_history_user_id_fkey";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "user_tryon_history_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       users: {
         Row: {
-          avatar_url: string | null;
-          bio: string | null;
-          created_at: string;
-          display_name: string | null;
-          email: string;
-          id: string;
-          ink_credits: number;
-          is_admin: boolean;
-          rank: string;
-          studio_config: Json | null;
-          style_dna: Json | null;
-          total_points: number;
-          updated_at: string;
-          username: string;
-        };
+          avatar_url: string | null
+          bio: string | null
+          created_at: string
+          display_name: string | null
+          email: string
+          id: string
+          ink_credits: number
+          is_admin: boolean
+          rank: string
+          studio_config: Json | null
+          style_dna: Json | null
+          total_points: number
+          updated_at: string
+          username: string
+        }
         Insert: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          display_name?: string | null;
-          email: string;
-          id: string;
-          ink_credits?: number;
-          is_admin?: boolean;
-          rank?: string;
-          studio_config?: Json | null;
-          style_dna?: Json | null;
-          total_points?: number;
-          updated_at?: string;
-          username: string;
-        };
+          avatar_url?: string | null
+          bio?: string | null
+          created_at?: string
+          display_name?: string | null
+          email: string
+          id: string
+          ink_credits?: number
+          is_admin?: boolean
+          rank?: string
+          studio_config?: Json | null
+          style_dna?: Json | null
+          total_points?: number
+          updated_at?: string
+          username: string
+        }
         Update: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          display_name?: string | null;
-          email?: string;
-          id?: string;
-          ink_credits?: number;
-          is_admin?: boolean;
-          rank?: string;
-          studio_config?: Json | null;
-          style_dna?: Json | null;
-          total_points?: number;
-          updated_at?: string;
-          username?: string;
-        };
-        Relationships: [];
-      };
+          avatar_url?: string | null
+          bio?: string | null
+          created_at?: string
+          display_name?: string | null
+          email?: string
+          id?: string
+          ink_credits?: number
+          is_admin?: boolean
+          rank?: string
+          studio_config?: Json | null
+          style_dna?: Json | null
+          total_points?: number
+          updated_at?: string
+          username?: string
+        }
+        Relationships: []
+      }
       view_logs: {
         Row: {
-          created_at: string;
-          id: string;
-          reference_id: string;
-          reference_type: string;
-          user_id: string | null;
-        };
+          created_at: string
+          id: string
+          reference_id: string
+          reference_type: string
+          user_id: string | null
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          reference_id: string;
-          reference_type: string;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id: string
+          reference_id: string
+          reference_type: string
+          user_id?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          reference_id?: string;
-          reference_type?: string;
-          user_id?: string | null;
-        };
+          created_at?: string
+          id?: string
+          reference_id?: string
+          reference_type?: string
+          user_id?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_view_logs_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_view_logs_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       votes: {
         Row: {
-          created_at: string;
-          id: string;
-          solution_id: string;
-          user_id: string;
-          vote_type: string;
-        };
+          created_at: string
+          id: string
+          solution_id: string
+          user_id: string
+          vote_type: string
+        }
         Insert: {
-          created_at?: string;
-          id: string;
-          solution_id: string;
-          user_id: string;
-          vote_type: string;
-        };
+          created_at?: string
+          id: string
+          solution_id: string
+          user_id: string
+          vote_type: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          solution_id?: string;
-          user_id?: string;
-          vote_type?: string;
-        };
+          created_at?: string
+          id?: string
+          solution_id?: string
+          user_id?: string
+          vote_type?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_votes_solution_id";
-            columns: ["solution_id"];
-            isOneToOne: false;
-            referencedRelation: "solutions";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_votes_solution_id"
+            columns: ["solution_id"]
+            isOneToOne: false
+            referencedRelation: "solutions"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_votes_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_votes_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
       explore_posts: {
         Row: {
-          ai_summary: string | null;
-          artist_id: string | null;
-          artist_name: string | null;
-          context: string | null;
-          created_at: string | null;
-          created_with_solutions: boolean | null;
-          group_id: string | null;
-          group_name: string | null;
-          id: string | null;
-          image_url: string | null;
-          media_metadata: Json | null;
-          media_type: string | null;
-          post_magazine_id: string | null;
-          post_magazine_title: string | null;
-          status: string | null;
-          title: string | null;
-          trending_score: number | null;
-          updated_at: string | null;
-          user_id: string | null;
-          view_count: number | null;
-        };
+          ai_summary: string | null
+          artist_id: string | null
+          artist_name: string | null
+          context: string | null
+          created_at: string | null
+          created_with_solutions: boolean | null
+          group_id: string | null
+          group_name: string | null
+          id: string | null
+          image_url: string | null
+          media_metadata: Json | null
+          media_type: string | null
+          post_magazine_id: string | null
+          post_magazine_title: string | null
+          status: string | null
+          title: string | null
+          trending_score: number | null
+          updated_at: string | null
+          user_id: string | null
+          view_count: number | null
+        }
         Relationships: [
           {
-            foreignKeyName: "fk_posts_post_magazine_id";
-            columns: ["post_magazine_id"];
-            isOneToOne: false;
-            referencedRelation: "post_magazines";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_posts_post_magazine_id"
+            columns: ["post_magazine_id"]
+            isOneToOne: false
+            referencedRelation: "post_magazines"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "fk_posts_user_id";
-            columns: ["user_id"];
-            isOneToOne: false;
-            referencedRelation: "users";
-            referencedColumns: ["id"];
+            foreignKeyName: "fk_posts_user_id"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Functions: {
+      is_admin: { Args: { user_id: string }; Returns: boolean }
       search_similar: {
         Args: {
-          filter_type?: string;
-          match_count?: number;
-          query_embedding: string;
-        };
+          filter_type?: string
+          match_count?: number
+          query_embedding: string
+        }
         Returns: {
-          content_text: string;
-          entity_id: string;
-          entity_type: string;
-          similarity: number;
-        }[];
-      };
-    };
+          content_text: string
+          entity_id: string
+          entity_type: string
+          similarity: number
+        }[]
+      }
+      update_magazine_status: {
+        Args: {
+          p_admin_user_id: string
+          p_magazine_id: string
+          p_new_status: string
+          p_rejection_reason?: string
+        }
+        Returns: {
+          approved_by: string | null
+          created_at: string
+          error_log: Json | null
+          id: string
+          keyword: string | null
+          layout_json: Json | null
+          published_at: string | null
+          rejection_reason: string | null
+          review_summary: string | null
+          status: string
+          subtitle: string | null
+          title: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "post_magazines"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
+      [_ in never]: never
+    }
+  }
   warehouse: {
     Tables: {
       admin_audit_log: {
         Row: {
-          action: string;
-          admin_user_id: string;
-          after_state: Json | null;
-          before_state: Json | null;
-          created_at: string;
-          id: string;
-          metadata: Json | null;
-          target_id: string | null;
-          target_table: string;
-        };
+          action: string
+          admin_user_id: string
+          after_state: Json | null
+          before_state: Json | null
+          created_at: string
+          id: string
+          metadata: Json | null
+          target_id: string | null
+          target_table: string
+        }
         Insert: {
-          action: string;
-          admin_user_id: string;
-          after_state?: Json | null;
-          before_state?: Json | null;
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          target_id?: string | null;
-          target_table: string;
-        };
+          action: string
+          admin_user_id: string
+          after_state?: Json | null
+          before_state?: Json | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          target_id?: string | null
+          target_table: string
+        }
         Update: {
-          action?: string;
-          admin_user_id?: string;
-          after_state?: Json | null;
-          before_state?: Json | null;
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          target_id?: string | null;
-          target_table?: string;
-        };
-        Relationships: [];
-      };
+          action?: string
+          admin_user_id?: string
+          after_state?: Json | null
+          before_state?: Json | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          target_id?: string | null
+          target_table?: string
+        }
+        Relationships: []
+      }
       artists: {
         Row: {
-          created_at: string;
-          id: string;
-          metadata: Json | null;
-          name_en: string | null;
-          name_ko: string | null;
-          primary_instagram_account_id: string | null;
-          profile_image_url: string | null;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          metadata: Json | null
+          name_en: string | null
+          name_ko: string | null
+          primary_instagram_account_id: string | null
+          profile_image_url: string | null
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          profile_image_url?: string | null
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          profile_image_url?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "artists_primary_instagram_account_id_fkey";
-            columns: ["primary_instagram_account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "artists_primary_instagram_account_id_fkey"
+            columns: ["primary_instagram_account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       brands: {
         Row: {
-          created_at: string;
-          id: string;
-          logo_image_url: string | null;
-          metadata: Json | null;
-          name_en: string | null;
-          name_ko: string | null;
-          primary_instagram_account_id: string | null;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          logo_image_url: string | null
+          metadata: Json | null
+          name_en: string | null
+          name_ko: string | null
+          primary_instagram_account_id: string | null
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          logo_image_url?: string | null;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          logo_image_url?: string | null
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          logo_image_url?: string | null;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          logo_image_url?: string | null
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "brands_primary_instagram_account_id_fkey";
-            columns: ["primary_instagram_account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "brands_primary_instagram_account_id_fkey"
+            columns: ["primary_instagram_account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       group_members: {
         Row: {
-          artist_id: string;
-          created_at: string;
-          group_id: string;
-          is_active: boolean;
-          metadata: Json | null;
-          updated_at: string;
-        };
+          artist_id: string
+          created_at: string
+          group_id: string
+          is_active: boolean
+          metadata: Json | null
+          updated_at: string
+        }
         Insert: {
-          artist_id: string;
-          created_at?: string;
-          group_id: string;
-          is_active?: boolean;
-          metadata?: Json | null;
-          updated_at?: string;
-        };
+          artist_id: string
+          created_at?: string
+          group_id: string
+          is_active?: boolean
+          metadata?: Json | null
+          updated_at?: string
+        }
         Update: {
-          artist_id?: string;
-          created_at?: string;
-          group_id?: string;
-          is_active?: boolean;
-          metadata?: Json | null;
-          updated_at?: string;
-        };
+          artist_id?: string
+          created_at?: string
+          group_id?: string
+          is_active?: boolean
+          metadata?: Json | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "group_members_artist_id_fkey";
-            columns: ["artist_id"];
-            isOneToOne: false;
-            referencedRelation: "artists";
-            referencedColumns: ["id"];
+            foreignKeyName: "group_members_artist_id_fkey"
+            columns: ["artist_id"]
+            isOneToOne: false
+            referencedRelation: "artists"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "group_members_group_id_fkey";
-            columns: ["group_id"];
-            isOneToOne: false;
-            referencedRelation: "groups";
-            referencedColumns: ["id"];
+            foreignKeyName: "group_members_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "groups"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       groups: {
         Row: {
-          created_at: string;
-          id: string;
-          metadata: Json | null;
-          name_en: string | null;
-          name_ko: string | null;
-          primary_instagram_account_id: string | null;
-          profile_image_url: string | null;
-          updated_at: string;
-        };
+          created_at: string
+          id: string
+          metadata: Json | null
+          name_en: string | null
+          name_ko: string | null
+          primary_instagram_account_id: string | null
+          profile_image_url: string | null
+          updated_at: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          profile_image_url?: string | null
+          updated_at?: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          primary_instagram_account_id?: string | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-        };
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          primary_instagram_account_id?: string | null
+          profile_image_url?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "groups_primary_instagram_account_id_fkey";
-            columns: ["primary_instagram_account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "groups_primary_instagram_account_id_fkey"
+            columns: ["primary_instagram_account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       images: {
         Row: {
-          created_at: string;
-          id: string;
-          image_hash: string;
-          image_url: string;
-          post_id: string;
-          status: string;
-          with_items: boolean;
-        };
+          created_at: string
+          id: string
+          image_hash: string
+          image_url: string
+          post_id: string
+          status: string
+          with_items: boolean
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          image_hash: string;
-          image_url: string;
-          post_id: string;
-          status?: string;
-          with_items?: boolean;
-        };
+          created_at?: string
+          id?: string
+          image_hash: string
+          image_url: string
+          post_id: string
+          status?: string
+          with_items?: boolean
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          image_hash?: string;
-          image_url?: string;
-          post_id?: string;
-          status?: string;
-          with_items?: boolean;
-        };
+          created_at?: string
+          id?: string
+          image_hash?: string
+          image_url?: string
+          post_id?: string
+          status?: string
+          with_items?: boolean
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_images_post_id_fkey";
-            columns: ["post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_images_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       instagram_accounts: {
         Row: {
-          account_type: Database["warehouse"]["Enums"]["account_type"];
-          artist_id: string | null;
-          bio: string | null;
-          brand_id: string | null;
-          created_at: string;
-          display_name: string | null;
+          account_type: Database["warehouse"]["Enums"]["account_type"]
+          artist_id: string | null
+          bio: string | null
+          brand_id: string | null
+          created_at: string
+          display_name: string | null
           entity_ig_role:
             | Database["warehouse"]["Enums"]["entity_ig_role"]
-            | null;
-          entity_region_code: string | null;
-          id: string;
-          is_active: boolean;
-          metadata: Json | null;
-          name_en: string | null;
-          name_ko: string | null;
-          needs_review: boolean | null;
-          profile_image_url: string | null;
-          updated_at: string;
-          username: string;
-          wikidata_id: string | null;
-          wikidata_status: string | null;
-        };
+            | null
+          entity_region_code: string | null
+          id: string
+          is_active: boolean
+          metadata: Json | null
+          name_en: string | null
+          name_ko: string | null
+          needs_review: boolean | null
+          profile_image_url: string | null
+          updated_at: string
+          username: string
+          wikidata_id: string | null
+          wikidata_status: string | null
+        }
         Insert: {
-          account_type: Database["warehouse"]["Enums"]["account_type"];
-          artist_id?: string | null;
-          bio?: string | null;
-          brand_id?: string | null;
-          created_at?: string;
-          display_name?: string | null;
+          account_type: Database["warehouse"]["Enums"]["account_type"]
+          artist_id?: string | null
+          bio?: string | null
+          brand_id?: string | null
+          created_at?: string
+          display_name?: string | null
           entity_ig_role?:
             | Database["warehouse"]["Enums"]["entity_ig_role"]
-            | null;
-          entity_region_code?: string | null;
-          id?: string;
-          is_active?: boolean;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          needs_review?: boolean | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-          username: string;
-          wikidata_id?: string | null;
-          wikidata_status?: string | null;
-        };
+            | null
+          entity_region_code?: string | null
+          id?: string
+          is_active?: boolean
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          needs_review?: boolean | null
+          profile_image_url?: string | null
+          updated_at?: string
+          username: string
+          wikidata_id?: string | null
+          wikidata_status?: string | null
+        }
         Update: {
-          account_type?: Database["warehouse"]["Enums"]["account_type"];
-          artist_id?: string | null;
-          bio?: string | null;
-          brand_id?: string | null;
-          created_at?: string;
-          display_name?: string | null;
+          account_type?: Database["warehouse"]["Enums"]["account_type"]
+          artist_id?: string | null
+          bio?: string | null
+          brand_id?: string | null
+          created_at?: string
+          display_name?: string | null
           entity_ig_role?:
             | Database["warehouse"]["Enums"]["entity_ig_role"]
-            | null;
-          entity_region_code?: string | null;
-          id?: string;
-          is_active?: boolean;
-          metadata?: Json | null;
-          name_en?: string | null;
-          name_ko?: string | null;
-          needs_review?: boolean | null;
-          profile_image_url?: string | null;
-          updated_at?: string;
-          username?: string;
-          wikidata_id?: string | null;
-          wikidata_status?: string | null;
-        };
+            | null
+          entity_region_code?: string | null
+          id?: string
+          is_active?: boolean
+          metadata?: Json | null
+          name_en?: string | null
+          name_ko?: string | null
+          needs_review?: boolean | null
+          profile_image_url?: string | null
+          updated_at?: string
+          username?: string
+          wikidata_id?: string | null
+          wikidata_status?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: "instagram_accounts_artist_id_fkey";
-            columns: ["artist_id"];
-            isOneToOne: false;
-            referencedRelation: "artists";
-            referencedColumns: ["id"];
+            foreignKeyName: "instagram_accounts_artist_id_fkey"
+            columns: ["artist_id"]
+            isOneToOne: false
+            referencedRelation: "artists"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "instagram_accounts_brand_id_fkey";
-            columns: ["brand_id"];
-            isOneToOne: false;
-            referencedRelation: "brands";
-            referencedColumns: ["id"];
+            foreignKeyName: "instagram_accounts_brand_id_fkey"
+            columns: ["brand_id"]
+            isOneToOne: false
+            referencedRelation: "brands"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       posts: {
         Row: {
-          account_id: string;
-          caption_text: string | null;
-          created_at: string;
-          id: string;
-          posted_at: string;
-          tagged_account_ids: string[] | null;
-        };
+          account_id: string
+          caption_text: string | null
+          created_at: string
+          id: string
+          posted_at: string
+          tagged_account_ids: string[] | null
+        }
         Insert: {
-          account_id: string;
-          caption_text?: string | null;
-          created_at?: string;
-          id?: string;
-          posted_at: string;
-          tagged_account_ids?: string[] | null;
-        };
+          account_id: string
+          caption_text?: string | null
+          created_at?: string
+          id?: string
+          posted_at: string
+          tagged_account_ids?: string[] | null
+        }
         Update: {
-          account_id?: string;
-          caption_text?: string | null;
-          created_at?: string;
-          id?: string;
-          posted_at?: string;
-          tagged_account_ids?: string[] | null;
-        };
+          account_id?: string
+          caption_text?: string | null
+          created_at?: string
+          id?: string
+          posted_at?: string
+          tagged_account_ids?: string[] | null
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_posts_account_id_fkey";
-            columns: ["account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_posts_account_id_fkey"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       seed_asset: {
         Row: {
-          archived_url: string | null;
-          created_at: string;
-          id: string;
-          image_hash: string;
-          metadata: Json | null;
-          seed_post_id: string;
-          source_domain: string | null;
-          source_url: string | null;
-          updated_at: string;
-        };
+          archived_url: string | null
+          created_at: string
+          id: string
+          image_hash: string
+          metadata: Json | null
+          seed_post_id: string
+          source_domain: string | null
+          source_url: string | null
+          updated_at: string
+        }
         Insert: {
-          archived_url?: string | null;
-          created_at?: string;
-          id?: string;
-          image_hash: string;
-          metadata?: Json | null;
-          seed_post_id: string;
-          source_domain?: string | null;
-          source_url?: string | null;
-          updated_at?: string;
-        };
+          archived_url?: string | null
+          created_at?: string
+          id?: string
+          image_hash: string
+          metadata?: Json | null
+          seed_post_id: string
+          source_domain?: string | null
+          source_url?: string | null
+          updated_at?: string
+        }
         Update: {
-          archived_url?: string | null;
-          created_at?: string;
-          id?: string;
-          image_hash?: string;
-          metadata?: Json | null;
-          seed_post_id?: string;
-          source_domain?: string | null;
-          source_url?: string | null;
-          updated_at?: string;
-        };
+          archived_url?: string | null
+          created_at?: string
+          id?: string
+          image_hash?: string
+          metadata?: Json | null
+          seed_post_id?: string
+          source_domain?: string | null
+          source_url?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_seed_asset_seed_post_id_fkey";
-            columns: ["seed_post_id"];
-            isOneToOne: false;
-            referencedRelation: "seed_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_asset_seed_post_id_fkey"
+            columns: ["seed_post_id"]
+            isOneToOne: false
+            referencedRelation: "seed_posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       seed_posts: {
         Row: {
-          artist_account_id: string | null;
-          backend_post_id: string | null;
-          context: string | null;
-          created_at: string;
-          group_account_id: string | null;
-          id: string;
-          image_url: string;
-          media_source: Json | null;
-          metadata: Json | null;
-          publish_error: string | null;
-          source_image_id: string | null;
-          source_post_id: string | null;
-          status: string;
-          updated_at: string;
-        };
+          artist_account_id: string | null
+          backend_post_id: string | null
+          context: string | null
+          created_at: string
+          group_account_id: string | null
+          id: string
+          image_url: string
+          media_source: Json | null
+          metadata: Json | null
+          publish_error: string | null
+          source_image_id: string | null
+          source_post_id: string | null
+          status: string
+          updated_at: string
+        }
         Insert: {
-          artist_account_id?: string | null;
-          backend_post_id?: string | null;
-          context?: string | null;
-          created_at?: string;
-          group_account_id?: string | null;
-          id?: string;
-          image_url: string;
-          media_source?: Json | null;
-          metadata?: Json | null;
-          publish_error?: string | null;
-          source_image_id?: string | null;
-          source_post_id?: string | null;
-          status?: string;
-          updated_at?: string;
-        };
+          artist_account_id?: string | null
+          backend_post_id?: string | null
+          context?: string | null
+          created_at?: string
+          group_account_id?: string | null
+          id?: string
+          image_url: string
+          media_source?: Json | null
+          metadata?: Json | null
+          publish_error?: string | null
+          source_image_id?: string | null
+          source_post_id?: string | null
+          status?: string
+          updated_at?: string
+        }
         Update: {
-          artist_account_id?: string | null;
-          backend_post_id?: string | null;
-          context?: string | null;
-          created_at?: string;
-          group_account_id?: string | null;
-          id?: string;
-          image_url?: string;
-          media_source?: Json | null;
-          metadata?: Json | null;
-          publish_error?: string | null;
-          source_image_id?: string | null;
-          source_post_id?: string | null;
-          status?: string;
-          updated_at?: string;
-        };
+          artist_account_id?: string | null
+          backend_post_id?: string | null
+          context?: string | null
+          created_at?: string
+          group_account_id?: string | null
+          id?: string
+          image_url?: string
+          media_source?: Json | null
+          metadata?: Json | null
+          publish_error?: string | null
+          source_image_id?: string | null
+          source_post_id?: string | null
+          status?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_seed_posts_artist_account_id_fkey";
-            columns: ["artist_account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_posts_artist_account_id_fkey"
+            columns: ["artist_account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "warehouse_seed_posts_group_account_id_fkey";
-            columns: ["group_account_id"];
-            isOneToOne: false;
-            referencedRelation: "instagram_accounts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_posts_group_account_id_fkey"
+            columns: ["group_account_id"]
+            isOneToOne: false
+            referencedRelation: "instagram_accounts"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "warehouse_seed_posts_source_image_id_fkey";
-            columns: ["source_image_id"];
-            isOneToOne: false;
-            referencedRelation: "images";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_posts_source_image_id_fkey"
+            columns: ["source_image_id"]
+            isOneToOne: false
+            referencedRelation: "images"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "warehouse_seed_posts_source_post_id_fkey";
-            columns: ["source_post_id"];
-            isOneToOne: false;
-            referencedRelation: "posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_posts_source_post_id_fkey"
+            columns: ["source_post_id"]
+            isOneToOne: false
+            referencedRelation: "posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       seed_solutions: {
         Row: {
-          backend_solution_id: string | null;
-          brand: string | null;
-          created_at: string;
-          description: string | null;
-          id: string;
-          metadata: Json | null;
-          original_url: string | null;
-          price_amount: number | null;
-          price_currency: string | null;
-          product_name: string | null;
-          publish_error: string | null;
-          seed_spot_id: string | null;
-          status: string;
-          updated_at: string;
-        };
+          backend_solution_id: string | null
+          brand: string | null
+          created_at: string
+          description: string | null
+          id: string
+          metadata: Json | null
+          original_url: string | null
+          price_amount: number | null
+          price_currency: string | null
+          product_name: string | null
+          publish_error: string | null
+          seed_spot_id: string | null
+          status: string
+          updated_at: string
+        }
         Insert: {
-          backend_solution_id?: string | null;
-          brand?: string | null;
-          created_at?: string;
-          description?: string | null;
-          id?: string;
-          metadata?: Json | null;
-          original_url?: string | null;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          product_name?: string | null;
-          publish_error?: string | null;
-          seed_spot_id?: string | null;
-          status?: string;
-          updated_at?: string;
-        };
+          backend_solution_id?: string | null
+          brand?: string | null
+          created_at?: string
+          description?: string | null
+          id?: string
+          metadata?: Json | null
+          original_url?: string | null
+          price_amount?: number | null
+          price_currency?: string | null
+          product_name?: string | null
+          publish_error?: string | null
+          seed_spot_id?: string | null
+          status?: string
+          updated_at?: string
+        }
         Update: {
-          backend_solution_id?: string | null;
-          brand?: string | null;
-          created_at?: string;
-          description?: string | null;
-          id?: string;
-          metadata?: Json | null;
-          original_url?: string | null;
-          price_amount?: number | null;
-          price_currency?: string | null;
-          product_name?: string | null;
-          publish_error?: string | null;
-          seed_spot_id?: string | null;
-          status?: string;
-          updated_at?: string;
-        };
+          backend_solution_id?: string | null
+          brand?: string | null
+          created_at?: string
+          description?: string | null
+          id?: string
+          metadata?: Json | null
+          original_url?: string | null
+          price_amount?: number | null
+          price_currency?: string | null
+          product_name?: string | null
+          publish_error?: string | null
+          seed_spot_id?: string | null
+          status?: string
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_seed_solutions_seed_spot_id_fkey";
-            columns: ["seed_spot_id"];
-            isOneToOne: false;
-            referencedRelation: "seed_spots";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_solutions_seed_spot_id_fkey"
+            columns: ["seed_spot_id"]
+            isOneToOne: false
+            referencedRelation: "seed_spots"
+            referencedColumns: ["id"]
           },
-        ];
-      };
+        ]
+      }
       seed_spots: {
         Row: {
-          backend_spot_id: string | null;
-          created_at: string;
-          id: string;
-          position_left: string;
-          position_top: string;
-          publish_error: string | null;
-          request_order: number;
-          seed_post_id: string;
-          status: string;
-          subcategory_code: string | null;
-          updated_at: string;
-        };
+          backend_spot_id: string | null
+          created_at: string
+          id: string
+          position_left: string
+          position_top: string
+          publish_error: string | null
+          request_order: number
+          seed_post_id: string
+          status: string
+          subcategory_code: string | null
+          updated_at: string
+        }
         Insert: {
-          backend_spot_id?: string | null;
-          created_at?: string;
-          id?: string;
-          position_left: string;
-          position_top: string;
-          publish_error?: string | null;
-          request_order: number;
-          seed_post_id: string;
-          status?: string;
-          subcategory_code?: string | null;
-          updated_at?: string;
-        };
+          backend_spot_id?: string | null
+          created_at?: string
+          id?: string
+          position_left: string
+          position_top: string
+          publish_error?: string | null
+          request_order: number
+          seed_post_id: string
+          status?: string
+          subcategory_code?: string | null
+          updated_at?: string
+        }
         Update: {
-          backend_spot_id?: string | null;
-          created_at?: string;
-          id?: string;
-          position_left?: string;
-          position_top?: string;
-          publish_error?: string | null;
-          request_order?: number;
-          seed_post_id?: string;
-          status?: string;
-          subcategory_code?: string | null;
-          updated_at?: string;
-        };
+          backend_spot_id?: string | null
+          created_at?: string
+          id?: string
+          position_left?: string
+          position_top?: string
+          publish_error?: string | null
+          request_order?: number
+          seed_post_id?: string
+          status?: string
+          subcategory_code?: string | null
+          updated_at?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "warehouse_seed_spots_seed_post_id_fkey";
-            columns: ["seed_post_id"];
-            isOneToOne: false;
-            referencedRelation: "seed_posts";
-            referencedColumns: ["id"];
+            foreignKeyName: "warehouse_seed_spots_seed_post_id_fkey"
+            columns: ["seed_post_id"]
+            isOneToOne: false
+            referencedRelation: "seed_posts"
+            referencedColumns: ["id"]
           },
-        ];
-      };
-    };
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
       account_type:
         | "artist"
@@ -2455,38 +2545,35 @@ export type Database = {
         | "source"
         | "influencer"
         | "place"
-        | "other";
-      entity_ig_role: "primary" | "regional" | "secondary";
-    };
+        | "other"
+      entity_ig_role: "primary" | "regional" | "secondary"
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  "public"
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
@@ -2494,95 +2581,95 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R;
+        Row: infer R
       }
       ? R
       : never
-    : never;
+    : never
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I;
+        Insert: infer I
       }
       ? I
       : never
-    : never;
+    : never
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U;
+        Update: infer U
       }
       ? U
       : never
-    : never;
+    : never
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never;
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never;
+    : never
 
 export const Constants = {
   public: {
@@ -2602,7 +2689,8 @@ export const Constants = {
       entity_ig_role: ["primary", "regional", "secondary"],
     },
   },
-} as const;
+} as const
+
 
 // =============================================================================
 // CUSTOM TYPE ALIASES (manually maintained)

--- a/packages/web/tests/admin/magazine-approval.spec.ts
+++ b/packages/web/tests/admin/magazine-approval.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * E2E — Admin magazine approval flow.
+ *
+ * Exercises the full loop: pending list → approve / reject / unpublish, and
+ * verifies server-side side effects via a service_role Supabase client
+ * (status transitions + audit log rows).
+ *
+ * Env requirements (test is skipped if any are missing):
+ * - NEXT_PUBLIC_SUPABASE_URL
+ * - SUPABASE_SERVICE_ROLE_KEY
+ *
+ * The test user seeded by auth.setup.ts must have an admin row in
+ * public.admin_users (or whichever table checkIsAdmin consults) — otherwise
+ * the Magazines tab will 403 and all assertions will fail.
+ */
+import { test, expect } from "@playwright/test";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const skipReason = !SUPABASE_URL
+  ? "NEXT_PUBLIC_SUPABASE_URL missing"
+  : !SERVICE_ROLE_KEY
+    ? "SUPABASE_SERVICE_ROLE_KEY missing"
+    : null;
+
+test.describe("admin magazine approval", () => {
+  test.skip(!!skipReason, skipReason ?? "");
+
+  let admin: SupabaseClient;
+  let magazineId: string;
+
+  test.beforeAll(() => {
+    admin = createClient(SUPABASE_URL!, SERVICE_ROLE_KEY!, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  });
+
+  test.beforeEach(async () => {
+    const { data, error } = await admin
+      .from("post_magazines")
+      .insert({
+        title: `E2E Test Magazine ${Date.now()}`,
+        subtitle: "E2E fixture",
+        keyword: "e2e",
+        status: "pending",
+      })
+      .select("id")
+      .single();
+    if (error || !data) {
+      throw new Error(`Failed to seed magazine: ${error?.message}`);
+    }
+    magazineId = data.id as string;
+  });
+
+  test.afterEach(async () => {
+    if (!magazineId) return;
+    await admin.from("post_magazines").delete().eq("id", magazineId);
+  });
+
+  test("approves a pending magazine", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines&status=pending");
+
+    const row = page.getByRole("row", {
+      name: new RegExp(`E2E Test Magazine`),
+    });
+    await expect(row).toBeVisible();
+    await row.getByRole("button", { name: /approve/i }).click();
+
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .from("post_magazines")
+          .select("status, approved_by, published_at")
+          .eq("id", magazineId)
+          .single();
+        return data?.status;
+      })
+      .toBe("published");
+
+    const { data: final } = await admin
+      .from("post_magazines")
+      .select("approved_by, published_at")
+      .eq("id", magazineId)
+      .single();
+    expect(final?.approved_by).not.toBeNull();
+    expect(final?.published_at).not.toBeNull();
+  });
+
+  test("rejects with required reason", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines&status=pending");
+
+    const row = page.getByRole("row", {
+      name: new RegExp(`E2E Test Magazine`),
+    });
+    await expect(row).toBeVisible();
+    await row.getByRole("button", { name: /^reject$/i }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Submit button is disabled until reason typed
+    const submit = dialog.getByRole("button", { name: /^reject$/i });
+    await expect(submit).toBeDisabled();
+
+    await dialog.getByRole("textbox").fill("Off-topic content");
+    await expect(submit).toBeEnabled();
+    await submit.click();
+
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .from("post_magazines")
+          .select("status, rejection_reason")
+          .eq("id", magazineId)
+          .single();
+        return data?.status;
+      })
+      .toBe("rejected");
+
+    const { data: final } = await admin
+      .from("post_magazines")
+      .select("rejection_reason")
+      .eq("id", magazineId)
+      .single();
+    expect(final?.rejection_reason).toBe("Off-topic content");
+  });
+
+  test("writes an audit log entry on approval", async ({ page }) => {
+    await page.goto("/admin/content?tab=magazines&status=pending");
+
+    const row = page.getByRole("row", {
+      name: new RegExp(`E2E Test Magazine`),
+    });
+    await row.getByRole("button", { name: /approve/i }).click();
+
+    await expect
+      .poll(async () => {
+        const { data } = await admin
+          .schema("warehouse")
+          .from("admin_audit_log")
+          .select("action")
+          .eq("target_id", magazineId)
+          .eq("action", "magazine_approve");
+        return data?.length ?? 0;
+      })
+      .toBeGreaterThan(0);
+  });
+});

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -8,10 +8,13 @@ export default defineConfig({
     include: [
       "tests/**/*.test.ts",
       "tests/**/*.test.tsx",
+      "lib/**/__tests__/**/*.test.ts",
       "lib/**/__tests__/**/*.test.tsx",
       "lib/**/*.test.ts",
       "lib/**/*.test.tsx",
+      "app/**/__tests__/**/*.test.ts",
       "app/**/__tests__/**/*.test.tsx",
+      "app/**/*.test.ts",
       "app/**/*.test.tsx",
     ],
     env: {

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
       "lib/**/__tests__/**/*.test.tsx",
       "lib/**/*.test.ts",
       "lib/**/*.test.tsx",
+      "app/**/__tests__/**/*.test.tsx",
+      "app/**/*.test.tsx",
     ],
     env: {
       NEXT_PUBLIC_SUPABASE_URL: "http://localhost:54321",

--- a/supabase/migrations/20260417120000_magazine_approval_fields.sql
+++ b/supabase/migrations/20260417120000_magazine_approval_fields.sql
@@ -45,3 +45,10 @@ CREATE POLICY "admin_can_update_magazines"
 CREATE INDEX IF NOT EXISTS post_magazines_status_idx
   ON public.post_magazines(status)
   WHERE status IN ('pending', 'draft');
+
+-- 7) FK: approved_by ON DELETE SET NULL (historical audit reference 보존하면서 admin user 삭제 허용)
+ALTER TABLE public.post_magazines
+  DROP CONSTRAINT IF EXISTS post_magazines_approved_by_fkey;
+ALTER TABLE public.post_magazines
+  ADD CONSTRAINT post_magazines_approved_by_fkey
+    FOREIGN KEY (approved_by) REFERENCES auth.users(id) ON DELETE SET NULL;

--- a/supabase/migrations/20260417120000_magazine_approval_fields.sql
+++ b/supabase/migrations/20260417120000_magazine_approval_fields.sql
@@ -1,0 +1,47 @@
+-- #151 Post Magazine 승인 워크플로우: is_admin 함수 + 필드 + CHECK + RLS
+
+-- 1) is_admin(uuid) SQL 함수 정의
+--    `users.is_admin` 컬럼을 단일 진실원으로 사용
+CREATE OR REPLACE FUNCTION public.is_admin(user_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT COALESCE(
+    (SELECT is_admin FROM public.users WHERE id = user_id),
+    false
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_admin(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_admin(uuid) TO authenticated, service_role;
+
+-- 2) 승인 메타데이터 컬럼
+ALTER TABLE public.post_magazines
+  ADD COLUMN IF NOT EXISTS approved_by UUID REFERENCES auth.users(id),
+  ADD COLUMN IF NOT EXISTS rejection_reason TEXT;
+
+-- 3) 기존 NULL 레코드 안전하게 'draft'로 백필
+UPDATE public.post_magazines SET status = 'draft' WHERE status IS NULL;
+
+-- 4) status CHECK 제약
+ALTER TABLE public.post_magazines
+  DROP CONSTRAINT IF EXISTS post_magazines_status_check;
+ALTER TABLE public.post_magazines
+  ADD CONSTRAINT post_magazines_status_check
+  CHECK (status IN ('draft', 'pending', 'published', 'rejected'));
+
+-- 5) 관리자 UPDATE RLS 정책
+DROP POLICY IF EXISTS "admin_can_update_magazines" ON public.post_magazines;
+CREATE POLICY "admin_can_update_magazines"
+  ON public.post_magazines
+  FOR UPDATE
+  USING (public.is_admin(auth.uid()))
+  WITH CHECK (public.is_admin(auth.uid()));
+
+-- 6) 필터링 인덱스
+CREATE INDEX IF NOT EXISTS post_magazines_status_idx
+  ON public.post_magazines(status)
+  WHERE status IN ('pending', 'draft');

--- a/supabase/migrations/20260417120001_update_magazine_status_rpc.sql
+++ b/supabase/migrations/20260417120001_update_magazine_status_rpc.sql
@@ -21,7 +21,7 @@ BEGIN
   SELECT * INTO v_before FROM public.post_magazines
     WHERE id = p_magazine_id FOR UPDATE;
 
-  IF v_before IS NULL THEN
+  IF NOT FOUND THEN
     RAISE EXCEPTION 'magazine_not_found' USING ERRCODE = 'P0002';
   END IF;
 
@@ -68,7 +68,7 @@ BEGIN
     jsonb_build_object('rejection_reason', p_rejection_reason)
   );
 
-  RETURN QUERY SELECT * FROM public.post_magazines WHERE id = p_magazine_id;
+  RETURN NEXT v_after;
 END;
 $$;
 

--- a/supabase/migrations/20260417120001_update_magazine_status_rpc.sql
+++ b/supabase/migrations/20260417120001_update_magazine_status_rpc.sql
@@ -1,0 +1,76 @@
+-- #151 update_magazine_status RPC
+-- UPDATE post_magazines + INSERT warehouse.admin_audit_log 원자 처리
+-- 상태 전이 검증: draft→pending, pending→published/rejected, rejected→pending, published→draft
+-- rejected 시 rejection_reason 필수
+
+CREATE OR REPLACE FUNCTION public.update_magazine_status(
+  p_magazine_id UUID,
+  p_new_status VARCHAR,
+  p_admin_user_id UUID,
+  p_rejection_reason TEXT DEFAULT NULL
+) RETURNS SETOF public.post_magazines
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, warehouse, pg_temp
+AS $$
+DECLARE
+  v_before public.post_magazines;
+  v_after public.post_magazines;
+  v_action TEXT;
+BEGIN
+  SELECT * INTO v_before FROM public.post_magazines
+    WHERE id = p_magazine_id FOR UPDATE;
+
+  IF v_before IS NULL THEN
+    RAISE EXCEPTION 'magazine_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 전이 유효성
+  IF NOT (
+    (v_before.status = 'draft'     AND p_new_status = 'pending')   OR
+    (v_before.status = 'pending'   AND p_new_status = 'published') OR
+    (v_before.status = 'pending'   AND p_new_status = 'rejected')  OR
+    (v_before.status = 'rejected'  AND p_new_status = 'pending')   OR
+    (v_before.status = 'published' AND p_new_status = 'draft')
+  ) THEN
+    RAISE EXCEPTION 'invalid_transition: % -> %', v_before.status, p_new_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_new_status = 'rejected' AND (p_rejection_reason IS NULL OR length(trim(p_rejection_reason)) = 0) THEN
+    RAISE EXCEPTION 'rejection_reason_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.post_magazines
+  SET status = p_new_status,
+      approved_by = CASE WHEN p_new_status = 'published' THEN p_admin_user_id ELSE approved_by END,
+      published_at = CASE WHEN p_new_status = 'published' THEN now() ELSE published_at END,
+      rejection_reason = CASE WHEN p_new_status = 'rejected' THEN p_rejection_reason ELSE NULL END,
+      updated_at = now()
+  WHERE id = p_magazine_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE p_new_status
+    WHEN 'published' THEN 'magazine_approve'
+    WHEN 'rejected'  THEN 'magazine_reject'
+    WHEN 'pending'   THEN 'magazine_submit'
+    WHEN 'draft'     THEN 'magazine_unpublish'
+    ELSE 'magazine_status_change'
+  END;
+
+  INSERT INTO warehouse.admin_audit_log (
+    admin_user_id, action, target_table, target_id,
+    before_state, after_state, metadata
+  ) VALUES (
+    p_admin_user_id, v_action, 'post_magazines', p_magazine_id,
+    row_to_json(v_before)::jsonb,
+    row_to_json(v_after)::jsonb,
+    jsonb_build_object('rejection_reason', p_rejection_reason)
+  );
+
+  RETURN QUERY SELECT * FROM public.post_magazines WHERE id = p_magazine_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) TO authenticated, service_role;

--- a/supabase/migrations/20260417120002_update_magazine_status_rpc_admin_guard.sql
+++ b/supabase/migrations/20260417120002_update_magazine_status_rpc_admin_guard.sql
@@ -27,14 +27,25 @@ DECLARE
   v_action TEXT;
   v_caller UUID := auth.uid();
 BEGIN
-  -- AuthZ: caller must be an admin. When invoked from a user session
-  -- (auth.uid() non-null) we additionally require the passed admin_user_id
-  -- to match the session, so a malicious caller can't stamp the audit log
-  -- with someone else's UUID.
+  -- AuthZ trust boundary (read carefully).
+  --
+  -- This RPC is GRANT EXECUTE TO service_role only (see bottom of file).
+  -- That means only the Next.js admin client, which ran checkIsAdmin() on
+  -- the session first, can reach here. When invoked via service_role,
+  -- auth.uid() is NULL and we must trust p_admin_user_id -- the caller
+  -- is responsible for passing the authenticated session's user id.
+  --
+  -- If an authenticated (non-service_role) caller ever regains execute
+  -- permission, the caller_mismatch check below forces p_admin_user_id to
+  -- equal the session's auth.uid(), preventing UUID spoofing in the audit
+  -- log even under that fallback scenario.
   IF v_caller IS NOT NULL AND v_caller <> p_admin_user_id THEN
     RAISE EXCEPTION 'caller_mismatch' USING ERRCODE = 'P0003';
   END IF;
 
+  -- Defense-in-depth: even with service_role, the passed UUID must
+  -- resolve to an admin row. Prevents a bug in the route layer from
+  -- accidentally escalating a non-admin user.
   IF NOT public.is_admin(p_admin_user_id) THEN
     RAISE EXCEPTION 'caller_not_admin' USING ERRCODE = 'P0003';
   END IF;

--- a/supabase/migrations/20260417120002_update_magazine_status_rpc_admin_guard.sql
+++ b/supabase/migrations/20260417120002_update_magazine_status_rpc_admin_guard.sql
@@ -1,0 +1,103 @@
+-- #151 Security fix: guard update_magazine_status RPC against non-admin callers.
+--
+-- Before this patch the RPC was GRANTed to `authenticated`, so any logged-in
+-- user could call supabase.rpc('update_magazine_status', { p_admin_user_id: own_id })
+-- from the browser and approve/reject any magazine, bypassing the Next.js
+-- checkIsAdmin() gate entirely. SECURITY DEFINER also skips RLS.
+--
+-- Fix:
+-- 1) Assert the passed p_admin_user_id is actually an admin AND equals auth.uid()
+--    when called in a user session (auth.uid() is non-null).
+-- 2) Revoke grant from `authenticated`; only service_role (used by the Next.js
+--    admin client in `createAdminSupabaseClient`) may invoke this RPC.
+
+CREATE OR REPLACE FUNCTION public.update_magazine_status(
+  p_magazine_id UUID,
+  p_new_status VARCHAR,
+  p_admin_user_id UUID,
+  p_rejection_reason TEXT DEFAULT NULL
+) RETURNS SETOF public.post_magazines
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, warehouse, pg_temp
+AS $$
+DECLARE
+  v_before public.post_magazines;
+  v_after public.post_magazines;
+  v_action TEXT;
+  v_caller UUID := auth.uid();
+BEGIN
+  -- AuthZ: caller must be an admin. When invoked from a user session
+  -- (auth.uid() non-null) we additionally require the passed admin_user_id
+  -- to match the session, so a malicious caller can't stamp the audit log
+  -- with someone else's UUID.
+  IF v_caller IS NOT NULL AND v_caller <> p_admin_user_id THEN
+    RAISE EXCEPTION 'caller_mismatch' USING ERRCODE = 'P0003';
+  END IF;
+
+  IF NOT public.is_admin(p_admin_user_id) THEN
+    RAISE EXCEPTION 'caller_not_admin' USING ERRCODE = 'P0003';
+  END IF;
+
+  -- rejection_reason length guard (defense-in-depth; routes also trim/clamp).
+  IF p_rejection_reason IS NOT NULL AND length(p_rejection_reason) > 2000 THEN
+    RAISE EXCEPTION 'rejection_reason_too_long' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_before FROM public.post_magazines
+    WHERE id = p_magazine_id FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'magazine_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF NOT (
+    (v_before.status = 'draft'     AND p_new_status = 'pending')   OR
+    (v_before.status = 'pending'   AND p_new_status = 'published') OR
+    (v_before.status = 'pending'   AND p_new_status = 'rejected')  OR
+    (v_before.status = 'rejected'  AND p_new_status = 'pending')   OR
+    (v_before.status = 'published' AND p_new_status = 'draft')
+  ) THEN
+    RAISE EXCEPTION 'invalid_transition: % -> %', v_before.status, p_new_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF p_new_status = 'rejected' AND (p_rejection_reason IS NULL OR length(trim(p_rejection_reason)) = 0) THEN
+    RAISE EXCEPTION 'rejection_reason_required' USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.post_magazines
+  SET status = p_new_status,
+      approved_by = CASE WHEN p_new_status = 'published' THEN p_admin_user_id ELSE approved_by END,
+      published_at = CASE WHEN p_new_status = 'published' THEN now() ELSE published_at END,
+      rejection_reason = CASE WHEN p_new_status = 'rejected' THEN p_rejection_reason ELSE NULL END,
+      updated_at = now()
+  WHERE id = p_magazine_id
+  RETURNING * INTO v_after;
+
+  v_action := CASE p_new_status
+    WHEN 'published' THEN 'magazine_approve'
+    WHEN 'rejected'  THEN 'magazine_reject'
+    WHEN 'pending'   THEN 'magazine_submit'
+    WHEN 'draft'     THEN 'magazine_unpublish'
+    ELSE 'magazine_status_change'
+  END;
+
+  INSERT INTO warehouse.admin_audit_log (
+    admin_user_id, action, target_table, target_id,
+    before_state, after_state, metadata
+  ) VALUES (
+    p_admin_user_id, v_action, 'post_magazines', p_magazine_id,
+    row_to_json(v_before)::jsonb,
+    row_to_json(v_after)::jsonb,
+    jsonb_build_object('rejection_reason', p_rejection_reason)
+  );
+
+  RETURN NEXT v_after;
+END;
+$$;
+
+-- Drop authenticated grant — Next.js admin route uses service_role client.
+REVOKE ALL ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT) TO service_role;


### PR DESCRIPTION
Closes #151

## Summary

Admin 페이지 mock → 실데이터 전환 + Post Magazine 승인 워크플로우 신규 구현.

- **Wave 1**: `audit-log / content / editorial-candidates / monitoring` 4개 페이지 빈 상태 UI 추가
- **Wave 2a**: `post_magazines` 승인 필드 + `update_magazine_status` RPC(원자 상태전이+audit) + `is_admin` SQL 헬퍼
- **Wave 2b**: `GET /api/v1/admin/posts/magazines`, `PATCH /api/v1/admin/posts/magazines/:id/status`
- **Wave 2c**: React Query 훅 2종 + 컴포넌트 4종(MagazineStatusFilter / RejectModal / MagazineActions / MagazineApprovalTable) + `content` 페이지에 magazines 탭 배선
- **Wave 3**: `picks` CRUD 3개 라우트에 `writeAuditLog` 커버 (Rust proxy 엔드포인트는 #237로 분리)
- **Wave 4**: 보안/코드리뷰 피드백 반영 — RPC admin guard, 에러 메시지 일반화, PATCH 타입 검증, RejectModal 접근성

## 분리 이슈

- #237 Rust API audit 통합 (reports, posts status/metadata)
- #238 entities/seed 서브라우트 실데이터 점검 + empty state
- Editorial 승인 워크플로우는 추후 별도 이슈

## 주요 보안 수정

- `update_magazine_status` RPC가 `authenticated`에 노출되어 클라이언트에서 `p_admin_user_id`를 스푸핑하면 누구나 매거진을 승인/거부할 수 있던 High 취약점 해결:
  - `is_admin(p_admin_user_id)` 검증 추가
  - `auth.uid() <> p_admin_user_id` 차단 (세션 ID 스푸핑 방지)
  - `authenticated`에 대한 grant 제거, `service_role`에만 실행 허용
- admin 라우트 5건에서 DB 에러 메시지 직접 노출 → 서버 로그 + `internal_error` 일반 메시지
- `picks` PATCH body 필드별 명시적 타입 검증 + 길이 clamp
- `rejection_reason` 2000자 상한 (라우트 + RPC 이중 방어)

## 설계 문서

`docs/superpowers/specs/2026-04-17-151-admin-real-data-design.md`

## Test plan

- [x] Vitest 유닛/통합 — 52 admin + magazine 테스트 pass
- [x] 신규 5개 admin 라우트 타입체크 clean
- [x] 신규 9개 파일 ESLint clean
- [x] Supabase 마이그레이션 3건 (magazine 필드/RPC/보안 가드) 순차 적용 가능
- [x] security-reviewer + code-reviewer 에이전트 피드백 반영 완료
- [ ] Playwright E2E `tests/admin/magazine-approval.spec.ts` — 서비스 롤 키가 있는 환경에서 실행 (현 로컬에선 env-gated skip)
- [ ] 리뷰어: 로컬에서 `/admin/content?tab=magazines`로 수동 승인/거부 흐름 확인

## 커밋 스타일

- TDD 우선 (테스트 → 구현 → 커밋) / Wave별 원자 커밋
- 32 커밋: Wave 1(5) + Wave 2a(6) + Wave 2b(4) + Wave 2c(8) + Wave 3(3) + Wave 4(1) + 기존 dashboard mock→real 전환 작업(+5)