### PR TITLE
test(web/request): Playwright E2E for upload flow (#145 PR-5)

### DIFF
--- a/packages/web/tests/upload-direct.spec.ts
+++ b/packages/web/tests/upload-direct.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * E2E for direct-URL /request/upload rendering.
+ *
+ * Covers #145 PR-4 Section 9 / D5: direct browser navigation should render
+ * the full-page layout, NOT the RequestFlowModal dialog chrome. Intercept
+ * behaviour is covered by upload-intercept.spec.ts.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Upload direct URL", () => {
+  test("direct navigation renders full-page, not modal dialog", async ({
+    page,
+  }) => {
+    await page.goto("/request/upload");
+
+    // Full-page: StepProgress + DropZone visible.
+    await expect(page.getByText("Drag and drop images")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByLabel(/Step 1 of/)).toBeVisible();
+
+    // No modal chrome for direct URL.
+    await expect(page.getByTestId("request-flow-modal-dialog")).toHaveCount(0);
+    await expect(page.getByTestId("request-flow-modal-backdrop")).toHaveCount(
+      0
+    );
+  });
+});

--- a/packages/web/tests/upload-draft.spec.ts
+++ b/packages/web/tests/upload-draft.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * E2E for upload draft restore toast.
+ *
+ * Covers #145 PR-3 C3: useUploadFlow's offline draft restore. Once a user
+ * has marked spots or selected userKnowsItems, the draft auto-saves to
+ * localStorage. A page reload should surface a "Restore" toast; the second
+ * reload within the same session should NOT show it again (once-per-session
+ * dedup handled by toast duration + loadDraft() call placement on mount).
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Upload draft restore", () => {
+  test("draft restore toast appears after reload when a draft exists", async ({
+    page,
+  }) => {
+    await page.goto("/request/upload");
+
+    // Seed a draft by selecting an image and declaring user-type.
+    const fileInput = page.locator("input[type='file']").first();
+    await fileInput.setInputFiles("tests/fixtures/test-image.jpg");
+
+    // Selecting userKnowsItems satisfies auto-save guard
+    // (detectedSpots.length === 0 && userKnowsItems === null skip).
+    await page
+      .getByRole("button", { name: /no.*curious/i })
+      .click({ timeout: 10_000 });
+
+    // Trigger a reload — loadDraft() runs once on mount and should fire toast.
+    await page.reload();
+
+    // Toast body from useUploadFlow.ts: "You have an unsaved request draft."
+    await expect(page.getByText(/unsaved request draft/i)).toBeVisible({
+      timeout: 15_000,
+    });
+    // Restore action label — ensure the toast exposes the restore affordance.
+    await expect(page.getByRole("button", { name: /restore/i })).toBeVisible();
+  });
+});

--- a/packages/web/tests/upload-intercept.spec.ts
+++ b/packages/web/tests/upload-intercept.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * E2E for the intercepting /request/upload modal overlay.
+ *
+ * Covers #145 PR-3 Section 4: in-app navigation (Desktop SmartNav) routes
+ * through the intercept, so the upload flow renders inside RequestFlowModal
+ * on top of the previous page. Direct URL rendering is covered by
+ * upload-direct.spec.ts.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("Upload intercept modal", () => {
+  test("in-app nav opens intercept modal on /request/upload", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // SmartNav Upload button (desktop). Match case-insensitive; there may be
+    // multiple Upload buttons (main nav + profile dropdown) — take the first.
+    await page
+      .getByRole("button", { name: /upload/i })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(/\/request\/upload/);
+    await expect(page.getByTestId("request-flow-modal-dialog")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("ESC closes the intercept modal and routes back", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /upload/i })
+      .first()
+      .click();
+
+    const dialog = page.getByTestId("request-flow-modal-dialog");
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    await page.keyboard.press("Escape");
+
+    // GSAP close timeline is ~0.2s; give the router + unmount time to settle.
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+    await expect(page).not.toHaveURL(/\/request\/upload/);
+  });
+
+  test("backdrop click closes the intercept modal", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /upload/i })
+      .first()
+      .click();
+
+    const dialog = page.getByTestId("request-flow-modal-dialog");
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    await page.getByTestId("request-flow-modal-backdrop").click();
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+  });
+});

