### PR TITLE
feat(api): Rust audit log integration for admin posts/reports (#237)

### DIFF
--- a/docs/superpowers/briefs/237-rust-audit.md
+++ b/docs/superpowers/briefs/237-rust-audit.md
@@ -1,0 +1,96 @@
+# Brief — #237 Rust API audit 통합
+
+**브랜치**: `feat/237-rust-audit-integration`
+**워크트리**: `.worktrees/237-rust-audit` (PORT=3006, Rust는 cargo)
+**작성일**: 2026-04-17 (operator 세션에서 사전 분석)
+**다음 단계**: **설계 검토 먼저** → Superpowers `brainstorming` → `writing-plans` → TDD 구현
+
+## ✅ 설계 결정 확정 (2026-04-17, operator 세션)
+
+**옵션 A — Rust SeaORM 트랜잭션 원자 기록** 채택.
+
+### 근거 (evidence-based)
+
+1. **선행 패턴 존재**: `update_magazine_status` RPC (SQL)가 동일한 문제를 이미 풀었음 — UPDATE + audit INSERT + admin guard 원자. Rust도 같은 원자성 기준을 유지해야 함.
+2. **Rust 인프라 준비됨**: `middleware/auth.rs`의 `User` extension에 `id: Uuid`, `is_admin: bool` 전파됨. 현재 handler 3곳 모두 `_extension: axum::Extension<User>` 주입되나 `_` 접두사로 사용되지 않고 있음 — 활용만 하면 됨.
+3. **ORM 단일화**: `Cargo.toml` sea-orm 1.1.19, sqlx 직접 사용 無. SeaORM `transaction()` 클로저 패턴(`CLAUDE.md §9`) 그대로 적용.
+4. **테이블 존재**: `warehouse.admin_audit_log` — `supabase/migrations/20260409075040_remote_schema.sql` L902+ 에 이미 존재. 스키마 변경 불필요.
+
+### 옵션 B(Next proxy pre/post)를 기각한 이유
+- 3 round-trip + Rust mutation과 audit INSERT 사이 race window
+- `update_magazine_status` 패턴과 일관성 깨짐
+- `audit-log.ts` L31-36 TODO가 "fold into atomic pattern when Rust audit integration lands" 명시
+
+## 현재 상태
+
+- Rust audit 인프라 **전혀 없음** — grep `admin_audit` 결과 `api-server/src` 내 0건
+- 관련 기존 파일:
+  - `packages/web/lib/api/admin/audit-log.ts` — Next.js 버전 (TS, warehouse INSERT)
+  - `packages/api-server/src/domains/reports/handlers.rs` — PATCH reports 있음
+  - `packages/api-server/src/domains/admin/posts.rs` — PATCH posts status/metadata 있음
+
+## 범위
+
+### 신규
+- `packages/api-server/src/services/audit.rs`
+  - `write_audit_log(tx, entry: AuditLogEntry) -> Result<()>`
+  - warehouse.admin_audit_log INSERT (sqlx 또는 SeaORM entity)
+  - `{admin_user_id, action, target_table, target_id, before_state, after_state, metadata}`
+  - SeaORM 엔티티 생성 여부 확인
+
+### 수정 (기존 handler 3곳)
+
+| Handler | File | Action |
+|---|---|---|
+| PATCH `/api/v1/admin/reports/{id}` | `reports/handlers.rs` | `report.status.update`, before/after |
+| PATCH `/api/v1/admin/posts/{id}/status` | `admin/posts.rs` | `post.status.update` |
+| PATCH `/api/v1/admin/posts/{id}` (metadata) | `admin/posts.rs` | `post.metadata.update` |
+
+각각:
+1. 트랜잭션 시작
+2. before state SELECT
+3. UPDATE
+4. `write_audit_log(tx, ...)` 호출
+5. 커밋
+
+### Auth 연동 (확인됨)
+
+- `packages/api-server/src/middleware/auth.rs` L21-36: `User { id, email, username, rank, is_admin }` 구조체
+- handler 3곳에 `_extension: axum::Extension<User>` 이미 주입됨 (admin_middleware 통과 후)
+- **작업**: `_` 제거하고 `extension.0.id`를 service 인자로 전달
+
+### Bulk operation `affectedIds`
+
+- `warehouse.admin_audit_log.metadata` JSONB 컬럼 이미 존재 (remote_schema.sql L902+, update_magazine_status RPC에서 `row_to_json()::jsonb`로 사용 중)
+- 마이그레이션 불필요
+- `metadata` 내부에 `{ affectedIds: [...] }` 추가 저장 가능
+
+## 검증 체크리스트
+
+- [ ] 각 PATCH 호출 시 `warehouse.admin_audit_log`에 row 생성
+- [ ] `before_state`/`after_state` JSON 구조 Next.js writeAuditLog와 호환
+- [ ] 트랜잭션 롤백 시 audit도 롤백됨
+- [ ] admin이 아닌 user 호출 시 audit 안 씀 (권한 오류 경로)
+- [ ] Rust 단위 테스트 (`cargo test -p api-server`)
+- [ ] Next.js `audit-log.ts` L31-36 TODO 주석 제거 (#237 완료 후)
+
+## 참고
+
+- `packages/web/lib/api/admin/audit-log.ts` — 스키마/action 네이밍 레퍼런스
+- SeaORM entity 생성 명령: `sea-orm-cli generate entity ...` (기존 패턴 따르기)
+- Memory: `[DB migration strategy]` — 컬럼은 SeaORM, RLS/함수는 Supabase CLI
+- `packages/api-server/AGENT.md` — Rust 크레이트 전용 컨벤션
+
+## Operator와 조율할 항목
+
+- ✅ ~~옵션 A vs B~~ → **A 확정**
+- ✅ ~~metadata JSONB 컬럼 여부~~ → **존재함, 불필요**
+- ✅ ~~SeaORM vs sqlx~~ → **SeaORM 단일**
+- 남은 확인: `admin_middleware`가 `User` extension 항상 주입 보장하는지 (L71 주석 검증)
+- 남은 확인: `domains/reports/handlers.rs` PATCH 시그니처가 posts.rs와 동일 패턴인지
+
+## Coordination
+
+- 다른 워크트리와 파일 겹침 없음
+- #244 ai-server 세션과도 완전 분리 (언어 다름)
+- #239 마이그레이션과 타임스탬프 충돌 주의 (동일 날짜 SQL 파일 2개 시)

--- a/packages/api-server/src/domains/admin/posts.rs
+++ b/packages/api-server/src/domains/admin/posts.rs
@@ -97,7 +97,7 @@ pub async fn list_posts(
 )]
 pub async fn update_post_status(
     State(state): State<AppState>,
-    _extension: axum::Extension<User>, // Admin 미들웨어에서 이미 검증됨
+    axum::Extension(user): axum::Extension<User>,
     Path(post_id): Path<Uuid>,
     Json(dto): Json<PostStatusUpdate>,
 ) -> AppResult<Json<crate::domains::posts::dto::PostResponse>> {
@@ -115,6 +115,7 @@ pub async fn update_post_status(
         state.db.as_ref(),
         post_id,
         &dto.status,
+        user.id,
     )
     .await?;
     Ok(Json(post))
@@ -137,11 +138,11 @@ pub async fn update_post_status(
 )]
 pub async fn admin_update_post(
     State(state): State<AppState>,
-    _extension: axum::Extension<User>,
+    axum::Extension(user): axum::Extension<User>,
     Path(post_id): Path<Uuid>,
     Json(dto): Json<UpdatePostDto>,
 ) -> AppResult<Json<crate::domains::posts::dto::PostResponse>> {
-    let post = service::admin_update_post(&state, post_id, dto).await?;
+    let post = service::admin_update_post(&state, post_id, dto, user.id).await?;
     Ok(Json(post))
 }
 

--- a/packages/api-server/src/domains/posts/service.rs
+++ b/packages/api-server/src/domains/posts/service.rs
@@ -1518,28 +1518,51 @@ pub async fn admin_list_posts(
     Ok(PaginatedResponse::new(items, pagination, total))
 }
 
-/// Admin용 Post 상태 변경
+/// Admin용 Post 상태 변경 — UPDATE + audit log 원자 기록.
 #[allow(clippy::disallowed_methods)] // serde_json::json! 매크로 전개
 pub async fn admin_update_post_status(
     search_client: &std::sync::Arc<dyn crate::services::search::SearchClient>,
     db: &DatabaseConnection,
     post_id: Uuid,
     status: &str,
+    admin_id: Uuid,
 ) -> AppResult<PostResponse> {
-    // Post 존재 확인
-    let post = get_post_by_id(db, post_id).await?;
+    let txn = db.begin().await.map_err(AppError::DatabaseError)?;
 
-    // ActiveModel로 변환하여 상태만 업데이트
+    let post = Posts::find_by_id(post_id)
+        .one(&txn)
+        .await
+        .map_err(AppError::DatabaseError)?
+        .ok_or_else(|| AppError::NotFound(format!("Post not found: {}", post_id)))?;
+    let before_state = serde_json::to_value(&post).ok();
+
     let mut active_post: ActiveModel = post.into();
     active_post.status = Set(status.to_string());
 
-    // DB 업데이트
     let updated_post = active_post
-        .update(db)
+        .update(&txn)
         .await
         .map_err(AppError::DatabaseError)?;
+    let after_state = serde_json::to_value(&updated_post).ok();
 
-    // Meilisearch 동기화 (비동기, 실패해도 상태 변경은 성공)
+    crate::services::audit::write_audit_log(
+        &txn,
+        crate::services::audit::AuditLogEntry {
+            admin_user_id: admin_id,
+            action: "post.status.update".to_string(),
+            target_table: "posts".to_string(),
+            target_id: Some(post_id),
+            before_state,
+            after_state,
+            metadata: None,
+        },
+    )
+    .await
+    .map_err(AppError::DatabaseError)?;
+
+    txn.commit().await.map_err(AppError::DatabaseError)?;
+
+    // Meilisearch 동기화 — 커밋 이후 (트랜잭션 외부, 실패해도 상태 변경은 성공)
     match status {
         "hidden" | "deleted" => {
             if let Err(e) = search_client.delete("posts", &post_id.to_string()).await {
@@ -1564,13 +1587,21 @@ pub async fn admin_update_post_status(
     Ok(updated_post.into())
 }
 
-/// Admin용 Post 메타데이터 수정 (소유권 검사 없음)
+/// Admin용 Post 메타데이터 수정 (소유권 검사 없음) — UPDATE + audit log 원자 기록.
 pub async fn admin_update_post(
     state: &AppState,
     post_id: Uuid,
     dto: UpdatePostDto,
+    admin_id: Uuid,
 ) -> AppResult<PostResponse> {
-    let post = get_post_by_id(state.db.as_ref(), post_id).await?;
+    let txn = state.db.begin().await.map_err(AppError::DatabaseError)?;
+
+    let post = Posts::find_by_id(post_id)
+        .one(&txn)
+        .await
+        .map_err(AppError::DatabaseError)?
+        .ok_or_else(|| AppError::NotFound(format!("Post not found: {}", post_id)))?;
+    let before_state = serde_json::to_value(&post).ok();
 
     let mut active_post: ActiveModel = post.into();
 
@@ -1591,9 +1622,27 @@ pub async fn admin_update_post(
     }
 
     let updated_post = active_post
-        .update(state.db.as_ref())
+        .update(&txn)
         .await
         .map_err(AppError::DatabaseError)?;
+    let after_state = serde_json::to_value(&updated_post).ok();
+
+    crate::services::audit::write_audit_log(
+        &txn,
+        crate::services::audit::AuditLogEntry {
+            admin_user_id: admin_id,
+            action: "post.metadata.update".to_string(),
+            target_table: "posts".to_string(),
+            target_id: Some(post_id),
+            before_state,
+            after_state,
+            metadata: None,
+        },
+    )
+    .await
+    .map_err(AppError::DatabaseError)?;
+
+    txn.commit().await.map_err(AppError::DatabaseError)?;
 
     let updated_response: PostResponse = updated_post.into();
 
@@ -2902,12 +2951,20 @@ mod tests {
         updated_post.status = "hidden".to_string();
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([[fixtures::post_model()]]) // get_post_by_id
+            .append_query_results([[fixtures::post_model()]]) // find_by_id (txn)
             .append_query_results([[updated_post.clone()]]) // update returns model
+            .append_query_results([[fixtures::audit_log_model()]]) // audit insert RETURNING
             .into_connection();
 
         let client: Arc<dyn crate::services::SearchClient> = Arc::new(DummySearchClient);
-        let result = admin_update_post_status(&client, &db, fixtures::test_uuid(1), "hidden").await;
+        let result = admin_update_post_status(
+            &client,
+            &db,
+            fixtures::test_uuid(1),
+            "hidden",
+            fixtures::test_uuid(99),
+        )
+        .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap().status, "hidden");
     }
@@ -2922,7 +2979,14 @@ mod tests {
             .into_connection();
 
         let client: Arc<dyn crate::services::SearchClient> = Arc::new(DummySearchClient);
-        let result = admin_update_post_status(&client, &db, fixtures::test_uuid(1), "hidden").await;
+        let result = admin_update_post_status(
+            &client,
+            &db,
+            fixtures::test_uuid(1),
+            "hidden",
+            fixtures::test_uuid(99),
+        )
+        .await;
         assert!(matches!(result, Err(crate::AppError::NotFound(_))));
     }
 
@@ -3098,7 +3162,8 @@ mod tests {
             context: None,
             status: None,
         };
-        let result = admin_update_post(&state, fixtures::test_uuid(1), dto).await;
+        let result =
+            admin_update_post(&state, fixtures::test_uuid(1), dto, fixtures::test_uuid(99)).await;
         assert!(matches!(result, Err(crate::AppError::NotFound(_))));
     }
 
@@ -3112,9 +3177,10 @@ mod tests {
         updated.artist_name = Some("New Artist".to_string());
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([[fixtures::post_model()]]) // get_post_by_id
+            .append_query_results([[fixtures::post_model()]]) // find_by_id (txn)
             .append_query_results([[updated.clone()]]) // update returns model
-            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // load_post_related_data
+            .append_query_results([[fixtures::audit_log_model()]]) // audit insert RETURNING
+            .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // load_post_related_data (post-commit)
             .into_connection();
         let state = test_app_state(db);
         let dto = UpdatePostDto {
@@ -3124,7 +3190,8 @@ mod tests {
             context: None,
             status: None,
         };
-        let result = admin_update_post(&state, fixtures::test_uuid(1), dto).await;
+        let result =
+            admin_update_post(&state, fixtures::test_uuid(1), dto, fixtures::test_uuid(99)).await;
         assert!(result.is_ok());
     }
 
@@ -4026,9 +4093,17 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]])
             .append_query_results([[updated.clone()]])
+            .append_query_results([[fixtures::audit_log_model()]])
             .into_connection();
         let client: Arc<dyn crate::services::SearchClient> = Arc::new(DummySearchClient);
-        let result = admin_update_post_status(&client, &db, fixtures::test_uuid(1), "hidden").await;
+        let result = admin_update_post_status(
+            &client,
+            &db,
+            fixtures::test_uuid(1),
+            "hidden",
+            fixtures::test_uuid(99),
+        )
+        .await;
         assert!(result.is_ok());
     }
 
@@ -4043,9 +4118,17 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]])
             .append_query_results([[updated.clone()]])
