### PR TITLE
fix(db): guard item image dimensions migration with IF EXISTS

### DIFF
--- a/supabase/migrations/20260409181000_add_item_image_dimensions.sql
+++ b/supabase/migrations/20260409181000_add_item_image_dimensions.sql
@@ -1,8 +1,18 @@
 -- Add image dimension columns to item table for CLS prevention
 -- Nullable to avoid breaking existing workflows
-ALTER TABLE public.item
-  ADD COLUMN IF NOT EXISTS image_width  integer,
-  ADD COLUMN IF NOT EXISTS image_height integer;
+-- Guarded with IF EXISTS so local Supabase (where `item` table may not yet exist)
+-- and any environment without the legacy `item` table can run this migration safely.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'item'
+  ) THEN
+    ALTER TABLE public.item
+      ADD COLUMN IF NOT EXISTS image_width  integer,
+      ADD COLUMN IF NOT EXISTS image_height integer;
 
-COMMENT ON COLUMN public.item.image_width IS '아이템 이미지 가로 크기 (픽셀)';
-COMMENT ON COLUMN public.item.image_height IS '아이템 이미지 세로 크기 (픽셀)';
+    COMMENT ON COLUMN public.item.image_width IS '아이템 이미지 가로 크기 (픽셀)';
+    COMMENT ON COLUMN public.item.image_height IS '아이템 이미지 세로 크기 (픽셀)';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- `public.item` 테이블이 `supabase/migrations/20260409075040_remote_schema.sql`에 정의되지 않아 `bunx supabase start`가 `20260409181000_add_item_image_dimensions.sql` 적용 시 실패.
- `DO $$ IF EXISTS ... END $$` 블록으로 감싸 테이블이 없으면 skip, 있으면 기존 동작(컬럼 추가 + COMMENT) 유지.

## Why
`#131/#142`에서 `item` 테이블을 가정하고 작성된 migration이지만, Postgres 스키마 스냅샷에는 해당 테이블이 없어 **신규 개발자가 로컬 Supabase 시작 불가**. #151 Admin 실데이터 연동 작업 중 로컬 Supabase 시작 시 발견.

## Risk
- DEV/PROD에 이미 컬럼이 있으면 \`ADD COLUMN IF NOT EXISTS\` 라 안전 (idempotent).
- 테이블이 없으면 아무 작업도 하지 않음 (이전보다 더 안전).
- 실패하던 로컬 \`supabase start\`가 이 패치로 정상 동작 확인 (#151 worktree에서 검증).

## Test plan
- [x] 로컬: \`bunx supabase start\` → migration 통과 + 컨테이너 실행 확인
- [ ] 리뷰어: DO 블록 문법 + IF EXISTS guard 검토
- [ ] DEV 재적용 시 no-op 확인 (이미 컬럼 있으므로)

## Related
- Blocker fix for #151 Admin 실데이터 연동 (feature/151-admin-real-data)