### PR TITLE
refactor(ai-server): supabase-py → asyncpg 이관 (DB 접근 추상화) (#266)

### DIFF
--- a/packages/ai-server/pyproject.toml
+++ b/packages/ai-server/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "supabase (>=2.0)",
     "tenacity (>=9.0)",
     "sentry-sdk[fastapi,grpcio]>=2.56.0,<3.0.0",
+    "asyncpg>=0.29",
 ]
 
 [dependency-groups]

--- a/packages/ai-server/src/config/_container.py
+++ b/packages/ai-server/src/config/_container.py
@@ -13,6 +13,7 @@ from ._environment import Environment
 from ._logger import LoggerService, get_logger
 from src.managers.redis._manager import RedisManager
 from src.managers.queue.queue_manager import QueueManager
+from src.managers.database import DatabaseManager
 from src.services.metadata.core.metadata_extract_service import MetadataExtractService
 from src.services.metadata.core.result_batch_service import ResultBatchService
 from src.services.metadata.management.failed_items_manager import FailedItemsManager
@@ -45,6 +46,12 @@ class InfrastructureContainer(DeclarativeContainer):
         QueueManager,
         environment=environment,
         logger=logger,
+    )
+
+    # Postgres direct access — asyncpg pool. DATABASE_URL로 로컬/prod 투명 전환.
+    database_manager: Singleton[DatabaseManager] = Singleton(
+        DatabaseManager,
+        environment=environment,
     )
 
 

--- a/packages/ai-server/src/config/_environment.py
+++ b/packages/ai-server/src/config/_environment.py
@@ -42,6 +42,11 @@ class Environment(BaseModel):
 
     QUEUE_BATCH_SIZE: int = 10
 
+    # Postgres 직접 연결 (asyncpg pool) — 로컬/prod 투명 전환 (DATABASE_URL 값만 교체)
+    DATABASE_URL: str = ""
+    DATABASE_POOL_MIN: int = 1
+    DATABASE_POOL_MAX: int = 5
+
     API_SERVER_HTTP_URL: str
     API_SERVER_ACCESS_TOKEN: str
 

--- a/packages/ai-server/src/grpc/servicer/metadata_servicer.py
+++ b/packages/ai-server/src/grpc/servicer/metadata_servicer.py
@@ -422,12 +422,13 @@ class MetadataServicer(inbound_pb2_grpc.QueueServicer):
             self.logger.info(f"ExtractPostContext for post {post_id}")
 
             service = PostContextService()
-            supabase_url = os.environ.get("SUPABASE_URL", "")
-            supabase_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+            # asyncpg pool via DI — DATABASE_URL 로 투명 전환 (#266)
+            from src.config._container import Application
 
