### PR TITLE
fix(ai-server): resolve residual lint (F811/F841/E722/E501/W291) (PR-B of #244)

### DIFF
--- a/packages/ai-server/.flake8
+++ b/packages/ai-server/.flake8
@@ -12,3 +12,9 @@ exclude =
     src/generated,
     build,
     dist
+per-file-ignores =
+    # User-Agent strings cannot be broken without losing meaning
+    src/services/metadata/clients/web_scraper.py: E501
+    # LLM prompt templates — natural-language content inside f""" blocks
+    src/post_editorial/nodes/editorial.py: E501
+    src/post_editorial/nodes/news_research.py: E501

--- a/packages/ai-server/src/bootstrap.py
+++ b/packages/ai-server/src/bootstrap.py
@@ -40,8 +40,6 @@ async def initialize_async_resources(application: Application):
 
 
 def configure_routes(app: FastAPI, application: Application) -> FastAPI:
-    logger = application.logger()
-    infrastructure = application.infrastructure()
     environment = application.environment()
 
     # CORS 설정

--- a/packages/ai-server/src/managers/llm/adapters/groq.py
+++ b/packages/ai-server/src/managers/llm/adapters/groq.py
@@ -5,7 +5,6 @@ import logging
 import httpx
 from pydantic import BaseModel
 from src.config._environment import Environment
-from src.managers.llm.base.config import LLMConfig
 from src.managers.llm.base import BaseLLMClient, LLMConfig, LLMMessage, LLMResponse, LLMUsage
 from src.managers.llm.base.types import ContentType
 
@@ -177,7 +176,10 @@ class GroqClient(BaseLLMClient):
         # Keep beginning and end for context
         keep_start = max_chars // 3
         keep_end = max_chars // 3
-        middle_text = f"\n\n[Content truncated - original length: {len(content)} chars, estimated {estimated_tokens} tokens]\n\n"
+        middle_text = (
+            f"\n\n[Content truncated - original length: {len(content)} chars, "
+            f"estimated {estimated_tokens} tokens]\n\n"
+        )
 
         if keep_start + len(middle_text) + keep_end >= max_chars:
             # If still too long, just truncate from end
@@ -293,8 +295,6 @@ class GroqClient(BaseLLMClient):
 
     async def _handle_link_completion(self, messages: List[LLMMessage], **kwargs) -> LLMResponse:
         """Handle link analysis completion"""
-        url = kwargs.get("url", "")
-
         # Use the content from the provided messages (includes enhanced content like YouTube transcript)
         user_content = self._build_link_analysis_prompt(messages[0].content)
 

--- a/packages/ai-server/src/managers/llm/adapters/local_llm.py
+++ b/packages/ai-server/src/managers/llm/adapters/local_llm.py
@@ -195,11 +195,17 @@ class LocalLLMClient(BaseLLMClient):
         enhanced_messages = [
             LLMMessage(
                 role="system",
-                content="You are being asked to analyze an image, but as a text-based model, you cannot process images directly.",
+                content=(
+                    "You are being asked to analyze an image, but as a text-based model, "
+                    "you cannot process images directly."
+                ),
             ),
             LLMMessage(
                 role="user",
-                content="I need image analysis, but this is a text-only model. Please explain what image analysis typically involves.",
+                content=(
+                    "I need image analysis, but this is a text-only model. "
+                    "Please explain what image analysis typically involves."
+                ),
             ),
         ]
 
@@ -307,7 +313,10 @@ class LocalLLMClient(BaseLLMClient):
     async def _make_api_request(self, prompt: str) -> Dict[str, Any]:
         """Make API request to Local LLM"""
         try:
-            system_message = "You are a helpful assistant that provides information and returns structured JSON responses."
+            system_message = (
+                "You are a helpful assistant that provides information "
+                "and returns structured JSON responses."
+            )
 
             response = await self.client.chat.completions.create(
                 model=self.config.model,

--- a/packages/ai-server/src/managers/llm/prompt_manager.py
+++ b/packages/ai-server/src/managers/llm/prompt_manager.py
@@ -103,7 +103,7 @@ class PromptManager:
         try:
             self.env.get_template(template_name)
             return True
-        except:
+        except Exception:
             return False
 
     def list_templates(self) -> list[str]:

--- a/packages/ai-server/src/post_editorial/nodes/news_research.py
+++ b/packages/ai-server/src/post_editorial/nodes/news_research.py
@@ -1,4 +1,7 @@
-"""NewsResearch node: find item-specific fashion news via per-item Perplexity search + OG extraction + Gemini filtering."""
+"""NewsResearch node: find item-specific fashion news.
+
+Uses per-item Perplexity search + OG extraction + Gemini filtering.
+"""
 
 from __future__ import annotations
 

--- a/packages/ai-server/src/services/metadata/clients/searxng_client.py
+++ b/packages/ai-server/src/services/metadata/clients/searxng_client.py
@@ -385,7 +385,6 @@ class SearXNGClient:
 
         # Check title/content for relevance
         title = result.get("title", "").lower()
-        content = result.get("content", "").lower()
 
         # Skip if title suggests it's not a main content image
         skip_title_patterns = ["icon", "logo", "button", "banner", "avatar", "thumbnail"]

--- a/packages/ai-server/src/services/metadata/core/result_aggregator.py
+++ b/packages/ai-server/src/services/metadata/core/result_aggregator.py
@@ -77,10 +77,12 @@ class ResultAggregator:
                 backend_address = (
                     f"{self.environment.grpc_backend_host}:{self.environment.grpc_backend_port}"
                 )
+                grpc_port = self.environment.grpc_backend_port
                 self.logger.warning(
-                    f"Connection timeout/error for batch {batch_id} on attempt {attempt + 1}: {str(e)}. "
+                    f"Connection timeout/error for batch {batch_id} on attempt {attempt + 1}: "
+                    f"{str(e)}. "
                     f"Backend server at {backend_address} may be unreachable or slow to respond. "
-                    f"Please verify: 1) Backend server is running, 2) Port {self.environment.grpc_backend_port} is accessible, "
+                    f"Please verify: 1) Backend server is running, 2) Port {grpc_port} is accessible, "
                     f"3) Docker network configuration allows connection to host.docker.internal"
                 )
                 if attempt < max_retries - 1:

--- a/packages/ai-server/src/services/metadata/extractors/youtube_extractor.py
+++ b/packages/ai-server/src/services/metadata/extractors/youtube_extractor.py
@@ -145,17 +145,17 @@ class YouTubeExtractor(BaseExtractor):
             try:
                 transcript = transcript_list.find_manually_created_transcript([preferred_language])
                 self.logger.debug(f"✓ Using {preferred_language} manual transcript")
-            except:
+            except Exception:
                 # 2. Preferred language auto-generated transcript
                 try:
                     transcript = transcript_list.find_generated_transcript([preferred_language])
                     self.logger.debug(f"✓ Using {preferred_language} auto-generated transcript")
-                except:
+                except Exception:
                     # 3. English transcript
                     try:
                         transcript = transcript_list.find_transcript(["en"])
                         self.logger.debug("✓ Using English transcript")
-                    except:
+                    except Exception:
                         # 4. First available transcript
                         transcript = next(iter(transcript_list))
                         self.logger.debug(f"✓ Using {transcript.language} transcript")
@@ -177,8 +177,10 @@ class YouTubeExtractor(BaseExtractor):
                     if last_period > max_transcript_length * 0.8:  # If period is in last 20%
                         full_text = full_text[: last_period + 1]
                 full_text += " [transcript truncated for optimization]"
+                original_length = len(" ".join([item.text for item in transcript_data.snippets]))
                 self.logger.info(
-                    f"Truncated transcript for video {video_id}: original length {len(' '.join([item.text for item in transcript_data.snippets]))} chars -> {len(full_text)} chars"
+                    f"Truncated transcript for video {video_id}: "
+                    f"original length {original_length} chars -> {len(full_text)} chars"
                 )
 
             return {

--- a/packages/ai-server/src/services/metadata/management/tasks.py
+++ b/packages/ai-server/src/services/metadata/management/tasks.py
@@ -393,7 +393,10 @@ async def process_ai_analysis_queue(
             "partial_count": partial_count,
             "failed_count": failed_count,
             "batch_id": batch_id,
-            "message": f"Processed {len(items)} items from queue: {success_count} success, {partial_count} partial, {failed_count} failed",
+            "message": (
+                f"Processed {len(items)} items from queue: "
+                f"{success_count} success, {partial_count} partial, {failed_count} failed"
+            ),
         }
 
         logger.info(

--- a/packages/ai-server/src/services/metadata/processors/link_ai_analyzer.py
+++ b/packages/ai-server/src/services/metadata/processors/link_ai_analyzer.py
@@ -157,7 +157,10 @@ class LinkAIAnalyzer:
             messages.append(
                 LLMMessage(
                     role="user",
-                    content="Summarize the content of this link in 1-2 sentences and put it in the summary field (English).",
+                    content=(
+                        "Summarize the content of this link in 1-2 sentences "
+                        "and put it in the summary field (English)."
+                    ),
                 )
             )
             messages.append(

--- a/packages/ai-server/src/utils/selenium_utils.py
+++ b/packages/ai-server/src/utils/selenium_utils.py
@@ -100,7 +100,7 @@ def enhance_stealth_setup(
                         length: 4,
                         refresh: function() {},
                         item: function(index) { return this[index] },
-                        namedItem: function(name) { 
+                        namedItem: function(name) {
                             return Object.values(this).find(plugin => plugin.name === name);
                         }
                     };


### PR DESCRIPTION
Closes #244

## Summary
PR-A(#245, ruff format + `.flake8`) 위에 올리는 후속. 수동 수정이 필요한 잔여 11건의 lint 에러를 정리하여 `bun run lint --filter @decoded/ai-server` 를 **exit 0** 으로 만든다.

## 수정 내역

### F841 — unused local variables (4건)
- `src/bootstrap.py` — `logger`, `infrastructure` 미사용 변수 삭제
- `src/managers/llm/adapters/groq.py` — `_handle_link_completion`의 미사용 `url` 삭제
- `src/services/metadata/clients/searxng_client.py` — `_is_relevant_result`의 미사용 `content` 삭제

### F811 — redefined import (1건)
- `src/managers/llm/adapters/groq.py` — 중복 `LLMConfig` import 제거

### E722 — bare except (4건)
- `src/managers/llm/prompt_manager.py` `template_exists`
- `src/services/metadata/extractors/youtube_extractor.py` transcript fallback 3곳 — 모두 `except Exception:` 으로

### W291 — trailing whitespace (1건)
- `src/utils/selenium_utils.py`

### E501 — 라인 길이 (긴 string/f-string)
- 수동 분할(괄호 concat): `local_llm.py`×3, `result_aggregator.py`, `tasks.py`, `link_ai_analyzer.py`, `youtube_extractor.py`, `news_research.py` docstring
- `.flake8` `per-file-ignores` (자연어/UA — 개행 불가):
  - `src/services/metadata/clients/web_scraper.py` (USER_AGENTS)
  - `src/post_editorial/nodes/editorial.py` (LLM prompt)
  - `src/post_editorial/nodes/news_research.py` (LLM prompt)

## Test plan
- [x] `uv run flake8 src` → 0 errors
- [x] `bun run lint --filter @decoded/ai-server` → exit 0
- [ ] 리뷰어: `per-file-ignores` 3파일이 실제 자연어/UA 상수인지 확인
- [ ] CI `bun run lint` 전체 green 회복

## Why split from PR-A
PR-A는 **포맷팅 전용** (99파일 reformat, 행동 변경 無). PR-B는 **lint 에러 수동 수정** (12파일 +46/-21, 일부 변수/import 삭제). 분리해서 rollback/리뷰 단순화.

Closes #244