### PR TITLE
refactor(search): stabilize explore sync + explicit search error UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ packages/backend/target/
 
 # Worktrees
 .claude/worktrees/
+.worktrees/
 .vercel
 packages/ai-server/searxng/settings.yml.new
 

--- a/packages/web/app/explore/ExploreClient.tsx
+++ b/packages/web/app/explore/ExploreClient.tsx
@@ -62,7 +62,7 @@ export function ExploreClient({
       setQuery(initialQuery);
       setDebouncedQuery(initialQuery);
     }
-  }, []);
+  }, [initialQuery, query, setQuery, setDebouncedQuery]);
 
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);

--- a/packages/web/app/explore/ExploreClient.tsx
+++ b/packages/web/app/explore/ExploreClient.tsx
@@ -354,7 +354,7 @@ export function ExploreClient({
               </div>
             )}
 
-            {/* Error state — browse mode only (search mode falls through to fallback) */}
+            {/* Error state — browse mode */}
             {isError && mode !== "search" && (
               <div className="absolute inset-0 z-0 flex items-center justify-center">
                 <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
@@ -385,9 +385,48 @@ export function ExploreClient({
               </div>
             )}
 
-            {/* Empty/error state with search suggestions */}
-            {((!isError && !isLoading && items.length === 0) ||
-              (isError && mode === "search")) && (
+            {/* Error state — search mode (backend/Meilisearch outage) */}
+            {isError && mode === "search" && (
+              <div className="absolute inset-0 z-0 flex items-center justify-center">
+                <div className="flex flex-col items-center justify-center px-4 py-12 text-center max-w-md">
+                  <div className="mb-4 text-4xl">🛠️</div>
+                  <h2 className="mb-2 text-xl font-semibold text-foreground">
+                    Search is temporarily unavailable
+                  </h2>
+                  <p className="mb-6 text-sm text-muted-foreground">
+                    {(() => {
+                      if (process.env.NODE_ENV === "development") {
+                        console.error("[ExploreClient] Search error:", error);
+                      }
+                      const msg =
+                        error instanceof Error
+                          ? error.message
+                          : "Please try again in a moment.";
+                      return msg.length > 140 ? `${msg.slice(0, 140)}…` : msg;
+                    })()}
+                  </p>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    <button
+                      onClick={() => refetch()}
+                      className="rounded-full border border-border bg-card/80 px-4 py-2 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+                      type="button"
+                    >
+                      Retry
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleClear}
+                      className="rounded-full px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Clear search
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Empty state with search suggestions */}
+            {!isError && !isLoading && items.length === 0 && (
               <div className="absolute inset-0 z-0 flex items-center justify-center">
                 <div className="flex flex-col items-center justify-center px-4 py-12 text-center max-w-md">
                   <div className="mb-4 text-4xl">

--- a/packages/web/lib/hooks/useExploreData.ts
+++ b/packages/web/lib/hooks/useExploreData.ts
@@ -116,11 +116,7 @@ export function useExploreData(
 
   // Search mode: Meilisearch with API filters
   const searchResult = useInfiniteQuery({
-    queryKey: [
-      "search",
-      "infinite",
-      { q: debouncedQuery, context: activeContext, sort: activeSort },
-    ],
+    queryKey: ["search", "infinite", debouncedQuery, activeContext, activeSort],
     queryFn: async ({ pageParam = 1 }) => {
       return search({
         q: debouncedQuery,


### PR DESCRIPTION
## Summary

- `ExploreClient`: complete `useEffect` dep array for URL→store init, prevents store desync on later query changes.
- `useExploreData`: flatten `useInfiniteQuery` key to primitives so React Query can share cache across renders.
- `ExploreClient`: split the search-mode error branch from the empty-state branch so users see a clear "Search is temporarily unavailable" message (with Retry) when Meilisearch / the search proxy is unreachable instead of a generic "No results" screen.

## Scope note

Does **not close #149**. The reported user symptom ("search doesn't return results") is actually caused by the local **Meilisearch service being unreachable** (port 7700, 502 from \`/api/v1/search\`) — an infra/dev-env issue tracked separately.

This PR hardens the explore page around that failure mode and reduces React Query churn, which is a strict improvement regardless of the Meilisearch issue.

## Evidence

- \`bun run lint\`: 0 errors (98 pre-existing warnings)
- \`bun run typecheck\`: clean
- \`bash packages/web/scripts/pre-push.sh\`: \`=== web: 모든 체크 통과 ===\`
- Manual: typed in search box → new \`/api/v1/search?q=...\` requests fire correctly; 502 responses now render an explicit error panel.

## Test plan

- [ ] Open \`/search?q=test\` without local Meilisearch → explicit "Search is temporarily unavailable" panel with Retry + Clear buttons.
- [ ] With Meilisearch running: keyword changes update results, URL param drives initial state, "Clear search" resets both input and store.
- [ ] Browse mode (no query) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)