--- a/packages/web/tests/upload-mobile.spec.ts
+++ b/packages/web/tests/upload-mobile.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * E2E for the intercept modal under mobile viewport.
+ *
+ * Covers #145 PR-4 Section 9 / D5: iPhone SE viewport should render the
+ * intercepting RequestFlowModal with `mobileFullScreen=true`, producing a
+ * dialog that spans the full viewport width.
+ */
+import { test, expect, devices } from "@playwright/test";
+
+test.use({ ...devices["iPhone SE (3rd gen)"] });
+
+test.describe("Upload intercept modal — mobile", () => {
+  test("mobile viewport → intercept modal is full-screen", async ({ page }) => {
+    await page.goto("/");
+    await page
+      .getByRole("button", { name: /upload/i })
+      .first()
+      .click();
+
+    const dialog = page.getByTestId("request-flow-modal-dialog");
+    await expect(dialog).toBeVisible({ timeout: 15_000 });
+
+    const box = await dialog.boundingBox();
+    // iPhone SE width is 375 — allow ~5px margin for scrollbar / DPR rounding.
+    expect(box?.width ?? 0).toBeGreaterThanOrEqual(370);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up PR delivering the Playwright E2E suite deferred across PR-3 (#242) and PR-4 (#247) of the #145 upload modal unification. Four new \`.spec.ts\` files, 153 lines total.

| spec | behaviour | derived from |
|------|-----------|--------------|
| \`upload-intercept.spec.ts\` | home → SmartNav Upload → intercept modal opens at \`/request/upload\`; ESC + backdrop click close | PR-3 C2 |
| \`upload-direct.spec.ts\` | direct URL renders full-page (no \`request-flow-modal-dialog\`) | PR-4 D5 |
| \`upload-mobile.spec.ts\` | iPhone SE viewport → intercept dialog width ≥ 370px (mobileFullScreen) | PR-4 D5 |
| \`upload-draft.spec.ts\` | reload after file + userKnowsItems seeds a draft → Restore toast visible | PR-3 C3 |

All specs use existing fixture \`tests/fixtures/test-image.jpg\` and the \`playwright.config.ts\` \`webServer: bun dev\` auto-start.

## Why

PR-1 → PR-4 landed the refactor but verified only unit + typecheck. The intercept overlay, mobile full-screen chrome, and draft restore path are exactly the behaviours unit tests can't cover (router + jsdom + real DOM animation). This PR closes the E2E gap so the flow has regression guards before additional upload work stacks on top.

## Test plan

Local runs require a dev server + \`auth.setup.ts\` storageState, so these specs were **not executed in the authoring session**. Validation paths:

- [ ] CI — \`chromium\` project will run the new specs against the auto-started dev server.
- [ ] Local smoke — \`cd packages/web && bun x playwright test tests/upload-intercept.spec.ts tests/upload-direct.spec.ts tests/upload-mobile.spec.ts tests/upload-draft.spec.ts\` (needs \`.env.local\` + prior auth).

## Known fragilities

- \`upload-intercept.spec.ts\` / \`upload-mobile.spec.ts\` select \`getByRole(\"button\", { name: /upload/i }).first()\`. Page renders multiple Upload buttons (SmartNav + profile dropdown); \`.first()\` pins the main nav button, but if the layout order changes the selector will drift.
- \`upload-draft.spec.ts\` assumes the \"No, I'm curious\" fork button triggers \`setUserKnowsItems\` which in turn satisfies \`useUploadFlow\`'s auto-save guard (\`detectedSpots.length === 0 && userKnowsItems === null skip\`). Any future change to that guard needs a matching spec update.
- Mobile spec relies on the desktop-labelled \"Upload\" button appearing in the mobile layout. If the renewed main page uses a different mobile nav (e.g. \`MobileNavBar\`, \`BottomNav\`), the spec may need a selector adjustment — flagged as follow-up if CI fails.

## Follow-ups

- If CI fails on mobile selector, wire the spec to \`MobileNavBar\` or fall back to router-level navigation.
- \`/request/detect\` modal visual-diff (#145 PR-4 D6) still pending — manual on Vercel preview.

Part of #145. Stacks on #247.