### PR TITLE
refactor(editorial): harden MagazineNewsSection image rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ packages/backend/target/
 
 # Worktrees
 .claude/worktrees/
+.worktrees/
 .vercel
 packages/ai-server/searxng/settings.yml.new
 

--- a/packages/web/lib/components/detail/magazine/MagazineNewsSection.tsx
+++ b/packages/web/lib/components/detail/magazine/MagazineNewsSection.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 import ScrollTrigger from "gsap/ScrollTrigger";
 import Image from "next/image";
 import type { PostMagazineNewsReference } from "@/lib/api/mutation-types";
+
+const isValidImageUrl = (url: string | null | undefined): boolean => {
+  if (!url) return false;
+  try {
+    const u = new URL(url);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
 
 if (typeof window !== "undefined") {
   gsap.registerPlugin(ScrollTrigger);
@@ -23,6 +33,7 @@ export function MagazineNewsSection({
   isModal,
 }: Props) {
   const sectionRef = useRef<HTMLDivElement>(null);
+  const [imgErrorSet, setImgErrorSet] = useState<Set<string>>(new Set());
 
   useGSAP(() => {
     if (!sectionRef.current || isModal) return;
@@ -93,17 +104,29 @@ export function MagazineNewsSection({
                   rel="noopener noreferrer"
                   className="news-card group flex gap-3 rounded-lg border border-border/50 bg-card p-3 transition-all hover:border-border hover:shadow-md"
                 >
-                  {ref.og_image && (
-                    <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                  <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                    {isValidImageUrl(ref.og_image) &&
+                    !imgErrorSet.has(`${ref.url}-${i}`) ? (
                       <Image
-                        src={ref.og_image}
+                        src={ref.og_image!}
                         alt={ref.title}
                         fill
                         className="object-cover transition-transform duration-300 group-hover:scale-105"
                         sizes="80px"
+                        onError={() =>
+                          setImgErrorSet((prev) =>
+                            new Set(prev).add(`${ref.url}-${i}`)
+                          )
+                        }
                       />
-                    </div>
-                  )}
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center">
+                        <span className="text-lg font-semibold uppercase text-muted-foreground/50">
+                          {(ref.source ?? ref.title).charAt(0)}
+                        </span>
+                      </div>
+                    )}
+                  </div>
 
                   <div className="flex min-w-0 flex-1 flex-col justify-between">
                     <div>


### PR DESCRIPTION
## Summary

\`MagazineNewsSection\` now:

- Validates \`og_image\` URL (must be http/https and parseable).
- Tracks per-reference \`onError\` failures so one broken image doesn't cascade.
- Renders a neutral \`bg-muted\` box with the source/title initial as a fallback so the 80×80 card keeps layout stability when the proxy fails or the URL is missing.

## Scope note

Does **not close #148**. While investigating, DevTools evidence showed:

- The \`Related News\` section does **not render at all** for the reported post because backend \`post_magazine_news_references\` rows are empty for every published magazine (\`news_count = 0\` for 6/6 magazines checked).
- The images the user sees as "broken" on the Editorial page are actually **Solution/Item cards** going through Next \`_next/image\` → \`/api/v1/image-proxy\` and failing for HTTP-only domains (\`nowfromthen.com\`, Pinterest) and large-size requests (\`w=1920\` → \`naturalWidth: 0\`).

The true fix requires a backend pipeline investigation (why \`post_magazine_news_references\` is never populated) and/or an image-proxy audit. Both are tracked separately; #148 should be re-scoped with that context.

This PR still lands the frontend defense so that when \`news_references\` *does* start flowing, a failing OG image URL won't break the layout.

## Evidence

- \`bun run lint\`: 0 errors
- \`bun run typecheck\`: clean
- \`bash packages/web/scripts/pre-push.sh\`: passed
- Manual (via Playwright): existing pages unchanged; placeholder renders correctly when URL is invalid.

## Test plan

- [ ] Editorial post with valid \`news_references\`: images render as before.
- [ ] Inject an invalid/broken \`og_image\` URL → placeholder with source initial appears, layout stable.
- [ ] No console errors from \`<Image>\` onError cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)