### PR TITLE
feat(infra): worktree bootstrap script + bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,88 @@
+name: 🐛 Bug report
+description: 재현 가능한 버그 보고 — 증상·증거·기대값을 분리해서 적어주세요
+title: "bug(<scope>): <한 줄 요약>"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        증상만 기반으로 이슈를 열면 다른 사람이 **다른 버그를 고치게 될 수 있습니다**. 아래 섹션을 최대한 채워주세요.
+  - type: input
+    id: scope
+    attributes:
+      label: 스코프
+      description: 어느 영역? (web/api/ai/infra/editorial/search/upload 등)
+      placeholder: web / search
+    validations:
+      required: true
+  - type: textarea
+    id: symptom
+    attributes:
+      label: 증상 (What)
+      description: 사용자가 실제로 본 것. 화면 캡처/GIF 권장.
+      placeholder: |
+        - 예: /search?q=블랙핑크 → 결과가 뜨지 않음
+        - 예: Editorial 상세 → Related News 이미지가 깨짐
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: 재현 단계
+      description: 다른 사람이 그대로 따라할 수 있는 단계
+      placeholder: |
+        1. dev 서버 기동 (`just local-deps && bun dev`)
+        2. http://localhost:3000/search 진입
+        3. 검색창에 "test" 입력
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 증거 (DevTools / 로그 / 쿼리 응답)
+      description: |
+        증상만으로는 원인이 불명확합니다. 최소 하나 이상 첨부:
+        - **Network**: 요청 URL + 응답 상태 + 응답 바디 (민감정보 마스킹)
+        - **Console**: 에러/경고 메시지
+        - **DB/SQL 결과**: 관련 row 상태 (Supabase Studio 등)
+        - **서버 로그**: `.logs/local/*.log`
+      placeholder: |
+        Request:  GET /api/v1/search?q=test&page=1&limit=40
+        Response: 502 Bad Gateway
+        Body:     {"error":{"code":502,"message":"Advanced search failed..."}}
+        Console:  Failed to load resource: 502 (Bad Gateway)
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 기대 동작
+      placeholder: 검색 결과 그리드가 표시되거나, 최소한 "검색 서비스 일시 장애" 같은 명시적 에러 UI가 나와야 함
+    validations:
+      required: true
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: 가설 (선택)
+      description: 원인에 대한 추측. 확정 아님을 명시. 없으면 비워도 됨.
+      placeholder: |
+        - Meilisearch 미기동? 혹은 `/api/v1/search` 프록시 문제?
+        - useEffect 의존성 누락으로 store 재동기화 실패?
+  - type: textarea
+    id: environment
+    attributes:
+      label: 환경
+      placeholder: |
+        - 브랜치/커밋: dev @ 71eedf42
+        - 로컬: macOS 25.3.0, bun 1.3.10, Node 22
+        - Meilisearch/Redis 기동 여부: ✅ / ❌
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: 체크리스트
+      options:
+        - label: 메인 `dev` 브랜치 최신에서 재현됨
+          required: false
+        - label: 이미 있는 이슈를 검색했음 (중복 아님)
+          required: true

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ packages/backend/target/
 
 # Worktrees
 .claude/worktrees/
+.worktrees/
 .vercel
 packages/ai-server/searxng/settings.yml.new
 

--- a/Justfile
+++ b/Justfile
@@ -54,4 +54,22 @@ e2e:
 e2e-only PATTERN:
     cd "{{ repo }}/packages/web" && bunx playwright test --grep "{{ PATTERN }}"
 
+# 워크트리 부트스트랩 — env 심볼릭 링크 + bun install + 포트 안내
+# 예:   just worktree-setup .worktrees/149-search-fix
+#       just worktree-setup .worktrees/148-editorial-og 3001
+worktree-setup PATH PORT="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=("{{ PATH }}")
+    if [[ -n "{{ PORT }}" ]]; then args+=(--port "{{ PORT }}"); fi
+    bash "{{ repo }}/scripts/worktree-bootstrap.sh" "${args[@]}"
+
+# 현재 워크트리(cwd)에서 즉시 부트스트랩
+worktree-setup-here PORT="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    args=(--here)
+    if [[ -n "{{ PORT }}" ]]; then args+=(--port "{{ PORT }}"); fi
+    bash "{{ repo }}/scripts/worktree-bootstrap.sh" "${args[@]}"
+
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "decoded-monorepo",