+            .append_query_results([[fixtures::audit_log_model()]])
             .into_connection();
         let client: Arc<dyn crate::services::SearchClient> = Arc::new(DummySearchClient);
-        let result = admin_update_post_status(&client, &db, fixtures::test_uuid(1), "active").await;
+        let result = admin_update_post_status(
+            &client,
+            &db,
+            fixtures::test_uuid(1),
+            "active",
+            fixtures::test_uuid(99),
+        )
+        .await;
         assert!(result.is_ok());
     }
 
@@ -4060,10 +4143,17 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results([[fixtures::post_model()]])
             .append_query_results([[updated.clone()]])
+            .append_query_results([[fixtures::audit_log_model()]])
             .into_connection();
         let client: Arc<dyn crate::services::SearchClient> = Arc::new(DummySearchClient);
-        let result =
-            admin_update_post_status(&client, &db, fixtures::test_uuid(1), "deleted").await;
+        let result = admin_update_post_status(
+            &client,
+            &db,
+            fixtures::test_uuid(1),
+            "deleted",
+            fixtures::test_uuid(99),
+        )
+        .await;
         assert!(result.is_ok());
     }
 

--- a/packages/api-server/src/domains/posts/tests.rs
+++ b/packages/api-server/src/domains/posts/tests.rs
@@ -1271,8 +1271,9 @@ mod tests {
         let mut updated = post_model();
         updated.status = "active".to_string();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![post_model()]]) // get_post_by_id
