### PR TITLE
fix(db): revoke anon EXECUTE on admin RPCs (#151)

### DIFF
--- a/supabase/migrations/20260417120003_revoke_anon_from_admin_rpcs.sql
+++ b/supabase/migrations/20260417120003_revoke_anon_from_admin_rpcs.sql
@@ -1,0 +1,5 @@
+-- #151 Security hardening: revoke anon EXECUTE on admin-only RPCs. (user-approved 2026-04-17)
+REVOKE EXECUTE ON FUNCTION public.update_magazine_status(UUID, VARCHAR, UUID, TEXT)
+  FROM anon, authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.is_admin(UUID) FROM anon;


### PR DESCRIPTION
## Summary

#224의 후속 보안 패치. admin 전용 RPC에서 `anon` 역할의 EXECUTE 권한을 명시적으로 회수하여 방어 심화(defense-in-depth).

- `public.update_magazine_status(UUID, VARCHAR, UUID, TEXT)` ← REVOKE FROM anon, authenticated
- `public.is_admin(UUID)` ← REVOKE FROM anon

## Context

- #224 머지 후 보안 검토에서 식별된 잔여 리스크
- DEV에 이미 적용 완료 (`supabase_migrations.schema_migrations.version = 20260417092224`)
- 로컬 파일은 PR #224의 시퀀스(`120000/001/002`)에 이어 `120003`으로 정렬
- ACL 검증 완료 — 세션에서 실제 권한 확인됨

## PROD 영향

- merge → main 머지 후 PROD(`womgfycekpzodibauiyl`)에 자동 적용
- `REVOKE EXECUTE` DDL만 포함 (스키마/데이터 변경 없음)
- Next.js admin route는 `service_role` 클라이언트를 사용하므로 영향 없음

## Test plan

- [ ] CI green (lint/build/tests)
- [ ] DEV에서 anon JWT로 RPC 호출 시 `42501 permission denied` 확인
- [ ] DEV에서 service_role로 여전히 정상 호출 확인
- [ ] main 머지 후 PROD 배포 로그에서 마이그레이션 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)