-            result = await service.extract_and_update(
-                post_id, image_url, supabase_url, supabase_key
-            )
+            app = Application()
+            database_manager = app.infrastructure().database_manager()
+
+            result = await service.extract_and_update(post_id, image_url, database_manager)
 
             return inbound_pb2.ExtractPostContextResponse(
                 success=True,

--- a/packages/ai-server/src/main.py
+++ b/packages/ai-server/src/main.py
@@ -92,8 +92,8 @@ async def start_arq_worker(environment, metadata_container, infrastructure_conta
 
     worker = None
     try:
-        # Create worker with injected dependencies
-        worker = await create_worker(environment, metadata_container)
+        # Create worker with injected dependencies (incl. DatabaseManager for post_editorial)
+        worker = await create_worker(environment, metadata_container, infrastructure_container)
 
         # Initialize QueueManager (NEW - replaces service.initialize_arq_pool)
         queue_manager = infrastructure_container.queue_manager()
@@ -163,6 +163,13 @@ async def main():
             logger.info("Backend client closed")
         except Exception as e:
             logger.warning(f"Error closing backend client: {str(e)}")
+
+        # Cleanup asyncpg pool (#266)
+        try:
+            await infrastructure_container.database_manager().close()
+            logger.info("Database pool closed")
+        except Exception as e:
+            logger.warning(f"Error closing database pool: {str(e)}")
 
 
 if __name__ == "__main__":

--- a/packages/ai-server/src/managers/database/__init__.py
+++ b/packages/ai-server/src/managers/database/__init__.py
@@ -1,0 +1,3 @@
+from .pool import DatabaseManager
+
+__all__ = ["DatabaseManager"]

--- a/packages/ai-server/src/managers/database/pool.py
+++ b/packages/ai-server/src/managers/database/pool.py
@@ -1,0 +1,96 @@
+"""Async Postgres connection pool manager.
+
+Uses `asyncpg` for direct TCP access to the Postgres instance pointed to by
+`DATABASE_URL`. Works transparently against:
+- 로컬 Postgres 컨테이너 (`postgresql://postgres:postgres@localhost:5432/decoded`)
+- 원격 Supabase pooler (`postgresql://postgres.<ref>:<pwd>@aws-...pooler.supabase.com:5432/postgres`)
+
+Pool is lazily initialized on first `pool()` call and reused for the process
+lifetime. Size is bounded by `DATABASE_POOL_MIN`/`DATABASE_POOL_MAX` to stay
+within Supabase pooler quota on prod.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+import asyncpg
+
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseManager:
+    """Singleton asyncpg connection pool, injected via the DI container.
+
+    Usage:
+        async with db_manager.acquire() as conn:
+            row = await conn.fetchrow("SELECT * FROM posts WHERE id = $1", post_id)
+    """
+
+    def __init__(self, environment) -> None:
+        self._env = environment
+        self._pool: Optional[asyncpg.Pool] = None
+        self._lock = asyncio.Lock()
+
+    async def pool(self) -> asyncpg.Pool:
+        """Return the shared pool, initializing it on first call."""
+        if self._pool is not None:
+            return self._pool
+        async with self._lock:
+            if self._pool is not None:
+                return self._pool
+            dsn = self._env.DATABASE_URL
+            if not dsn:
+                raise RuntimeError(
+                    "DatabaseManager: DATABASE_URL is not configured. Set it in your env file."
+                )
+            self._pool = await asyncpg.create_pool(
+                dsn=dsn,
+                min_size=self._env.DATABASE_POOL_MIN,
+                max_size=self._env.DATABASE_POOL_MAX,
+                # Keep queries short-lived; long transactions are not expected here.
+                command_timeout=30,
+            )
+            logger.info(
+                "DatabaseManager: pool initialized (min=%s, max=%s)",
+                self._env.DATABASE_POOL_MIN,
+                self._env.DATABASE_POOL_MAX,
+            )
+            return self._pool
+
+    def acquire(self):
+        """Return an async context manager that yields a pooled connection.
+
+        Mirrors `asyncpg.Pool.acquire()` but ensures pool initialization.
+        """
+        return _AcquireProxy(self)
+
+    async def close(self) -> None:
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None
+            logger.info("DatabaseManager: pool closed")
+
+
+class _AcquireProxy:
+    """Thin proxy so callers can `async with db_manager.acquire() as conn:`.
+
+    `asyncpg.Pool.acquire()` already returns such a context manager but we
+    need to await `pool()` first to lazy-init.
+    """
+
+    def __init__(self, manager: DatabaseManager) -> None:
+        self._manager = manager
+        self._acquirer = None
+
+    async def __aenter__(self):
+        pool = await self._manager.pool()
+        self._acquirer = pool.acquire()
+        return await self._acquirer.__aenter__()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self._acquirer is not None:
+            return await self._acquirer.__aexit__(exc_type, exc, tb)

--- a/packages/ai-server/src/managers/queue/worker.py
+++ b/packages/ai-server/src/managers/queue/worker.py
@@ -66,19 +66,16 @@ class WorkerSettings:
         )
 
 
-async def create_worker(environment, metadata_container) -> Worker:
+async def create_worker(
+    environment, metadata_container, infrastructure_container=None
+) -> Worker:
     """
     Create and configure an ARQ worker with injected dependencies
 
-    This function:
-    1. Creates Redis connection settings from environment
-    2. Gets required services from the metadata container
-    3. Creates a context dictionary for job access
-    4. Initializes and returns the ARQ worker
-
     Args:
         environment: Environment configuration object
-        metadata_container: Metadata service container for dependency injection
+        metadata_container: Metadata service container
+        infrastructure_container: Infrastructure container (needed for database_manager)
 
     Returns:
         Configured ARQ Worker instance
@@ -101,6 +98,10 @@ async def create_worker(environment, metadata_container) -> Worker:
             "result_batch_service": result_batch_service,
             "environment": environment,
         }
+
+        # #266 DatabaseManager for post_editorial asyncpg access
+        if infrastructure_container is not None:
+            ctx["database_manager"] = infrastructure_container.database_manager()
 
         # Create worker with settings
         worker = Worker(

--- a/packages/ai-server/src/post_editorial/nodes/celeb_search.py
+++ b/packages/ai-server/src/post_editorial/nodes/celeb_search.py
@@ -4,17 +4,44 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any
 
+import asyncpg
 from google import genai
 from google.genai import types
 from pydantic import BaseModel
-from supabase import AsyncClient, acreate_client
+
+from src.managers.database import DatabaseManager
 
 from ..state import PostEditorialState
 from ..config import get_settings
 from ..gemini_retry import call_gemini_with_fallback
 
 logger = logging.getLogger(__name__)
+
+
+def _get_database_manager(config: Any) -> DatabaseManager | None:
+    """Fetch DatabaseManager from LangGraph config or DI fallback."""
+    configurable: dict = {}
+    if config is not None:
+        configurable = (
+            getattr(config, "configurable", {})
+            if hasattr(config, "configurable")
+            else config.get("configurable", {})
+            if isinstance(config, dict)
+            else {}
+        )
+    svc = configurable.get("database_manager")
+    if svc is not None:
+        return svc
+    try:
+        from src.config._container import Application
+
+        app = Application()
+        return app.infrastructure().database_manager()
+    except Exception:
+        logger.debug("DatabaseManager unavailable — celeb search will skip")
+        return None
 
 
 class RankedCeleb(BaseModel):
@@ -30,43 +57,58 @@ class CelebRankingOutput(BaseModel):
     celebs: list[RankedCeleb] = []
 
 
-async def _get_supabase_client() -> AsyncClient:
-    settings = get_settings()
-    return await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
+def _row_to_dict(row: asyncpg.Record | None) -> dict | None:
+    if row is None:
+        return None
+    out = dict(row)
+    # Cast UUIDs to str, parse jsonb-as-text if needed
+    if "id" in out:
+        out["id"] = str(out["id"])
+    meta = out.get("metadata")
+    if isinstance(meta, str):
+        try:
+            out["metadata"] = json.loads(meta)
+        except json.JSONDecodeError:
+            out["metadata"] = None
+    return out
 
 
 async def _get_artist_from_warehouse(
-    client: AsyncClient, artist_id: str | None, group_id: str | None
+    conn: asyncpg.Connection, artist_id: str | None, group_id: str | None
 ) -> dict:
     """Fetch canonical artist/group data from warehouse tables."""
     info: dict = {}
     if artist_id:
         try:
-            result = (
-                await client.schema("warehouse")
-                .table("artists")
-                .select("id, name_ko, name_en, profile_image_url, metadata")
-                .eq("id", artist_id)
-                .limit(1)
-                .execute()
+            row = await conn.fetchrow(
+                """
+                SELECT id, name_ko, name_en, profile_image_url, metadata
+                  FROM warehouse.artists
+                 WHERE id = $1::uuid
+                 LIMIT 1
+                """,
+                artist_id,
             )
-            if result.data:
-                info["artist"] = result.data[0]
+            converted = _row_to_dict(row)
+            if converted:
+                info["artist"] = converted
         except Exception:
             logger.debug("warehouse artist lookup failed for %s", artist_id, exc_info=True)
 
     if group_id:
         try:
-            result = (
-                await client.schema("warehouse")
-                .table("groups")
-                .select("id, name_ko, name_en, profile_image_url, metadata")
-                .eq("id", group_id)
-                .limit(1)
-                .execute()
+            row = await conn.fetchrow(
+                """
+                SELECT id, name_ko, name_en, profile_image_url, metadata
+                  FROM warehouse.groups
+                 WHERE id = $1::uuid
+                 LIMIT 1
+                """,
+                group_id,
             )
-            if result.data:
-                info["group"] = result.data[0]
+            converted = _row_to_dict(row)
+            if converted:
+                info["group"] = converted
         except Exception:
             logger.debug("warehouse group lookup failed for %s", group_id, exc_info=True)
 
@@ -74,7 +116,7 @@ async def _get_artist_from_warehouse(
 
 
 async def _query_similar_posts(
-    client: AsyncClient,
+    conn: asyncpg.Connection,
     post_id: str,
     artist_id: str | None,
     group_id: str | None,
@@ -84,43 +126,41 @@ async def _query_similar_posts(
     """Find similar posts — prefer FK-based matching, fallback to ilike."""
     # FK-based matching (preferred)
     if artist_id or group_id:
-        conditions = []
-        if artist_id:
-            conditions.append(f"artist_id.eq.{artist_id}")
-        if group_id:
-            conditions.append(f"group_id.eq.{group_id}")
-        or_filter = ",".join(conditions)
-        result = (
-            await client.table("posts")
-            .select("id, image_url, artist_name, group_name, title")
-            .or_(or_filter)
-            .neq("id", post_id)
-            .eq("status", "active")
-            .limit(20)
-            .execute()
+        rows = await conn.fetch(
+            """
+            SELECT id, image_url, artist_name, group_name, title
+              FROM public.posts
+             WHERE (($1::uuid IS NOT NULL AND artist_id = $1::uuid)
+                    OR ($2::uuid IS NOT NULL AND group_id = $2::uuid))
+               AND id <> $3::uuid
+               AND status = 'active'
+             LIMIT 20
+            """,
+            artist_id,
+            group_id,
+            post_id,
         )
-        if result.data:
-            return result.data
+        if rows:
+            return [{**r, "id": str(r["id"])} for r in (dict(row) for row in rows)]
 
     # Fallback: string-based matching
-    conditions = []
-    if artist_name:
-        conditions.append(f"artist_name.ilike.%{artist_name}%")
-    if group_name:
-        conditions.append(f"group_name.ilike.%{group_name}%")
-    if not conditions:
+    if not (artist_name or group_name):
         return []
-    or_filter = ",".join(conditions)
-    result = (
-        await client.table("posts")
-        .select("id, image_url, artist_name, group_name, title")
-        .or_(or_filter)
-        .neq("id", post_id)
-        .eq("status", "active")
-        .limit(20)
-        .execute()
+    rows = await conn.fetch(
+        """
+        SELECT id, image_url, artist_name, group_name, title
+          FROM public.posts
+         WHERE (($1::text IS NOT NULL AND artist_name ILIKE '%' || $1::text || '%')
+                OR ($2::text IS NOT NULL AND group_name ILIKE '%' || $2::text || '%'))
+           AND id <> $3::uuid
+           AND status = 'active'
+         LIMIT 20
+        """,
+        artist_name,
+        group_name,
+        post_id,
     )
-    return result.data or []
+    return [{**r, "id": str(r["id"])} for r in (dict(row) for row in rows)]
 
 
 def _build_celeb_ranking_prompt(
@@ -157,29 +197,34 @@ async def _rank_celebs(client: genai.Client, prompt: str, model: str) -> CelebRa
     return CelebRankingOutput.model_validate_json(raw_text)
 
 
-async def celeb_search_node(state: PostEditorialState) -> dict:
+async def celeb_search_node(state: PostEditorialState, config: Any = None) -> dict:
     """Query DB for similar celebs and AI-rank them."""
     existing = state.get("celeb_list")
     if existing:
         return {}
 
+    database_manager = _get_database_manager(config)
+    if database_manager is None:
+        logger.warning("celeb_search_node: database_manager not available; skipping")
+        return {"celeb_list": []}
+
     try:
         post_data = state["post_data"]
-        sb_client = await _get_supabase_client()
 
-        # Fetch warehouse artist/group data
-        warehouse_info = await _get_artist_from_warehouse(
-            sb_client, post_data.artist_id, post_data.group_id
-        )
+        async with database_manager.acquire() as conn:
+            # Fetch warehouse artist/group data
+            warehouse_info = await _get_artist_from_warehouse(
+                conn, post_data.artist_id, post_data.group_id
+            )
 
-        similar_posts = await _query_similar_posts(
-            sb_client,
-            post_data.id,
-            post_data.artist_id,
-            post_data.group_id,
-            post_data.artist_name,
-            post_data.group_name,
-        )
+            similar_posts = await _query_similar_posts(
+                conn,
+                post_data.id,
+                post_data.artist_id,
+                post_data.group_id,
+                post_data.artist_name,
+                post_data.group_name,
+            )
 
         if not similar_posts:
             return {"celeb_list": []}

--- a/packages/ai-server/src/post_editorial/nodes/item_research.py
+++ b/packages/ai-server/src/post_editorial/nodes/item_research.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from typing import Any
 
+import asyncpg
 import httpx
-from supabase import AsyncClient, acreate_client
+
+from src.managers.database import DatabaseManager
 
 from ..state import PostEditorialState
 from ..config import get_settings
@@ -13,24 +17,65 @@ from ..config import get_settings
 logger = logging.getLogger(__name__)
 
 
-async def _get_supabase_client() -> AsyncClient:
-    settings = get_settings()
-    return await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
+def _get_database_manager(config: Any) -> DatabaseManager | None:
+    """Fetch DatabaseManager from LangGraph config or DI fallback.
+
+    Mirrors `_get_metadata_extract_service` pattern so nodes stay
+    orchestration-agnostic.
+    """
+    configurable: dict = {}
+    if config is not None:
+        configurable = (
+            getattr(config, "configurable", {})
+            if hasattr(config, "configurable")
+            else config.get("configurable", {})
+            if isinstance(config, dict)
+            else {}
+        )
+    svc = configurable.get("database_manager")
+    if svc is not None:
+        return svc
+    try:
+        from src.config._container import Application
+
+        app = Application()
+        return app.infrastructure().database_manager()
+    except Exception:
+        logger.debug("DatabaseManager unavailable — warehouse enrichment will be skipped")
+        return None
 
 
-async def _fetch_warehouse_brands(client: AsyncClient, brand_ids: list[str]) -> dict[str, dict]:
+async def _fetch_warehouse_brands(
+    conn: asyncpg.Connection, brand_ids: list[str]
+) -> dict[str, dict]:
     """Batch-fetch brand data from warehouse.brands by IDs."""
     if not brand_ids:
         return {}
     try:
-        result = (
-            await client.schema("warehouse")
-            .table("brands")
-            .select("id, name_ko, name_en, logo_image_url, metadata")
-            .in_("id", brand_ids)
-            .execute()
+        rows = await conn.fetch(
+            """
+            SELECT id, name_ko, name_en, logo_image_url, metadata
+              FROM warehouse.brands
+             WHERE id = ANY($1::uuid[])
+            """,
+            brand_ids,
         )
-        return {b["id"]: b for b in (result.data or [])}
+        result: dict[str, dict] = {}
+        for row in rows:
+            metadata = row["metadata"]
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = None
+            result[str(row["id"])] = {
+                "id": str(row["id"]),
+                "name_ko": row["name_ko"],
+                "name_en": row["name_en"],
+                "logo_image_url": row["logo_image_url"],
+                "metadata": metadata,
+            }
+        return result
     except Exception:
         logger.debug("warehouse brands lookup failed", exc_info=True)
         return {}
@@ -192,19 +237,20 @@ def _extract_artist_brand_context(raw_content: str, state: PostEditorialState) -
     return " ".join(relevant[:5])
 
 
-async def item_research_node(state: PostEditorialState) -> dict:
+async def item_research_node(state: PostEditorialState, config: Any = None) -> dict:
     """Research item backstories via Perplexity Sonar, enriched with warehouse brand data."""
     try:
         post_data = state["post_data"]
+        database_manager = _get_database_manager(config)
 
         # Collect distinct brand_ids and fetch from warehouse
         brand_ids = list(
             {sol.brand_id for spot in post_data.spots for sol in spot.solutions if sol.brand_id}
         )
         warehouse_brands: dict[str, dict] = {}
-        if brand_ids:
-            sb_client = await _get_supabase_client()
-            warehouse_brands = await _fetch_warehouse_brands(sb_client, brand_ids)
+        if brand_ids and database_manager is not None:
+            async with database_manager.acquire() as conn:
+                warehouse_brands = await _fetch_warehouse_brands(conn, brand_ids)
 
         query = _build_research_query(state, warehouse_brands)
         raw_content, source_urls = await _perplexity_search_async(query)

--- a/packages/ai-server/src/post_editorial/nodes/item_search.py
+++ b/packages/ai-server/src/post_editorial/nodes/item_search.py
@@ -6,11 +6,13 @@ import json
 import logging
 from typing import Any
 
+import asyncpg
 import httpx
 from google import genai
 from google.genai import types
 from pydantic import BaseModel
-from supabase import AsyncClient, acreate_client
+
+from src.managers.database import DatabaseManager
 
 from ..state import PostEditorialState
 from ..config import get_settings
@@ -64,7 +66,7 @@ def _extract_brands(state: PostEditorialState) -> list[str]:
 
 
 async def _query_internal_items(
-    client: AsyncClient,
+    conn: asyncpg.Connection,
     brands: list[str],
     current_solution_ids: set[str],
 ) -> list[dict]:
@@ -72,18 +74,36 @@ async def _query_internal_items(
         return []
     all_results = []
     for brand in brands[:5]:
-        result = (
-            await client.table("solutions")
-            .select("id, title, thumbnail_url, original_url, metadata")
-            .ilike("metadata->>brand", f"%{brand}%")
-            .limit(10)
-            .execute()
+        pattern = f"%{brand}%"
+        rows = await conn.fetch(
+            """
+            SELECT id, title, thumbnail_url, original_url, metadata
+              FROM public.solutions
+             WHERE metadata->>'brand' ILIKE $1
+             LIMIT 10
+            """,
+            pattern,
         )
-        for row in result.data or []:
-            if row["id"] not in current_solution_ids:
-                all_results.append(row)
-    seen_ids = set()
-    deduped = []
+        for row in rows:
+            row_id = str(row["id"])
+            if row_id not in current_solution_ids:
+                metadata = row["metadata"]
+                if isinstance(metadata, str):
+                    try:
+                        metadata = json.loads(metadata)
+                    except json.JSONDecodeError:
+                        metadata = None
+                all_results.append(
+                    {
+                        "id": row_id,
+                        "title": row["title"],
+                        "thumbnail_url": row["thumbnail_url"],
+                        "original_url": row["original_url"],
+                        "metadata": metadata,
+                    }
+                )
+    seen_ids: set[str] = set()
+    deduped: list[dict] = []
     for r in all_results:
         if r["id"] not in seen_ids:
             seen_ids.add(r["id"])
@@ -243,6 +263,30 @@ def _get_metadata_extract_service(config: Any) -> Any:
         return None
 
 
+def _get_database_manager(config: Any) -> DatabaseManager | None:
+    """Get DatabaseManager from LangGraph config or DI fallback."""
+    configurable: dict = {}
+    if config is not None:
+        configurable = (
+            getattr(config, "configurable", {})
+            if hasattr(config, "configurable")
+            else config.get("configurable", {})
+            if isinstance(config, dict)
+            else {}
+        )
+    svc = configurable.get("database_manager")
+    if svc is not None:
+        return svc
+    try:
+        from src.config._container import Application
+
+        app = Application()
+        return app.infrastructure().database_manager()
+    except Exception:
+        logger.debug("DatabaseManager unavailable — internal item search will skip")
+        return None
+
+
 async def item_search_node(state: PostEditorialState, config: Any = None) -> dict:
     """Find related items via internal DB + Perplexity + decoded-ai OG."""
     existing = state.get("related_items")
@@ -254,6 +298,7 @@ async def item_search_node(state: PostEditorialState, config: Any = None) -> dic
         return {"related_items": []}
 
     metadata_extract_service = _get_metadata_extract_service(config)
+    database_manager = _get_database_manager(config)
 
     try:
         items = _extract_items_from_post(state)
@@ -266,10 +311,10 @@ async def item_search_node(state: PostEditorialState, config: Any = None) -> dic
             if sol.original_url
         }
 
-        settings = get_settings()
-        sb_client = await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
-
-        internal_results = await _query_internal_items(sb_client, brands, current_sol_ids)
+        internal_results: list[dict] = []
+        if database_manager is not None:
+            async with database_manager.acquire() as conn:
+                internal_results = await _query_internal_items(conn, brands, current_sol_ids)
         internal_candidates = [
             {
                 "title": r.get("title", ""),
@@ -297,6 +342,7 @@ async def item_search_node(state: PostEditorialState, config: Any = None) -> dic
         if not deduped:
             return {"related_items": []}
 
+        settings = get_settings()
         genai_client = genai.Client(api_key=settings.gemini_api_key)
         artist_info = (
             " / ".join(filter(None, [post_data.artist_name, post_data.group_name])) or "Unknown"

--- a/packages/ai-server/src/post_editorial/nodes/publish.py
+++ b/packages/ai-server/src/post_editorial/nodes/publish.py
@@ -5,42 +5,111 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
-from supabase import AsyncClient, acreate_client
+import asyncpg
+
+from src.managers.database import DatabaseManager
 
 from ..models import PostMagazineLayout
 from ..state import PostEditorialState
-from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 
 
-async def _get_supabase_client() -> AsyncClient:
-    settings = get_settings()
-    return await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
+def _get_database_manager(config: Any) -> DatabaseManager | None:
+    """Fetch DatabaseManager from LangGraph config or DI fallback."""
+    configurable: dict = {}
+    if config is not None:
+        configurable = (
+            getattr(config, "configurable", {})
+            if hasattr(config, "configurable")
+            else config.get("configurable", {})
+            if isinstance(config, dict)
+            else {}
+        )
+    svc = configurable.get("database_manager")
+    if svc is not None:
+        return svc
+    try:
+        from src.config._container import Application
+
+        app = Application()
+        return app.infrastructure().database_manager()
+    except Exception:
+        logger.warning(
+            "DatabaseManager unavailable — publish_node cannot persist results"
+        )
+        return None
 
 
-async def _fetch_warehouse_brands(client: AsyncClient, brand_ids: list[str]) -> dict[str, dict]:
+async def _fetch_warehouse_brands(
+    conn: asyncpg.Connection, brand_ids: list[str]
+) -> dict[str, dict]:
     """Batch-fetch brand data from warehouse.brands by IDs."""
     if not brand_ids:
         return {}
     try:
-        result = (
-            await client.schema("warehouse")
-            .table("brands")
-            .select("id, name_ko, name_en, logo_image_url, metadata")
-            .in_("id", brand_ids)
-            .execute()
+        rows = await conn.fetch(
+            """
+            SELECT id, name_ko, name_en, logo_image_url, metadata
+              FROM warehouse.brands
+             WHERE id = ANY($1::uuid[])
+            """,
+            brand_ids,
         )
-        return {b["id"]: b for b in (result.data or [])}
+        result: dict[str, dict] = {}
+        for row in rows:
+            metadata = row["metadata"]
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError:
+                    metadata = None
+            result[str(row["id"])] = {
+                "id": str(row["id"]),
+                "name_ko": row["name_ko"],
+                "name_en": row["name_en"],
+                "logo_image_url": row["logo_image_url"],
+                "metadata": metadata,
+            }
+        return result
     except Exception:
         logger.debug("warehouse brands lookup failed in publish", exc_info=True)
         return {}
 
 
-async def publish_node(state: PostEditorialState) -> dict:
+async def _mark_magazine_failed(
+    conn: asyncpg.Connection, post_magazine_id: str, error_msg: str
+) -> None:
+    try:
+        await conn.execute(
+            """
+            UPDATE public.post_magazines
+               SET status = 'failed',
+                   error_log = $1::jsonb,
+                   updated_at = $2
+             WHERE id = $3::uuid
+            """,
+            json.dumps([error_msg]),
+            datetime.now(timezone.utc),
+            post_magazine_id,
+        )
+    except Exception:
+        logger.exception("Failed to update magazine status to failed")
+
+
+async def publish_node(state: PostEditorialState, config: Any = None) -> dict:
     """Assemble PostMagazineLayout and save to post_magazines table."""
     post_magazine_id = state["post_magazine_id"]
+
+    database_manager = _get_database_manager(config)
+    if database_manager is None:
+        logger.error("publish_node: DatabaseManager unavailable")
+        return {
+            "pipeline_status": "failed",
+            "error_log": ["Publish failed: DatabaseManager unavailable"],
+        }
 
     try:
         post_data = state["post_data"]
@@ -48,135 +117,145 @@ async def publish_node(state: PostEditorialState) -> dict:
         editorial_section = state.get("editorial_section") or {"paragraphs": []}
         item_editorial_texts = state.get("item_editorial_texts") or {}
 
-        client = await _get_supabase_client()
-
-        # Batch-fetch warehouse brands for enrichment
+        # Batch-fetch warehouse brands for enrichment (fall back to item_research result)
         brand_ids = list(
             {sol.brand_id for spot in post_data.spots for sol in spot.solutions if sol.brand_id}
         )
-
-        # Try to reuse warehouse_brands from item_research if available
         item_research = state.get("item_research") or {}
         warehouse_brands = item_research.get("warehouse_brands") or {}
-        if brand_ids and not warehouse_brands:
-            warehouse_brands = await _fetch_warehouse_brands(client, brand_ids)
 
-        items = []
-        for spot in post_data.spots:
-            for sol in spot.solutions:
-                brand = None
-                brand_logo_url = None
-                metadata = sol.metadata or {}
+        async with database_manager.acquire() as conn:
+            if brand_ids and not warehouse_brands:
+                warehouse_brands = await _fetch_warehouse_brands(conn, brand_ids)
 
-                if isinstance(metadata, dict):
-                    brand = metadata.get("brand")
+            items = []
+            for spot in post_data.spots:
+                for sol in spot.solutions:
+                    brand = None
+                    brand_logo_url = None
+                    metadata = sol.metadata or {}
 
-                # Enrich with warehouse brand data
-                if sol.brand_id and sol.brand_id in warehouse_brands:
-                    wb = warehouse_brands[sol.brand_id]
-                    brand = wb.get("name_en") or wb.get("name_ko") or brand
-                    brand_logo_url = wb.get("logo_image_url")
-                    # Merge warehouse brand metadata
-                    if wb.get("metadata") and isinstance(wb["metadata"], dict):
-                        enriched_meta = dict(metadata) if isinstance(metadata, dict) else {}
-                        for k, v in wb["metadata"].items():
-                            if v and k not in enriched_meta:
-                                enriched_meta[k] = v
-                        metadata = enriched_meta
+                    if isinstance(metadata, dict):
+                        brand = metadata.get("brand")
 
-                items.append(
-                    {
-                        "spot_id": spot.id,
-                        "solution_id": sol.id,
-                        "title": sol.title,
-                        "brand": brand,
-                        "brand_logo_url": brand_logo_url,
-                        "image_url": sol.thumbnail_url,
-                        "original_url": sol.original_url,
-                        "metadata": metadata,
-                        "editorial_paragraphs": item_editorial_texts.get(spot.id, []),
-                    }
-                )
+                    # Enrich with warehouse brand data
+                    if sol.brand_id and sol.brand_id in warehouse_brands:
+                        wb = warehouse_brands[sol.brand_id]
+                        brand = wb.get("name_en") or wb.get("name_ko") or brand
+                        brand_logo_url = wb.get("logo_image_url")
+                        if wb.get("metadata") and isinstance(wb["metadata"], dict):
+                            enriched_meta = dict(metadata) if isinstance(metadata, dict) else {}
+                            for k, v in wb["metadata"].items():
+                                if v and k not in enriched_meta:
+                                    enriched_meta[k] = v
+                            metadata = enriched_meta
 
-        news_references = state.get("news_references") or []
+                    items.append(
+                        {
+                            "spot_id": spot.id,
+                            "solution_id": sol.id,
+                            "title": sol.title,
+                            "brand": brand,
+                            "brand_logo_url": brand_logo_url,
+                            "image_url": sol.thumbnail_url,
+                            "original_url": sol.original_url,
+                            "metadata": metadata,
+                            "editorial_paragraphs": item_editorial_texts.get(spot.id, []),
+                        }
+                    )
 
-        layout = PostMagazineLayout(
-            title=state.get("title", "Untitled"),
-            subtitle=state.get("subtitle"),
-            editorial=editorial_section,
-            celeb_list=state.get("celeb_list", []),
-            items=items,
-            related_items=state.get("related_items", []),
-            news_references=news_references,
-            design_spec=design_spec,
-        )
-        layout_dict = layout.model_dump()
-
-        now = datetime.now(timezone.utc).isoformat()
-        review_result = state.get("review_result") or {}
-
-        # Build keyword from artist/group name
-        keyword_parts = list(filter(None, [post_data.artist_name, post_data.group_name]))
-        keyword = ", ".join(keyword_parts) if keyword_parts else None
-
-        await (
-            client.table("post_magazines")
-            .update(
-                {
-                    "title": layout.title,
-                    "subtitle": layout.subtitle,
-                    "keyword": keyword,
-                    "layout_json": layout_dict,
-                    "status": "published",
-                    "review_summary": review_result.get("summary"),
-                    "published_at": now,
-                    "updated_at": now,
-                }
+            news_references = state.get("news_references") or []
+            layout = PostMagazineLayout(
+                title=state.get("title", "Untitled"),
+                subtitle=state.get("subtitle"),
+                editorial=editorial_section,
+                celeb_list=state.get("celeb_list", []),
+                items=items,
+                related_items=state.get("related_items", []),
+                news_references=news_references,
+                design_spec=design_spec,
             )
-            .eq("id", post_magazine_id)
-            .execute()
-        )
+            layout_dict = layout.model_dump()
 
-        # Save news references to dedicated table
-        if news_references:
-            for ref in news_references:
-                try:
-                    await (
-                        client.table("post_magazine_news_references")
-                        .insert(
-                            {
-                                "post_magazine_id": post_magazine_id,
-                                "title": ref.get("title", ""),
-                                "url": ref.get("url", ""),
-                                "source": ref.get("source", ""),
-                                "summary": ref.get("summary"),
-                                "og_title": ref.get("og_title"),
-                                "og_description": ref.get("og_description"),
-                                "og_image": ref.get("og_image"),
-                                "og_site_name": ref.get("og_site_name"),
-                                "relevance_score": ref.get("relevance_score", 0),
-                                "credibility_score": ref.get("credibility_score", 0),
-                                "matched_item": ref.get("matched_item"),
-                            }
+            now = datetime.now(timezone.utc)
+            review_result = state.get("review_result") or {}
+            keyword_parts = list(filter(None, [post_data.artist_name, post_data.group_name]))
+            keyword = ", ".join(keyword_parts) if keyword_parts else None
+
+            await conn.execute(
+                """
+                UPDATE public.post_magazines
+                   SET title = $1,
+                       subtitle = $2,
+                       keyword = $3,
+                       layout_json = $4::jsonb,
+                       status = 'published',
+                       review_summary = $5,
+                       published_at = $6,
+                       updated_at = $7
+                 WHERE id = $8::uuid
+                """,
+                layout.title,
+                layout.subtitle,
+                keyword,
+                json.dumps(layout_dict, default=str),
+                review_result.get("summary"),
+                now,
+                now,
+                post_magazine_id,
+            )
+
+            if news_references:
+                for ref in news_references:
+                    try:
+                        await conn.execute(
+                            """
+                            INSERT INTO public.post_magazine_news_references (
+                                post_magazine_id, title, url, source, summary,
+                                og_title, og_description, og_image, og_site_name,
+                                relevance_score, credibility_score, matched_item
+                            ) VALUES (
+                                $1::uuid, $2, $3, $4, $5,
+                                $6, $7, $8, $9,
+                                $10, $11, $12
+                            )
+                            """,
+                            post_magazine_id,
+                            ref.get("title", ""),
+                            ref.get("url", ""),
+                            ref.get("source", ""),
+                            ref.get("summary"),
+                            ref.get("og_title"),
+                            ref.get("og_description"),
+                            ref.get("og_image"),
+                            ref.get("og_site_name"),
+                            ref.get("relevance_score", 0),
+                            ref.get("credibility_score", 0),
+                            ref.get("matched_item"),
                         )
-                        .execute()
+                    except Exception:
+                        logger.warning(
+                            "Failed to save news reference: %s",
+                            ref.get("url"),
+                            exc_info=True,
+                        )
+
+            ai_summary = state.get("ai_summary")
+            if ai_summary:
+                try:
+                    await conn.execute(
+                        """
+                        UPDATE public.posts
+                           SET ai_summary = $1
+                         WHERE id = $2::uuid
+                        """,
+                        ai_summary,
+                        post_data.id,
                     )
                 except Exception:
                     logger.warning(
-                        "Failed to save news reference: %s", ref.get("url"), exc_info=True
+                        "Failed to save ai_summary to post %s", post_data.id, exc_info=True
                     )
-
-        ai_summary = state.get("ai_summary")
-        if ai_summary:
-            try:
-                await (
-                    client.table("posts")
-                    .update({"ai_summary": ai_summary})
-                    .eq("id", post_data.id)
-                    .execute()
-                )
-            except Exception:
-                logger.warning("Failed to save ai_summary to post %s", post_data.id, exc_info=True)
 
         return {"pipeline_status": "published"}
 
@@ -184,19 +263,8 @@ async def publish_node(state: PostEditorialState) -> dict:
         logger.exception("publish_node failed")
         error_msg = f"Publish failed: {type(e).__name__}: {e!s}"
         try:
-            client = await _get_supabase_client()
-            await (
-                client.table("post_magazines")
-                .update(
-                    {
-                        "status": "failed",
-                        "error_log": json.dumps([error_msg]),
-                        "updated_at": datetime.now(timezone.utc).isoformat(),
-                    }
-                )
-                .eq("id", post_magazine_id)
-                .execute()
-            )
+            async with database_manager.acquire() as conn:
+                await _mark_magazine_failed(conn, post_magazine_id, error_msg)
         except Exception:
-            logger.exception("Failed to update magazine status to failed")
+            logger.exception("Failed to mark magazine as failed")
         return {"pipeline_status": "failed", "error_log": [error_msg]}

--- a/packages/ai-server/src/services/post_context/post_context_service.py
+++ b/packages/ai-server/src/services/post_context/post_context_service.py
@@ -116,25 +116,26 @@ class PostContextService:
         return result
 
     async def extract_and_update(
-        self, post_id: str, image_url: str, supabase_url: str, supabase_key: str
+        self,
+        post_id: str,
+        image_url: str,
+        database_manager,
     ) -> dict:
-        """이미지 분석 후 Supabase posts 테이블 업데이트."""
-        from supabase import acreate_client
-
+        """이미지 분석 후 posts 테이블 업데이트 (asyncpg)."""
         result = await self.extract_context(image_url)
 
-        client = await acreate_client(supabase_url, supabase_key)
-        await (
-            client.table("posts")
-            .update(
-                {
-                    "context": result["context"],
-                    "style_tags": json.dumps(result["style_tags"]),
-                }
+        async with database_manager.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE public.posts
+                   SET context = $1,
+                       style_tags = $2::jsonb
+                 WHERE id = $3::uuid
+                """,
+                result["context"],
+                json.dumps(result["style_tags"]),
+                post_id,
             )
-            .eq("id", post_id)
-            .execute()
-        )
 
         logger.info(
             "Post %s context updated: %s, style_tags: %s",

--- a/packages/ai-server/src/services/post_editorial/post_editorial_service.py
+++ b/packages/ai-server/src/services/post_editorial/post_editorial_service.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict
 
+from src.managers.database import DatabaseManager
 from src.post_editorial.state import PostData
-from src.post_editorial.config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,8 @@ class PostEditorialService:
         Returns:
             Dict with pipeline_status and any error info
         """
+        database_manager: DatabaseManager | None = ctx.get("database_manager")
+
         try:
             post_data = PostData.model_validate_json(post_data_json)
         except Exception as e:
@@ -41,10 +44,11 @@ class PostEditorialService:
                 e,
                 post_data_json[:500] if post_data_json else "(empty)",
             )
-            await _mark_magazine_failed(post_magazine_id, f"Invalid post_data: {e!s}")
+            await _mark_magazine_failed(database_manager, post_magazine_id, f"Invalid post_data: {e!s}")
             return {"success": False, "error": str(e)}
 
         metadata_extract_service = ctx.get("metadata_extract_service")
+        database_manager = ctx.get("database_manager")
         from src.post_editorial.graph import create_post_editorial_graph
 
         graph = create_post_editorial_graph()
@@ -69,6 +73,8 @@ class PostEditorialService:
         config = {"configurable": {}}
         if metadata_extract_service:
             config["configurable"]["metadata_extract_service"] = metadata_extract_service
+        if database_manager:
+            config["configurable"]["database_manager"] = database_manager
 
         import uuid
 
@@ -84,7 +90,7 @@ class PostEditorialService:
 
             if final_status == "failed":
                 error_log = result.get("error_log", [])
-                await _mark_magazine_failed(post_magazine_id, "; ".join(str(x) for x in error_log))
+                await _mark_magazine_failed(database_manager, post_magazine_id, "; ".join(str(x) for x in error_log))
 
             return {
                 "success": final_status in ("published", "reviewed"),
@@ -94,28 +100,35 @@ class PostEditorialService:
         except Exception as e:
             logger.exception("Post editorial pipeline failed for %s", post_magazine_id)
             await _mark_magazine_failed(
-                post_magazine_id, f"Pipeline crash: {type(e).__name__}: {e!s}"
+                database_manager,
+                post_magazine_id,
+                f"Pipeline crash: {type(e).__name__}: {e!s}",
             )
             return {"success": False, "error": str(e)}
 
 
-async def _mark_magazine_failed(post_magazine_id: str, error_msg: str) -> None:
-    """Update post_magazines table with failed status."""
+async def _mark_magazine_failed(
+    database_manager: DatabaseManager | None,
+    post_magazine_id: str,
+    error_msg: str,
+) -> None:
+    """Update post_magazines.status = failed via asyncpg pool."""
+    if database_manager is None:
+        logger.warning("_mark_magazine_failed: no DatabaseManager — skip")
+        return
     try:
-        from supabase import acreate_client
-
-        settings = get_settings()
-        client = await acreate_client(settings.supabase_url, settings.supabase_service_role_key)
-        await (
-            client.table("post_magazines")
-            .update(
-                {
-                    "status": "failed",
-                    "error_log": json.dumps([error_msg]),
-                }
+        async with database_manager.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE public.post_magazines
+                   SET status = 'failed',
+                       error_log = $1::jsonb,
+                       updated_at = $2
+                 WHERE id = $3::uuid
+                """,
+                json.dumps([error_msg]),
+                datetime.now(timezone.utc),
+                post_magazine_id,
             )
-            .eq("id", post_magazine_id)
-            .execute()
-        )
     except Exception:
         logger.exception("Failed to update magazine status after failure")

--- a/packages/ai-server/uv.lock
+++ b/packages/ai-server/uv.lock
@@ -81,6 +81,38 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/17/cc02bc49bc350623d050fa139e34ea512cd6e020562f2a7312a7bcae4bc9/asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d", size = 643159, upload-time = "2025-11-24T23:25:36.443Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/62/4ded7d400a7b651adf06f49ea8f73100cca07c6df012119594d1e3447aa6/asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab", size = 638157, upload-time = "2025-11-24T23:25:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/4179538a9a72166a0bf60ad783b1ef16efb7960e4d7b9afe9f77a5551680/asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c", size = 2918051, upload-time = "2025-11-24T23:25:39.461Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/35/c27719ae0536c5b6e61e4701391ffe435ef59539e9360959240d6e47c8c8/asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109", size = 2972640, upload-time = "2025-11-24T23:25:41.512Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f4/01ebb9207f29e645a64699b9ce0eefeff8e7a33494e1d29bb53736f7766b/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da", size = 2851050, upload-time = "2025-11-24T23:25:43.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f4/03ff1426acc87be0f4e8d40fa2bff5c3952bef0080062af9efc2212e3be8/asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9", size = 2962574, upload-time = "2025-11-24T23:25:44.942Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/39/cc788dfca3d4060f9d93e67be396ceec458dfc429e26139059e58c2c244d/asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24", size = 521076, upload-time = "2025-11-24T23:25:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fc/735af5384c029eb7f1ca60ccb8fa95521dbdaeef788edf4cecfc604c3cab/asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047", size = 584980, upload-time = "2025-11-24T23:25:47.938Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -392,6 +424,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },
     { name = "arq" },
+    { name = "asyncpg" },
     { name = "beautifulsoup4" },
     { name = "bson" },
     { name = "dependency-injector" },
@@ -440,6 +473,7 @@ dev = [
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.10.0,<4.0.0" },
     { name = "arq", specifier = ">=0.26.0,<0.27.0" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "beautifulsoup4", specifier = ">=4.13.3,<5.0.0" },
     { name = "bson", specifier = ">=0.5.10,<0.6.0" },
     { name = "dependency-injector", specifier = ">=4.46.0,<5.0.0" },


### PR DESCRIPTION
## Summary

Epic #270 의 **PR-2**. ai-server 의 DB 접근을 `supabase-py` (HTTP REST) 에서 `asyncpg` (Postgres 직접 TCP) 로 이관. `SUPABASE_URL` 의존 제거, `DATABASE_URL` 하나로 로컬/prod 투명 전환.

Closes #266 (Epic #270)

## 변경 사항

### 신규 인프라
- `src/managers/database/` — `DatabaseManager` asyncpg pool (min/max env 제어)
- `InfrastructureContainer.database_manager` Singleton
- `pyproject.toml` — `asyncpg>=0.29`
- env: `DATABASE_URL`, `DATABASE_POOL_MIN=1`, `DATABASE_POOL_MAX=5`

### 노드/서비스 이관 (7개 파일)
- **노드**: `item_research`, `item_search`, `celeb_search`, `publish`
  - 모두 `config.configurable["database_manager"]` 또는 DI fallback 으로 주입
  - raw SQL + asyncpg (type-safe, schema-qualified)
- **서비스**: `post_editorial_service::_mark_magazine_failed`, `post_context_service::extract_and_update`

### 인프라
- `worker.py` — ARQ ctx 에 `database_manager` 주입
- `main.py` — 종료 시 pool close

## 쿼리 패턴 예시

```python
# Before
sb = await acreate_client(url, key)
r = await sb.schema("warehouse").table("brands").select("*").in_("id", brand_ids).execute()
brands = r.data

# After
async with database_manager.acquire() as conn:
    rows = await conn.fetch(
        "SELECT * FROM warehouse.brands WHERE id = ANY($1::uuid[])",
        brand_ids,
    )
```

## 검증

- ✅ `grep -rn "acreate_client\|from supabase import" src/` → **0건**
- ✅ `uv run flake8` — clean
- ✅ DI 컨테이너 + post_editorial graph compile OK
- ⚠️ Pre-existing pytest failures (batch_processor, data_classifier 등) 는 이 변경과 무관

## Prod 영향

- **스키마 변경 없음**
- `DATABASE_URL` 은 `.env.backend.prod` 에 이미 있음 (Supabase pooler)
- asyncpg pool `max_size=5` 로 Supabase pooler 한도 내 제한
- 연결 경로만 HTTP REST → 직접 TCP 로 변경

## Test plan

- [ ] Post editorial 파이프라인 실행 (ARQ enqueue → 완주)
- [ ] warehouse brand enrichment 정상 (item_research)
- [ ] celeb_search similar posts 결과 정상
- [ ] publish_node 가 post_magazines/news_references/posts 3 테이블에 정상 기록
- [ ] ExtractPostContext gRPC 호출 후 posts.context/style_tags 업데이트

## 연관

- Epic #270
- Next: PR-3 (#267) auth.users FK 이관 + RLS stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)