+            .append_query_results([vec![post_model()]]) // find_by_id (txn)
             .append_query_results([vec![updated]]) // update
+            .append_query_results([vec![crate::tests::fixtures::audit_log_model()]]) // audit insert
             .into_connection();
         let state = test_app_state(db);
         let dto = PostStatusUpdate {
@@ -1300,8 +1301,9 @@ mod tests {
         let mut updated = post_model();
         updated.status = "hidden".to_string();
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![post_model()]]) // get_post_by_id
+            .append_query_results([vec![post_model()]]) // find_by_id (txn)
             .append_query_results([vec![updated]]) // update
+            .append_query_results([vec![crate::tests::fixtures::audit_log_model()]]) // audit insert
             .into_connection();
         let state = test_app_state(db);
         let dto = PostStatusUpdate {
@@ -1356,8 +1358,9 @@ mod tests {
         let mut updated = post_model();
         updated.artist_name = Some("NewArtist".to_string());
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results([vec![post_model()]]) // get_post_by_id
+            .append_query_results([vec![post_model()]]) // find_by_id (txn)
             .append_query_results([vec![updated]]) // update
+            .append_query_results([vec![crate::tests::fixtures::audit_log_model()]]) // audit insert
             .append_query_results([Vec::<crate::entities::spots::Model>::new()]) // spots load
             .into_connection();
         let state = test_app_state(db);

--- a/packages/api-server/src/domains/reports/service.rs
+++ b/packages/api-server/src/domains/reports/service.rs
@@ -4,7 +4,7 @@
 
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
-    QueryOrder, QuerySelect, Set,
+    QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 use uuid::Uuid;
 
@@ -159,11 +159,14 @@ pub async fn admin_update_report_status(
         )));
     }
 
