### PR TITLE
refactor(web/request): clarify Details step field guidance (part of #145)

### DIFF
--- a/packages/web/lib/components/request/ArtistInput.tsx
+++ b/packages/web/lib/components/request/ArtistInput.tsx
@@ -38,7 +38,12 @@ export function ArtistInput({
       {/* Artist Name Input */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <label className="block text-xs text-muted-foreground">Name</label>
+          <div className="space-y-0.5">
+            <label className="block text-xs text-muted-foreground">Name</label>
+            <p className="text-[10px] text-muted-foreground/70">
+              Actor, singer, model, or public figure in the image
+            </p>
+          </div>
           {hasAiRecommendation && !isUsingAiRecommendation && (
             <button
               type="button"
@@ -80,9 +85,14 @@ export function ArtistInput({
 
       {/* Group Name Input */}
       <div className="space-y-2">
-        <label className="block text-xs text-muted-foreground">
-          Group / Agency
-        </label>
+        <div className="space-y-0.5">
+          <label className="block text-xs text-muted-foreground">
+            Group / Agency
+          </label>
+          <p className="text-[10px] text-muted-foreground/70">
+            Group (e.g., BLACKPINK) or agency (e.g., YG Entertainment)
+          </p>
+        </div>
         <input
           type="text"
           value={groupName}

--- a/packages/web/lib/components/request/DescriptionInput.tsx
+++ b/packages/web/lib/components/request/DescriptionInput.tsx
@@ -150,8 +150,8 @@ export function DescriptionInput() {
         <div className="flex justify-between items-center text-xs text-muted-foreground">
           <span>
             {localValue.length >= MIN_DESCRIPTION_LENGTH
-              ? "AI will extract metadata automatically"
-              : "Enter at least 10 characters"}
+              ? "AI will auto-fill title, year, and platform"
+              : `Enter at least ${MIN_DESCRIPTION_LENGTH} characters to trigger AI extraction`}
           </span>
           <span>
             {localValue.length}/{MAX_DESCRIPTION_LENGTH}

--- a/packages/web/lib/components/request/MediaSourceInput.tsx
+++ b/packages/web/lib/components/request/MediaSourceInput.tsx
@@ -15,6 +15,15 @@ const MEDIA_TYPES: { value: MediaSourceType; label: string }[] = [
   { value: "other", label: "Other" },
 ];
 
+const DEFAULT_TITLE_PLACEHOLDER = "e.g., The Glory, Squid Game";
+const TITLE_PLACEHOLDERS: Partial<Record<MediaSourceType, string>> = {
+  drama: DEFAULT_TITLE_PLACEHOLDER,
+  movie: "e.g., Parasite, Past Lives",
+  music_video: "e.g., BLACKPINK - How You Like That",
+  variety: "e.g., Running Man, Knowing Bros",
+  other: "e.g., brand campaign, magazine cover",
+};
+
 const PLATFORMS = [
   "Netflix",
   "Disney+",
@@ -82,7 +91,12 @@ export function MediaSourceInput({ value, onChange }: MediaSourceInputProps) {
 
       {/* Type Selection */}
       <div className="space-y-2">
-        <label className="block text-xs text-muted-foreground">Type *</label>
+        <div className="space-y-0.5">
+          <label className="block text-xs text-muted-foreground">Type *</label>
+          <p className="text-[10px] text-muted-foreground/70">
+            What kind of media is this image from?
+          </p>
+        </div>
         <div className="flex flex-wrap gap-2">
           {MEDIA_TYPES.map(({ value: typeValue, label }) => (
             <button
@@ -111,7 +125,10 @@ export function MediaSourceInput({ value, onChange }: MediaSourceInputProps) {
           type="text"
           value={value?.title || ""}
           onChange={(e) => handleTitleChange(e.target.value)}
-          placeholder="e.g., The Glory, Squid Game"
+          placeholder={
+            (value?.type && TITLE_PLACEHOLDERS[value.type]) ??
+            DEFAULT_TITLE_PLACEHOLDER
+          }
           className="
             w-full px-3 py-2 rounded-lg border border-border
             bg-background text-foreground text-sm


### PR DESCRIPTION
## Summary

Part of #145 (Details step UX). First small PR in a series — text-only polish, no store/API changes.

- `ArtistInput`: helper text under "Name" (actor / singer / model / public figure in the image) and "Group / Agency" (group vs agency) to disambiguate role.
- `DescriptionInput`: expand hint to call out what AI auto-fills (title / year / platform), and interpolate the `MIN_DESCRIPTION_LENGTH` constant so the copy stays in sync if the threshold changes.
- `MediaSourceInput`: add Type section helper ("What kind of media is this image from?") and per-type Title placeholder (drama → "The Glory", movie → "Parasite", MV → "BLACKPINK - How You Like That", variety → "Running Man", other → generic).

## Scope note

Does **not close #145**. Remaining work tracked as follow-ups:

- Section 1 (Spot UX): card scroll persistence on add, drag-to-reposition, delete confirmation/undo
- Section 2 (Solution): link metadata extraction feedback polish (success toast count, error state)
- Section 3 (rest of Details): multi-select Context (store + backend check), Platform/Year autocomplete, smart Title suggestion from description

## Evidence

- `bun run typecheck` — clean
- `bun run lint` — 0 errors (98 pre-existing warnings, none new)
- `prettier --check` — all files formatted
- `bash packages/web/scripts/pre-push.sh` — \`=== web: 모든 체크 통과 ===\`

## Test plan

- [ ] Open Upload modal → Step 3 (Details)
- [ ] Artist section: helper text visible under both "Name" and "Group / Agency"
- [ ] Description: hint reads "Enter at least 10 characters to trigger AI extraction" below 10 chars, switches to "AI will auto-fill title, year, and platform" at 10+
- [ ] Media Source: select each type (Drama/Movie/MV/Variety/Other) → Title placeholder updates; default is drama example when no type selected
- [ ] No visual regressions on existing Upload flow (Steps 1–2 unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)