### PR TITLE
feat(web/request): extend RequestFlowModal with maxWidth/onClose/mobileFullScreen props (#145 PR-1)

### DIFF
--- a/packages/web/lib/components/request/RequestFlowModal.tsx
+++ b/packages/web/lib/components/request/RequestFlowModal.tsx
@@ -15,10 +15,14 @@ const MAX_WIDTH_CLASS: Record<MaxWidth, string> = {
   "7xl": "max-w-7xl",
 };
 
+const MOBILE_FULLSCREEN_CLASSES =
+  "max-sm:rounded-none max-sm:max-w-none max-sm:max-h-none max-sm:h-[100dvh] max-sm:w-full";
+
 interface RequestFlowModalProps {
   children: React.ReactNode;
   maxWidth?: MaxWidth;
   onClose?: () => void;
+  mobileFullScreen?: boolean;
 }
 
 /**
@@ -29,6 +33,7 @@ export function RequestFlowModal({
   children,
   maxWidth = "4xl",
   onClose,
+  mobileFullScreen = false,
 }: RequestFlowModalProps) {
   const router = useRouter();
 
@@ -154,7 +159,7 @@ export function RequestFlowModal({
       <div
         ref={modalRef}
         data-testid="request-flow-modal-dialog"
-        className={`relative z-10 flex flex-col w-full ${MAX_WIDTH_CLASS[maxWidth]} max-h-[90vh] bg-background rounded-2xl shadow-2xl overflow-hidden`}
+        className={`relative z-10 flex flex-col w-full ${MAX_WIDTH_CLASS[maxWidth]} max-h-[90vh] bg-background rounded-2xl shadow-2xl overflow-hidden${mobileFullScreen ? ` ${MOBILE_FULLSCREEN_CLASSES}` : ""}`}
       >
         {/* Close Button */}
         <button

--- a/packages/web/lib/components/request/RequestFlowModal.tsx
+++ b/packages/web/lib/components/request/RequestFlowModal.tsx
@@ -6,15 +6,28 @@ import { X } from "lucide-react";
 import { gsap } from "gsap";
 import { getRequestActions } from "@/lib/stores/requestStore";
 
+type MaxWidth = "4xl" | "5xl" | "6xl" | "7xl";
+
+const MAX_WIDTH_CLASS: Record<MaxWidth, string> = {
+  "4xl": "max-w-4xl",
+  "5xl": "max-w-5xl",
+  "6xl": "max-w-6xl",
+  "7xl": "max-w-7xl",
+};
+
 interface RequestFlowModalProps {
   children: React.ReactNode;
+  maxWidth?: MaxWidth;
 }
 
 /**
  * Modal wrapper for request flow (upload/detect) on desktop
  * Uses intercepting routes to show request pages as modal overlay
  */