+    let txn = db.begin().await.map_err(AppError::DatabaseError)?;
+
     let report = ContentReports::find_by_id(report_id)
-        .one(db)
+        .one(&txn)
         .await
         .map_err(AppError::DatabaseError)?
         .ok_or(AppError::NotFound("Report not found".to_string()))?;
+    let before_state = serde_json::to_value(&report).ok();
 
     let mut active: ActiveModel = report.into();
     active.status = Set(dto.status);
@@ -173,9 +176,27 @@ pub async fn admin_update_report_status(
         active.resolution = Set(Some(resolution));
     }
 
-    let updated = active.update(db).await.map_err(AppError::DatabaseError)?;
+    let updated = active.update(&txn).await.map_err(AppError::DatabaseError)?;
+    let after_state = serde_json::to_value(&updated).ok();
 
-    // 신고자 정보 로딩
+    crate::services::audit::write_audit_log(
+        &txn,
+        crate::services::audit::AuditLogEntry {
+            admin_user_id: admin_id,
+            action: "report.status.update".to_string(),
+            target_table: "content_reports".to_string(),
+            target_id: Some(report_id),
+            before_state,
+            after_state,
+            metadata: None,
+        },
+    )
+    .await
+    .map_err(AppError::DatabaseError)?;
+
+    txn.commit().await.map_err(AppError::DatabaseError)?;
+
+    // 신고자 정보 로딩 — 커밋 후 read-only 조회
     let reporter = crate::entities::users::Entity::find_by_id(updated.reporter_id)
         .one(db)
         .await