--- a/docs/GIT-WORKFLOW.md
+++ b/docs/GIT-WORKFLOW.md
@@ -178,3 +178,52 @@ hotfix/*  ──PR──▶ main (긴급 시에만)
 ## 릴리스 플로우
 
 `dev` → `main` PR 머지 시 Vercel 자동 배포. 별도 릴리스 브랜치 없음.
+
+## 워크트리 (병렬 피처 작업)
+
+여러 피처/버그를 동시에 진행하거나, 장시간 dev 서버 없이 코드만 만지는 경우 [git worktree](https://git-scm.com/docs/git-worktree)를 사용.
+
+### 기본 사용
+
+```bash
+# 1) 워크트리 생성 — dev 기준 새 feature 브랜치
+git worktree add .worktrees/149-search-fix -b feature/149-search-fix dev
+
+# 2) 부트스트랩 — env 심볼릭 링크 + bun install
+just worktree-setup .worktrees/149-search-fix
+
+# 3) 여러 워크트리 동시에 dev 서버 띄우려면 포트 분리
+just worktree-setup .worktrees/148-editorial-og 3001
+```
+
+### 폴더 규칙
+
+- **위치**: `.worktrees/<branch-slug>/` (gitignored, 하이든 폴더)
+- **이름**: 이슈 번호 + 짧은 슬러그 (`149-search-fix`)
+- **브랜치**: `feature/<issue>-<slug>` 또는 `fix/*`
+- 메인 워크트리에서는 부트스트랩 실행하지 않음 (스크립트가 거부함)
+
+### 부트스트랩이 하는 일
+
+`scripts/worktree-bootstrap.sh` = `just worktree-setup`:
+
+1. 메인 워크트리에서 `.env.local`, `.env.backend.dev`, `packages/web/.playwright/`를 **심볼릭 링크** (수정이 즉시 모든 워크트리에 반영됨)
+2. `bun install` 실행 (워크트리 node_modules 동기화)
+3. `--port <N>` 지정 시 `packages/web/.env.local.port` 메모 파일 + `PORT=<N> bun dev` 안내
+
+### 수동 QA 패턴
+
+- **단일 수정 QA**: 해당 워크트리에서 바로 `bun dev` (포트 3000)
+- **여러 수정 합쳐서 QA**: 메인 워크트리에 `qa/*` 브랜치 만들어 피처 브랜치들 머지 → QA → PR 각자 올림
+- **병렬 QA**: 각 워크트리에 포트 다르게 (3001/3002) 부트스트랩 → 동시에 `bun dev`
+
+### 정리
+
+```bash
+# 브랜치 유지 + 폴더 삭제
+git worktree remove .worktrees/149-search-fix
+
+# 브랜치까지 삭제
+git worktree remove .worktrees/149-search-fix
+git branch -D feature/149-search-fix
+```

--- a/scripts/worktree-bootstrap.sh
+++ b/scripts/worktree-bootstrap.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# scripts/worktree-bootstrap.sh — 워크트리에서 `bun dev`를 바로 돌릴 수 있도록
+# env 파일을 메인 워크트리에서 심볼릭 링크하고 의존성을 재정비한다.
+#
+# 사용:
+#   ./scripts/worktree-bootstrap.sh <worktree-path>           # 메인 워크트리 기준으로 자동 셋업
+#   ./scripts/worktree-bootstrap.sh <worktree-path> --port 3001
+#   ./scripts/worktree-bootstrap.sh --here                     # 현재 cwd가 워크트리라고 가정
+#
+# 규칙:
+# - 메인 워크트리 = `git worktree list`의 첫 번째 (=원본 clone) 경로
+# - 대상 워크트리의 `.env.local` / `.env.backend.dev` / `packages/web/.playwright`가 없으면 심볼릭 링크
+# - `bun install`로 워크트리용 lockfile 동기화
+# - --port 지정 시 `<worktree>/packages/web/.env.local.port`에 PORT 써두고 안내 출력
+#
+# 왜 symlink인가:
+# - env 파일 수정이 모든 워크트리에 즉시 반영됨 (중복 없음)
+# - git status에 추적 대상으로 잡히지 않음 (gitignored)
+# - 실수로 커밋할 여지 최소화
+
+set -euo pipefail
+
+usage() {
+  cat <<EOS
+usage: $(basename "$0") <worktree-path> [--port <n>]
+       $(basename "$0") --here [--port <n>]
+
+options:
+  --port <n>    dev 서버가 쓸 포트 (기본: 3000, 여러 워크트리 동시 실행 시 3001/3002…)
+  --here        현재 cwd를 워크트리 경로로 사용
+  -h, --help    이 메시지
+
+예:
+  $(basename "$0") .worktrees/149-search-fix --port 3001
+EOS
+}
+
+WT=""
+PORT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --here) WT="$(pwd)"; shift ;;
+    --port) PORT="${2:?--port 값이 필요합니다}"; shift 2 ;;
+    --port=*) PORT="${1#*=}"; shift ;;
+    --) shift; break ;;
+    -*) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+    *)
+      if [[ -z "$WT" ]]; then WT="$1"; shift
+      else echo "unexpected argument: $1" >&2; usage >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$WT" ]]; then
+  echo "error: 워크트리 경로가 필요합니다." >&2
+  usage >&2
+  exit 2
+fi
+
+WT="$(cd "$WT" && pwd)"
+
+# 현재 디렉토리 기준으로 git 메타 조회 (main worktree 판별)
+MAIN_WT="$(git -C "$WT" worktree list --porcelain | awk '$1=="worktree"{print $2; exit}')"
+
+if [[ -z "$MAIN_WT" ]]; then
+  echo "error: $WT 는 git 워크트리가 아닙니다." >&2
+  exit 1
+fi
+
+if [[ "$MAIN_WT" == "$WT" ]]; then
+  echo "error: 메인 워크트리에서는 실행하지 마세요. 병렬 QA용 보조 워크트리에서만 돌립니다." >&2
+  echo "       현재 MAIN=$MAIN_WT"
+  exit 1
+fi
+
+echo "→ main worktree : $MAIN_WT"
+echo "→ target worktree: $WT"
+echo
+
+# -- env 심볼릭 링크 대상 목록
+# (source-relative-path | target-relative-path | required?)
+link_entry() {
+  local src_rel="$1"
+  local dst_rel="$2"
+  local required="${3:-false}"
+
+  local src="$MAIN_WT/$src_rel"
+  local dst="$WT/$dst_rel"
+
+  if [[ ! -e "$src" ]]; then
+    if [[ "$required" == "true" ]]; then
+      echo "  ✗ $dst_rel 필요하지만 메인에 $src_rel 없음" >&2
+      return 1
+    else
+      echo "  · $dst_rel skip (메인에 $src_rel 없음)"
+      return 0
+    fi
+  fi
+
+  # 이미 올바른 심볼릭 링크면 skip
+  if [[ -L "$dst" ]] && [[ "$(readlink "$dst")" == "$src" ]]; then
+    echo "  ✓ $dst_rel (이미 링크됨)"
+    return 0
+  fi
+
+  # 파일이 이미 있으면 보존 (수동 세팅 존중)
+  if [[ -e "$dst" ]] && [[ ! -L "$dst" ]]; then
+    echo "  · $dst_rel 이미 존재 (파일) — 유지"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$dst")"
+  ln -sfn "$src" "$dst"
+  echo "  ✓ $dst_rel → $src_rel"
+}
+
+echo "[1/3] env 파일 심볼릭 링크"
+link_entry "packages/web/.env.local"        "packages/web/.env.local"        true
+link_entry ".env.backend.dev"               ".env.backend.dev"
+link_entry "packages/web/.env.development"  "packages/web/.env.development"
+link_entry "packages/web/.playwright"       "packages/web/.playwright"
+
+echo
+echo "[2/3] bun install (워크트리 node_modules 동기화)"
+if command -v bun >/dev/null 2>&1; then
+  (cd "$WT" && bun install --silent)
+  echo "  ✓ bun install 완료"
+else
+  echo "  ✗ bun이 설치되어 있지 않습니다. 'brew install oven-sh/bun/bun'으로 먼저 설치하세요." >&2
+  exit 1
+fi
+
+echo
+echo "[3/3] 포트 안내"
+if [[ -n "$PORT" ]]; then
+  # `.env.worktree.local`은 기존 `.env.*.local` gitignore 패턴에 포함됨 → 워크트리 로컬 전용
+  PORT_ENV="$WT/packages/web/.env.worktree.local"
+  printf "PORT=%s\n" "$PORT" > "$PORT_ENV"
+  echo "  ✓ $PORT_ENV 생성 (gitignored)"
+  echo "  ℹ dev 서버: (cd $WT/packages/web && PORT=$PORT bun dev)"
+else
+  echo "  ℹ --port 미지정 (기본 3000). 다른 워크트리와 동시 실행 시 --port 3001/3002… 사용"
+  echo "  ℹ dev 서버: (cd $WT/packages/web && bun dev)"
+fi
+
+echo
+echo "✅ bootstrap 완료: $WT"


### PR DESCRIPTION
## Summary

병렬 워크트리 작업과 버그 보고 품질을 한 번에 정비한다.

- \`scripts/worktree-bootstrap.sh\` — 보조 워크트리에서 \`.env.local\` / \`.env.backend.dev\` / \`packages/web/.playwright\`를 **메인 워크트리에서 심볼릭 링크**하고, \`bun install\`을 돌린 뒤, \`--port <N>\` 옵션 시 \`.env.worktree.local\`에 \`PORT=<N>\` 을 써 둔다. 여러 워크트리를 서로 다른 포트로 동시에 \`bun dev\` 돌릴 수 있음.
- \`Justfile\` — \`just worktree-setup <path> [port]\` / \`just worktree-setup-here [port]\` 래퍼.
- \`docs/GIT-WORKFLOW.md\` — **"워크트리 (병렬 피처 작업)"** 섹션 추가 (폴더 규칙 / 부트스트랩 / 수동 QA 패턴 / 정리).
- \`.github/ISSUE_TEMPLATE/bug.yml\` — 새 버그 리포트 템플릿. **Symptom / Steps / Evidence (DevTools·로그·SQL) / Expected / Hypothesis / Environment**를 분리 요구해서 증상-기반 리포트로 인한 오진을 줄인다.

## 왜 (증거)

오늘 세션에서 이슈 #148 / #149를 재조사했더니:
- **#149** "검색 안 됨" = 실제로는 로컬 **Meilisearch 미기동** (502 Bad Gateway). 프론트 로직 이슈 아님.
- **#148** "Related News OG image 깨짐" = 해당 post는 \`post_magazine_news_references\`가 비어서 Related News 섹션이 렌더 자체를 안 함. 사용자가 본 깨진 이미지는 **Solution 카드의 image-proxy 실패**였음.

두 사례 모두 **증상만 기반으로 이슈가 만들어져 프론트엔드 수정 시도 → 헛발질 → Playwright/SQL로 실제 재현해서야 근본 원인 발견** 루프. 이번 PR의 템플릿은 이 루프를 줄이는 게 목표.

그리고 워크트리 3개(#148/#149/#145)를 병렬로 열었지만 **env 부재로 각 워크트리에서 \`bun dev\`를 못 돌려** 결국 메인에 \`qa/*\` 브랜치로 병합한 뒤에야 수동 QA가 가능했음. 부트스트랩 스크립트가 이 병목을 해소.

## 검증

- \`bash -n scripts/worktree-bootstrap.sh\` → 구문 OK
- \`just --list\` → 신규 레시피 노출
- 실제 \`bash scripts/worktree-bootstrap.sh .worktrees/149-search-fix --port 3001\` 실행 → symlink + bun install + port 파일 정상 생성
- 메인 워크트리 대상 실행 시 거부 확인
- \`.env.worktree.local\`이 \`.env.*.local\` 패턴으로 정상 gitignored 확인
- \`bash packages/web/scripts/pre-push.sh\` 통과

## Test plan

- [ ] \`just worktree-setup .worktrees/<branch>\` 실행 → 생성된 심볼릭 링크 확인 (\`ls -la\`)
- [ ] \`just worktree-setup .worktrees/<branch> 3002\` 실행 → \`.env.worktree.local\`에 \`PORT=3002\` 있는지 확인
- [ ] 메인 워크트리 대상 실행 시 거부되는지
- [ ] \`.github/ISSUE_TEMPLATE/bug.yml\`이 GitHub UI의 새 이슈 선택지에 노출되는지
- [ ] 두 워크트리 동시 \`bun dev\`로 3001/3002 포트 바인딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)