-export function RequestFlowModal({ children }: RequestFlowModalProps) {
+export function RequestFlowModal({
+  children,
+  maxWidth = "4xl",
+}: RequestFlowModalProps) {
   const router = useRouter();
 
   // Refs for animation
@@ -132,7 +145,8 @@ export function RequestFlowModal({ children }: RequestFlowModalProps) {
       {/* Modal Container */}
       <div
         ref={modalRef}
-        className="relative z-10 flex flex-col w-full max-w-4xl max-h-[90vh] bg-background rounded-2xl shadow-2xl overflow-hidden"
+        data-testid="request-flow-modal-dialog"
+        className={`relative z-10 flex flex-col w-full ${MAX_WIDTH_CLASS[maxWidth]} max-h-[90vh] bg-background rounded-2xl shadow-2xl overflow-hidden`}
       >
         {/* Close Button */}
         <button

--- a/packages/web/lib/components/request/RequestFlowModal.tsx
+++ b/packages/web/lib/components/request/RequestFlowModal.tsx
@@ -18,6 +18,7 @@ const MAX_WIDTH_CLASS: Record<MaxWidth, string> = {
 interface RequestFlowModalProps {
   children: React.ReactNode;
   maxWidth?: MaxWidth;
+  onClose?: () => void;
 }
 
 /**
@@ -27,6 +28,7 @@ interface RequestFlowModalProps {
 export function RequestFlowModal({
   children,
   maxWidth = "4xl",
+  onClose,
 }: RequestFlowModalProps) {
   const router = useRouter();
 
@@ -44,6 +46,11 @@ export function RequestFlowModal({
     ctxRef.current.add(() => {
       const tl = gsap.timeline({
         onComplete: () => {
+          if (onClose) {
+            onClose();
+            return;
+          }
+          // Legacy fallback for callers that haven't migrated yet (e.g., detect modal).
           getRequestActions().resetRequestFlow();
           if (window.history.length > 1) {
             router.back();
@@ -75,7 +82,7 @@ export function RequestFlowModal({
         0
       );
     });
-  }, [router]);
+  }, [router, onClose]);
 
   // Mount/Enter Animation
   useEffect(() => {
@@ -137,6 +144,7 @@ export function RequestFlowModal({
       {/* Backdrop */}
       <div
         ref={backdropRef}
+        data-testid="request-flow-modal-backdrop"
         onClick={handleClose}
         className="absolute inset-0 bg-black/80 backdrop-blur-sm"
         aria-hidden="true"

--- a/packages/web/lib/components/request/RequestFlowModal.tsx
+++ b/packages/web/lib/components/request/RequestFlowModal.tsx
@@ -6,7 +6,7 @@ import { X } from "lucide-react";
 import { gsap } from "gsap";
 import { getRequestActions } from "@/lib/stores/requestStore";
 
-type MaxWidth = "4xl" | "5xl" | "6xl" | "7xl";
+export type MaxWidth = "4xl" | "5xl" | "6xl" | "7xl";
 
 const MAX_WIDTH_CLASS: Record<MaxWidth, string> = {
   "4xl": "max-w-4xl",

--- a/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
+++ b/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, test, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+vi.mock("gsap", () => ({
+  gsap: {
+    to: vi.fn(),
+    set: vi.fn(),
+    fromTo: vi.fn(),
+    timeline: () => ({ to: vi.fn() }),
+    context: (fn: () => void) => {
+      fn();
+      return { add: (cb: () => void) => cb(), revert: vi.fn() };
+    },
+  },
+  default: {},
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+vi.mock("@/lib/stores/requestStore", () => ({
+  getRequestActions: () => ({ resetRequestFlow: vi.fn() }),
+}));
+
+import { RequestFlowModal } from "../RequestFlowModal";
+
+describe("RequestFlowModal — maxWidth prop", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "history", {
+      value: { length: 2 },
+      writable: true,
+    });
+  });
+
+  test("defaults to max-w-4xl when maxWidth not supplied", () => {
+    render(
+      <RequestFlowModal>
+        <div data-testid="child">c</div>
+      </RequestFlowModal>
+    );
+    const dialog = screen.getByTestId("request-flow-modal-dialog");
+    expect(dialog.className).toMatch(/max-w-4xl/);
+  });
+
+  test("applies max-w-6xl when maxWidth='6xl'", () => {
+    render(
+      <RequestFlowModal maxWidth="6xl">
+        <div data-testid="child">c</div>
+      </RequestFlowModal>
+    );
+    const dialog = screen.getByTestId("request-flow-modal-dialog");
+    expect(dialog.className).toMatch(/max-w-6xl/);
+    expect(dialog.className).not.toMatch(/max-w-4xl/);
+  });
+});

--- a/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
+++ b/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
@@ -67,9 +67,11 @@ describe("RequestFlowModal — onClose prop", () => {
     const { container } = render(
       <RequestFlowModal>
         <div>child</div>
-      </RequestFlowModal>,
+      </RequestFlowModal>
     );
-    expect(container.querySelector("[data-testid='request-flow-modal-backdrop']")).toBeTruthy();
+    expect(
+      container.querySelector("[data-testid='request-flow-modal-backdrop']")
+    ).toBeTruthy();
   });
 
   test("calls onClose when backdrop is clicked", () => {
@@ -77,9 +79,11 @@ describe("RequestFlowModal — onClose prop", () => {
     const { container } = render(
       <RequestFlowModal onClose={onClose}>
         <div>child</div>
-      </RequestFlowModal>,
+      </RequestFlowModal>
     );
-    const backdrop = container.querySelector("[data-testid='request-flow-modal-backdrop']") as HTMLElement;
+    const backdrop = container.querySelector(
+      "[data-testid='request-flow-modal-backdrop']"
+    ) as HTMLElement;
     fireEvent.click(backdrop);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -88,9 +92,37 @@ describe("RequestFlowModal — onClose prop", () => {
     const { container } = render(
       <RequestFlowModal>
         <div>child</div>
-      </RequestFlowModal>,
+      </RequestFlowModal>
     );
-    const backdrop = container.querySelector("[data-testid='request-flow-modal-backdrop']") as HTMLElement;
+    const backdrop = container.querySelector(
+      "[data-testid='request-flow-modal-backdrop']"
+    ) as HTMLElement;
     expect(() => fireEvent.click(backdrop)).not.toThrow();
+  });
+});
+
+describe("RequestFlowModal — mobileFullScreen prop", () => {
+  test("applies mobile full-screen classes when mobileFullScreen=true", () => {
+    render(
+      <RequestFlowModal mobileFullScreen>
+        <div data-testid="child">c</div>
+      </RequestFlowModal>
+    );
+    const dialog = screen.getByTestId("request-flow-modal-dialog");
+    expect(dialog.className).toMatch(/max-sm:rounded-none/);
+    expect(dialog.className).toMatch(/max-sm:max-w-none/);
+    expect(dialog.className).toMatch(/max-sm:h-\[100dvh\]/);
+    expect(dialog.className).toMatch(/max-sm:w-full/);
+  });
+
+  test("does not apply mobile classes by default", () => {
+    render(
+      <RequestFlowModal>
+        <div data-testid="child">c</div>
+      </RequestFlowModal>
+    );
+    const dialog = screen.getByTestId("request-flow-modal-dialog");
+    expect(dialog.className).not.toMatch(/max-sm:rounded-none/);
+    expect(dialog.className).not.toMatch(/max-sm:h-\[100dvh\]/);
   });
 });

--- a/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
+++ b/packages/web/lib/components/request/__tests__/RequestFlowModal.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { describe, test, expect, vi, beforeAll } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 vi.mock("gsap", () => ({
@@ -11,7 +11,11 @@ vi.mock("gsap", () => ({
     to: vi.fn(),
     set: vi.fn(),
     fromTo: vi.fn(),
-    timeline: () => ({ to: vi.fn() }),
+    timeline: (opts?: { onComplete?: () => void }) => {
+      // Invoke onComplete synchronously so close-path tests work in jsdom
+      opts?.onComplete?.();
+      return { to: vi.fn() };
+    },
     context: (fn: () => void) => {
       fn();
       return { add: (cb: () => void) => cb(), revert: vi.fn() };
@@ -55,5 +59,38 @@ describe("RequestFlowModal — maxWidth prop", () => {
     const dialog = screen.getByTestId("request-flow-modal-dialog");
     expect(dialog.className).toMatch(/max-w-6xl/);
     expect(dialog.className).not.toMatch(/max-w-4xl/);
+  });
+});
+
+describe("RequestFlowModal — onClose prop", () => {
+  test("adds data-testid to backdrop for testability", () => {
+    const { container } = render(
+      <RequestFlowModal>
+        <div>child</div>
+      </RequestFlowModal>,
+    );
+    expect(container.querySelector("[data-testid='request-flow-modal-backdrop']")).toBeTruthy();
+  });
+
+  test("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <RequestFlowModal onClose={onClose}>
+        <div>child</div>
+      </RequestFlowModal>,
+    );
+    const backdrop = container.querySelector("[data-testid='request-flow-modal-backdrop']") as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not crash when onClose is not supplied (legacy path)", () => {
+    const { container } = render(
+      <RequestFlowModal>
+        <div>child</div>
+      </RequestFlowModal>,
+    );
+    const backdrop = container.querySelector("[data-testid='request-flow-modal-backdrop']") as HTMLElement;
+    expect(() => fireEvent.click(backdrop)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

`RequestFlowModal` shell에 3개 prop을 추가해 upload/detect 모달이 각자의 크기·close 로직·모바일 레이아웃을 제어할 수 있게 한다. **모든 prop은 backwards-compatible default** — 현재 `children`만 전달하는 `(.)request/detect` / `(.)request/upload` 모달은 동작 변화 없음.

- `maxWidth?: "4xl" | "5xl" | "6xl" | "7xl"` (default `"4xl"`) — 폭 제어. 타입 export해 downstream 재사용 가능.
- `onClose?: () => void` — caller가 close 핸들러 주입. 미제공 시 기존 legacy flow (`resetRequestFlow` + `router.back()`) 그대로 실행.
- `mobileFullScreen?: boolean` (default `false`) — true일 때 `sm` 미만에서 `rounded-none` + `max-w-none` + `h-[100dvh]` + `w-full`로 full-screen.

#145 upload modal refactor의 PR-1. PR-2(hook + headless Steps 추출)와 PR-3(intercept 모달 전환), PR-4(legacy RequestModal 삭제 + nav 재배선)가 뒤따른다.

## Commits

- \`210568c8\` feat(web/request): add maxWidth prop to RequestFlowModal
- \`d16aaba1\` chore(web/request): export MaxWidth type for downstream reuse
- \`84b546f0\` feat(web/request): add onClose prop to RequestFlowModal
- \`3224d55d\` feat(web/request): add mobileFullScreen prop to RequestFlowModal

## Test plan

- [x] \`bun run test -- RequestFlowModal\` — 7/7 pass (maxWidth 2 + onClose 3 + mobileFullScreen 2)
- [x] \`bun run typecheck\` — RequestFlowModal 관련 오류 없음 (pre-existing gitignored generated API 오류는 무관)
- [ ] Vercel preview에서 \`/request/detect\` 모달 시각 유지 (기존 \`max-w-4xl\` 데스크탑 centered) — 리뷰어 확인 필요
- [ ] Vercel preview에서 \`/request/upload\` (intercept/full-page) 모달 기존 동작 유지
- [ ] Vercel preview 모바일 뷰포트에서 detect 모달이 기존 동작(centered, not full-screen) 유지 — \`mobileFullScreen\`을 아직 아무도 true로 주지 않으므로

## Docs

- Spec: [\`docs/superpowers/specs/2026-04-17-upload-modal-refactor-design.md\`](docs/superpowers/specs/2026-04-17-upload-modal-refactor-design.md)
- Plan: [\`docs/superpowers/plans/2026-04-17-upload-modal-refactor.md\`](docs/superpowers/plans/2026-04-17-upload-modal-refactor.md) (Phase A, PR-1)

Part of #145. Refs #230 (superseded 예정, PR-4에서 helper text 이식).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)