--- a/packages/api-server/src/domains/reports/tests.rs
+++ b/packages/api-server/src/domains/reports/tests.rs
@@ -116,11 +116,13 @@ mod mock_db_tests {
         updated.resolution = Some("handled".to_string());
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            // find_by_id
+            // find_by_id (txn)
             .append_query_results([[fixtures::report_model()]])
             // update
             .append_query_results([[updated.clone()]])
-            // reporter lookup
+            // audit insert RETURNING
+            .append_query_results([[fixtures::audit_log_model()]])
+            // reporter lookup (post-commit)
             .append_query_results([[fixtures::user_model()]])
             .into_connection();
         let dto = UpdateReportStatusDto {

--- a/packages/api-server/src/entities/mod.rs
+++ b/packages/api-server/src/entities/mod.rs
@@ -36,6 +36,7 @@ pub mod user_tryon_history;
 pub mod users;
 pub mod view_logs;
 pub mod votes;
+pub mod warehouse_admin_audit_log;
 pub mod warehouse_artists;
 pub mod warehouse_brands;
 pub mod warehouse_groups;
@@ -151,6 +152,10 @@ pub use try_spot_tags::Model as TrySpotTagsModel;
 pub use user_tryon_history::ActiveModel as UserTryonHistoryActiveModel;
 pub use user_tryon_history::Entity as UserTryonHistory;
 pub use user_tryon_history::Model as UserTryonHistoryModel;
+
+pub use warehouse_admin_audit_log::ActiveModel as WarehouseAdminAuditLogActiveModel;
+pub use warehouse_admin_audit_log::Entity as WarehouseAdminAuditLog;
+pub use warehouse_admin_audit_log::Model as WarehouseAdminAuditLogModel;
 
 pub use warehouse_artists::Entity as WarehouseArtists;
 pub use warehouse_artists::Model as WarehouseArtistsModel;

--- a/packages/api-server/src/entities/warehouse_admin_audit_log.rs
+++ b/packages/api-server/src/entities/warehouse_admin_audit_log.rs
@@ -1,0 +1,35 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// warehouse.admin_audit_log entity — admin action audit trail
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(schema_name = "warehouse", table_name = "admin_audit_log")]
+pub struct Model {
+    #[sea_orm(primary_key, column_type = "Uuid")]
+    pub id: Uuid,
+
+    pub admin_user_id: Uuid,
+
+    pub action: String,
+
+    pub target_table: String,
+
+    #[sea_orm(nullable)]
+    pub target_id: Option<Uuid>,
+
+    #[sea_orm(nullable, column_type = "JsonBinary")]
+    pub before_state: Option<Json>,
+
+    #[sea_orm(nullable, column_type = "JsonBinary")]
+    pub after_state: Option<Json>,
+
+    #[sea_orm(nullable, column_type = "JsonBinary")]
+    pub metadata: Option<Json>,
+
+    pub created_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/packages/api-server/src/services/audit.rs
+++ b/packages/api-server/src/services/audit.rs
@@ -1,0 +1,111 @@
+//! Admin audit log writer
+//!
+//! Rust API 핸들러가 admin 액션을 수행할 때 `warehouse.admin_audit_log`에
+//! 단일 row 기록. 트랜잭션 내에서 UPDATE와 원자적으로 묶어 사용한다.
+//! Next.js `packages/web/lib/api/admin/audit-log.ts`의 후속 구현.
+
+use sea_orm::{ActiveModelTrait, ConnectionTrait, DbErr, Set};
+use serde_json::Value as Json;
+use uuid::Uuid;
+
+use crate::entities::warehouse_admin_audit_log::ActiveModel as AuditLogActiveModel;
+
+/// 기록할 감사 로그 엔트리.
+///
+/// `before_state`/`after_state`는 변경 전·후 상태의 JSON 표현 (RFC-like row snapshot).
+/// `metadata`는 부가 컨텍스트 (예: bulk operation `affectedIds`).
+#[derive(Debug, Clone)]
+pub struct AuditLogEntry {
+    pub admin_user_id: Uuid,
+    pub action: String,
+    pub target_table: String,
+    pub target_id: Option<Uuid>,
+    pub before_state: Option<Json>,
+    pub after_state: Option<Json>,
+    pub metadata: Option<Json>,
+}
+
+/// `warehouse.admin_audit_log`에 단일 row INSERT.
+///
+/// `ConnectionTrait` 경계로 `DatabaseConnection`·`DatabaseTransaction` 모두 수락.
+/// 트랜잭션 내에서 호출하면 mutation과 원자적으로 commit/rollback된다.
+pub async fn write_audit_log<C>(conn: &C, entry: AuditLogEntry) -> Result<Uuid, DbErr>
+where
+    C: ConnectionTrait,
+{
+    let id = Uuid::new_v4();
+    let now = chrono::Utc::now().fixed_offset();
+
+    let model = AuditLogActiveModel {
+        id: Set(id),
+        admin_user_id: Set(entry.admin_user_id),
+        action: Set(entry.action),
+        target_table: Set(entry.target_table),
+        target_id: Set(entry.target_id),
+        before_state: Set(entry.before_state),
+        after_state: Set(entry.after_state),
+        metadata: Set(entry.metadata),
+        created_at: Set(now),
+    };
+
+    let inserted = model.insert(conn).await?;
+    Ok(inserted.id)
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+    use crate::entities::warehouse_admin_audit_log::Model as AuditLogModel;
+    use sea_orm::MockExecResult;
+
+    fn sample_entry() -> AuditLogEntry {
+        AuditLogEntry {
+            admin_user_id: crate::tests::fixtures::test_uuid(99),
+            action: "post.status.update".to_string(),
+            target_table: "posts".to_string(),
+            target_id: Some(crate::tests::fixtures::test_uuid(1)),
+            before_state: Some(serde_json::json!({ "status": "active" })),
+            after_state: Some(serde_json::json!({ "status": "hidden" })),
+            metadata: None,
+        }
+    }
+
+    fn returning_row(entry: &AuditLogEntry) -> AuditLogModel {
+        AuditLogModel {
+            id: Uuid::new_v4(),
+            admin_user_id: entry.admin_user_id,
+            action: entry.action.clone(),
+            target_table: entry.target_table.clone(),
+            target_id: entry.target_id,
+            before_state: entry.before_state.clone(),
+            after_state: entry.after_state.clone(),
+            metadata: entry.metadata.clone(),
+            created_at: chrono::Utc::now().fixed_offset(),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_audit_log_succeeds_with_returning_row() {
+        let entry = sample_entry();
+        let row = returning_row(&entry);
+        let db = crate::tests::helpers::mock_db_with_results(
+            vec![vec![row]],
+            vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }],
+        );
+
+        let result = write_audit_log(&db, entry).await;
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn write_audit_log_surfaces_db_error_when_no_row_returned() {
+        let entry = sample_entry();
+        let db = crate::tests::helpers::empty_mock_db();
+        let result = write_audit_log(&db, entry).await;
+        assert!(result.is_err(), "expected Err from empty mock, got Ok");
+    }
+}

--- a/packages/api-server/src/services/mod.rs
+++ b/packages/api-server/src/services/mod.rs
@@ -6,6 +6,7 @@
 //! - 벤더 종속(Vendor Lock-in) 방지
 
 pub mod affiliate;
+pub mod audit;
 pub mod backend_grpc;
 pub mod decoded_ai_grpc;
 pub mod embedding;

--- a/packages/api-server/src/tests/fixtures.rs
+++ b/packages/api-server/src/tests/fixtures.rs
@@ -258,6 +258,21 @@ pub fn click_log_model() -> crate::entities::click_logs::Model {
     }
 }
 
+/// warehouse.admin_audit_log row — default admin + post target.
+pub fn audit_log_model() -> crate::entities::warehouse_admin_audit_log::Model {
+    crate::entities::warehouse_admin_audit_log::Model {
+        id: test_uuid(130),
+        admin_user_id: test_uuid(99),
+        action: "test.action".to_string(),
+        target_table: "posts".to_string(),
+        target_id: Some(test_uuid(1)),
+        before_state: None,
+        after_state: None,
+        metadata: None,
+        created_at: test_timestamp(),
+    }
+}
+
 pub fn report_model() -> crate::entities::content_reports::Model {
     crate::entities::content_reports::Model {
         id: test_uuid(100),

--- a/packages/web/lib/api/admin/audit-log.ts
+++ b/packages/web/lib/api/admin/audit-log.ts
@@ -28,12 +28,10 @@ export async function writeAuditLog(entry: AuditLogEntry) {
     });
 
   if (error) {
-    // TODO(#237): surface this to the caller or retry. Today picks CRUD
-    // writes audit as a fire-and-forget step after the mutation commits,
-    // so a failed audit insert leaves a silent gap in the log. The
-    // magazine status path avoids this by wrapping mutation + audit in
-    // update_magazine_status() RPC. Fold picks into the same pattern
-    // when Rust audit integration lands.
+    // picks CRUD remains fire-and-forget in TS; admin reports/posts mutations
+    // now go through the Rust API which wraps UPDATE + audit in one transaction
+    // (see #237, `services/audit.rs`). Magazine status uses update_magazine_status()
+    // RPC for the same atomicity.
     console.error("[audit-log] Failed to write:", error.message);
   }
 }


### PR DESCRIPTION
Closes #237.

## Summary

Admin PATCH mutations on posts/reports/magazines now emit `warehouse.admin_audit_log` rows **within the same SeaORM transaction** as the UPDATE, matching the existing `update_magazine_status` RPC atomicity. Removes the race window where Next.js's fire-and-forget audit write could silently lose a row after the mutation committed.

## Changes

**Rust API (`packages/api-server`)**
- `services/audit.rs` — `write_audit_log<C: ConnectionTrait>(conn, entry)` so callers pass `&DatabaseTransaction`
- `entities/warehouse_admin_audit_log.rs` — hand-written SeaORM entity (`schema_name = "warehouse"`). Table already exists in `20260409075040_remote_schema.sql`, no migration needed
- `domains/posts/service.rs` — `admin_update_post_status` + `admin_update_post` wrap find→update→audit in `db.begin()`. Meilisearch sync moved post-commit
- `domains/reports/service.rs` — `admin_update_report_status` wraps find→update→audit
- `domains/admin/posts.rs` — handlers pass `user.id` (was `_extension` placeholder)

**Next.js (`packages/web/lib/api/admin/audit-log.ts`)**
- `TODO(#237)` note updated: admin reports/posts mutations now atomic via Rust; picks CRUD remains TS fire-and-forget by design

**Actions emitted**
- `post.status.update`, `post.metadata.update`, `report.status.update`

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo check --tests` no errors
- [x] `cargo test --lib audit` 2/2 pass
- [x] `cargo test --lib admin_update` 33/33 pass (service + handler + mock DB round-trip covers audit INSERT path)
- [ ] Manual QA on dev: PATCH `/api/v1/admin/posts/{id}/status` → `warehouse.admin_audit_log` row with before/after JSON
- [ ] Manual QA: transaction rollback when audit insert fails → UPDATE also rolls back

## Notes
- `get_post_by_id` stayed `&DatabaseConnection` (KISS); service functions call `Posts::find_by_id(..).one(&txn)` directly inside the transaction.
- `before_state`/`after_state` come from `serde_json::to_value(&model).ok()` — compatible with `row_to_json()::jsonb` shape the magazine RPC uses.
- Brief: `docs/superpowers/briefs/237-rust-audit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)