### PR TITLE
feat(api): decouple public tables from auth.users FK (#267)

### DIFF
--- a/packages/api-server/migration/src/lib.rs
+++ b/packages/api-server/migration/src/lib.rs
@@ -51,6 +51,8 @@ mod m20260406_000002_add_style_tags_to_posts;
 mod m20260407_000001_create_post_magazine_news_references;
 mod m20260409_add_image_dimensions;
 mod m20260412_000001_add_posts_performance_indexes;
+mod m20260501_000001_decouple_auth_users_fk;
+mod m20260501_000002_auth_uid_stub;
 
 pub struct Migrator;
 
@@ -109,6 +111,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260407_000001_create_post_magazine_news_references::Migration),
             Box::new(m20260409_add_image_dimensions::Migration),
             Box::new(m20260412_000001_add_posts_performance_indexes::Migration),
+            Box::new(m20260501_000002_auth_uid_stub::Migration),
+            Box::new(m20260501_000001_decouple_auth_users_fk::Migration),
         ]
     }
 }

--- a/packages/api-server/migration/src/lib.rs
+++ b/packages/api-server/migration/src/lib.rs
@@ -1,5 +1,6 @@
 pub use sea_orm_migration::prelude::*;
 
+mod m20230101_000000_local_auth_stub;
 mod m20240101_000001_create_users;
 mod m20240101_000002_create_categories;
 mod m20240101_000003_create_posts;
@@ -60,6 +61,8 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
+            // Ensure auth.users stub exists before any FK references it (#267).
+            Box::new(m20230101_000000_local_auth_stub::Migration),
             Box::new(m20240101_000001_create_users::Migration),
             Box::new(m20240101_000002_create_categories::Migration),
             Box::new(m20240101_000003_create_posts::Migration),

--- a/packages/api-server/migration/src/m20230101_000000_local_auth_stub.rs
+++ b/packages/api-server/migration/src/m20230101_000000_local_auth_stub.rs
@@ -1,0 +1,51 @@
+use sea_orm_migration::prelude::*;
+
+/// Ensure `auth.users` exists before any FK migration references it.
+///
+/// Why: `m20240101_000001_create_users` creates a FK `public.users.id → auth.users(id)`.
+/// On prod Supabase `auth.users` is managed by GoTrue and already exists. On local plain
+/// Postgres it doesn't — the FK creation fails.
+///
+/// This migration guarantees a minimal `auth.users` table exists on local so the FK can
+/// be created. Later migrations (this PR's `m20260501_000001_decouple_auth_users_fk`)
+/// drop that FK entirely.
+///
+/// Idempotent + non-destructive on prod:
+/// - `CREATE SCHEMA IF NOT EXISTS auth` → no-op where `auth` exists
+/// - `CREATE TABLE IF NOT EXISTS auth.users` → no-op where it exists (prod has GoTrue-managed
+///   table with many more columns; we never touch it)
+///
+/// Registered at the TOP of `Migrator::migrations()` so on fresh local it runs before the
+/// 2024-dated table migrations. On prod it runs once (after existing migrations complete),
+/// but because the schema+table already exist, it's a no-op.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                CREATE SCHEMA IF NOT EXISTS auth;
+
+                -- Minimal stub — prod's real auth.users has dozens more columns,
+                -- all of which we leave untouched. We only care that `id` exists
+                -- as the FK target for public.users.
+                CREATE TABLE IF NOT EXISTS auth.users (
+                    id uuid PRIMARY KEY
+                );
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Never drop auth schema / auth.users — on prod these belong to GoTrue.
+        let _ = manager;
+        Ok(())
+    }
+}

--- a/packages/api-server/migration/src/m20260501_000001_decouple_auth_users_fk.rs
+++ b/packages/api-server/migration/src/m20260501_000001_decouple_auth_users_fk.rs
@@ -1,0 +1,201 @@
+use sea_orm_migration::prelude::*;
+
+/// Decouple all `auth.users` FKs to `public.users` equivalents.
+///
+/// Why: Path X-1 (#267) requires public schema to stand alone on plain Postgres.
+/// `auth.users` only exists when Supabase GoTrue is running; local dev doesn't have it.
+/// `public.users` is already kept in sync with `auth.users` via the handle_new_user trigger
+/// (see migration/sql/01_auth_trigger_handle_new_user.sql), so `public.users.id` is the
+/// authoritative application-side identity.
+///
+/// Idempotent: every step uses `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` wrapped in
+/// `IF EXISTS` table checks. Prod (where old constraints exist) and fresh local (where
+/// some tables — content_reports, user_follows, user_tryon_history — haven't been created
+/// yet because they still live in migration/sql/*) both converge safely.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        // 1) public.users: drop FK to auth.users(id). public.users is now standalone.
+        //    The handle_new_user trigger continues to insert rows when Supabase auth
+        //    creates users — it is NOT a FK constraint, so removing the FK is safe.
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users') THEN
+                    ALTER TABLE public.users DROP CONSTRAINT IF EXISTS fk_users_auth_users;
+                    ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_id_fkey;
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        // 2) public.post_magazines.approved_by → public.users(id) ON DELETE SET NULL
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'post_magazines')
+                   AND EXISTS (SELECT 1 FROM information_schema.columns
+                               WHERE table_schema = 'public' AND table_name = 'post_magazines'
+                                 AND column_name = 'approved_by') THEN
+                    ALTER TABLE public.post_magazines
+                        DROP CONSTRAINT IF EXISTS post_magazines_approved_by_fkey;
+                    ALTER TABLE public.post_magazines
+                        ADD CONSTRAINT post_magazines_approved_by_fkey
+                        FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        // 3) public.user_follows: follower_id + following_id → public.users(id) CASCADE
+        //    (table comes from migration/sql/04_user_follows.sql — may be absent locally)
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_follows') THEN
+                    ALTER TABLE public.user_follows
+                        DROP CONSTRAINT IF EXISTS user_follows_follower_id_fkey;
+                    ALTER TABLE public.user_follows
+                        ADD CONSTRAINT user_follows_follower_id_fkey
+                        FOREIGN KEY (follower_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+                    ALTER TABLE public.user_follows
+                        DROP CONSTRAINT IF EXISTS user_follows_following_id_fkey;
+                    ALTER TABLE public.user_follows
+                        ADD CONSTRAINT user_follows_following_id_fkey
+                        FOREIGN KEY (following_id) REFERENCES public.users(id) ON DELETE CASCADE;
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        // 4) public.user_tryon_history.user_id → public.users(id) CASCADE
+        //    (table comes from migration/sql/05_user_tryon_history.sql)
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_tryon_history') THEN
+                    ALTER TABLE public.user_tryon_history
+                        DROP CONSTRAINT IF EXISTS user_tryon_history_user_id_fkey;
+                    ALTER TABLE public.user_tryon_history
+                        ADD CONSTRAINT user_tryon_history_user_id_fkey
+                        FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        // 5) public.content_reports.{reporter_id,reviewed_by} → public.users(id)
+        //    (table comes from migration/sql/06_content_reports.sql)
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'content_reports') THEN
+                    ALTER TABLE public.content_reports
+                        DROP CONSTRAINT IF EXISTS content_reports_reporter_id_fkey;
+                    ALTER TABLE public.content_reports
+                        ADD CONSTRAINT content_reports_reporter_id_fkey
+                        FOREIGN KEY (reporter_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+                    ALTER TABLE public.content_reports
+                        DROP CONSTRAINT IF EXISTS content_reports_reviewed_by_fkey;
+                    ALTER TABLE public.content_reports
+                        ADD CONSTRAINT content_reports_reviewed_by_fkey
+                        FOREIGN KEY (reviewed_by) REFERENCES public.users(id);
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Reverting is only meaningful when auth.users exists (i.e., on Supabase).
+        // On plain Postgres the auth schema may be absent or just a stub — do nothing.
+        let conn = manager.get_connection();
+
+        conn.execute_unprepared(
+            r#"
+            DO $$
+            BEGIN
+                -- Only revert if auth.users is a real table (not the local stub schema).
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_tables WHERE schemaname = 'auth' AND tablename = 'users'
+                ) THEN
+                    RETURN;
+                END IF;
+
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users') THEN
+                    ALTER TABLE public.users DROP CONSTRAINT IF EXISTS fk_users_auth_users;
+                    ALTER TABLE public.users
+                        ADD CONSTRAINT fk_users_auth_users
+                        FOREIGN KEY (id) REFERENCES auth.users(id) ON DELETE CASCADE;
+                END IF;
+
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'post_magazines') THEN
+                    ALTER TABLE public.post_magazines
+                        DROP CONSTRAINT IF EXISTS post_magazines_approved_by_fkey;
+                    ALTER TABLE public.post_magazines
+                        ADD CONSTRAINT post_magazines_approved_by_fkey
+                        FOREIGN KEY (approved_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+                END IF;
+
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_follows') THEN
+                    ALTER TABLE public.user_follows
+                        DROP CONSTRAINT IF EXISTS user_follows_follower_id_fkey;
+                    ALTER TABLE public.user_follows
+                        ADD CONSTRAINT user_follows_follower_id_fkey
+                        FOREIGN KEY (follower_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+                    ALTER TABLE public.user_follows
+                        DROP CONSTRAINT IF EXISTS user_follows_following_id_fkey;
+                    ALTER TABLE public.user_follows
+                        ADD CONSTRAINT user_follows_following_id_fkey
+                        FOREIGN KEY (following_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+                END IF;
+
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'user_tryon_history') THEN
+                    ALTER TABLE public.user_tryon_history
+                        DROP CONSTRAINT IF EXISTS user_tryon_history_user_id_fkey;
+                    ALTER TABLE public.user_tryon_history
+                        ADD CONSTRAINT user_tryon_history_user_id_fkey
+                        FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+                END IF;
+
+                IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'content_reports') THEN
+                    ALTER TABLE public.content_reports
+                        DROP CONSTRAINT IF EXISTS content_reports_reporter_id_fkey;
+                    ALTER TABLE public.content_reports
+                        ADD CONSTRAINT content_reports_reporter_id_fkey
+                        FOREIGN KEY (reporter_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+                    ALTER TABLE public.content_reports
+                        DROP CONSTRAINT IF EXISTS content_reports_reviewed_by_fkey;
+                    ALTER TABLE public.content_reports
+                        ADD CONSTRAINT content_reports_reviewed_by_fkey
+                        FOREIGN KEY (reviewed_by) REFERENCES auth.users(id);
+                END IF;
+            END $$;
+            "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+}

--- a/packages/api-server/migration/src/m20260501_000002_auth_uid_stub.rs
+++ b/packages/api-server/migration/src/m20260501_000002_auth_uid_stub.rs
@@ -1,0 +1,74 @@
+use sea_orm_migration::prelude::*;
+
+/// Provide `auth.uid()` stub for plain Postgres (local dev).
+///
+/// Why: existing RLS policies on public tables reference `auth.uid()`, which is provided
+/// by Supabase's GoTrue/PostgREST. Local plain Postgres doesn't have it, so RLS policy
+/// creation fails. We create a stub returning NULL so policies compile and behave as if
+/// no user were authenticated (api-server uses service_role, which bypasses RLS anyway).
+///
+/// On prod Supabase: `auth` schema already exists with the real `auth.uid()` function.
+/// This migration SKIPS creation when the function already exists — the real one is
+/// preserved, never overwritten.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                DO $$
+                BEGIN
+                    -- Ensure auth schema exists (Supabase prod: already present; local: create).
+                    CREATE SCHEMA IF NOT EXISTS auth;
+
+                    -- Create stub only if auth.uid() doesn't already exist.
+                    -- On prod Supabase, GoTrue creates the real function first, so this no-ops.
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_proc
+                        WHERE proname = 'uid'
+                          AND pronamespace = 'auth'::regnamespace
+                    ) THEN
+                        CREATE FUNCTION auth.uid() RETURNS uuid
+                            LANGUAGE sql STABLE
+                            AS $fn$ SELECT NULL::uuid $fn$;
+                    END IF;
+
+                    -- Same for auth.role() and auth.jwt() — referenced by some policies.
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_proc
+                        WHERE proname = 'role'
+                          AND pronamespace = 'auth'::regnamespace
+                    ) THEN
+                        CREATE FUNCTION auth.role() RETURNS text
+                            LANGUAGE sql STABLE
+                            AS $fn$ SELECT NULL::text $fn$;
+                    END IF;
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_proc
+                        WHERE proname = 'jwt'
+                          AND pronamespace = 'auth'::regnamespace
+                    ) THEN
+                        CREATE FUNCTION auth.jwt() RETURNS jsonb
+                            LANGUAGE sql STABLE
+                            AS $fn$ SELECT NULL::jsonb $fn$;
+                    END IF;
+                END $$;
+                "#,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Do NOT drop auth.uid()/role()/jwt() on prod — they are real Supabase functions.
+        // Down is a no-op; if we dropped them we could break prod authentication.
+        let _ = manager;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Phase A.3 of Epic #270 — Path X-1 dev environment refactoring. Migrates all public-table FKs that pointed to `auth.users` so the public schema can stand alone on plain Postgres (local dev without Supabase).

## Changes

### `m20260501_000001_decouple_auth_users_fk`
Drops old FKs to `auth.users(id)` and recreates them against `public.users(id)`:

| Table | Column(s) | On Delete |
|-------|-----------|-----------|
| `public.users` | `id` (self-FK dropped) | — |
| `public.post_magazines` | `approved_by` | SET NULL |
| `public.user_follows` | `follower_id`, `following_id` | CASCADE |
| `public.user_tryon_history` | `user_id` | CASCADE |
| `public.content_reports` | `reporter_id` | CASCADE |
| `public.content_reports` | `reviewed_by` | no action |

The `public.users ↔ auth.users` sync is preserved by the existing `handle_new_user` trigger (in `migration/sql/01_auth_trigger_handle_new_user.sql`) — that trigger inserts a row into `public.users` when Supabase Auth creates one. Removing the FK doesn't affect the trigger.

### `m20260501_000002_auth_uid_stub`
Creates stubs for `auth.uid()`, `auth.role()`, `auth.jwt()` **only when absent** (`IF NOT EXISTS (SELECT 1 FROM pg_proc ...)` guard). On prod Supabase, GoTrue already defined the real functions — they are never overwritten. Local plain Postgres gets stubs that return NULL so RLS policies referencing these functions compile without error.

## Idempotency

Every FK step uses `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` wrapped in `pg_tables` existence checks. This makes the migration safe for:
- **Prod** (where tables exist and old FKs point to auth.users) → drops + recreates
- **Fresh local** (where `content_reports`/`user_follows`/`user_tryon_history` may not exist yet — they still live in `migration/sql/`, to be moved to SeaORM in PR-4) → no-ops for missing tables

## Prod safety

Pre-check SQL to run on dev Supabase **before** merging:

\`\`\`sql
-- All auth.users FK columns should have matching rows in public.users
SELECT id, approved_by FROM public.post_magazines
 WHERE approved_by IS NOT NULL
   AND approved_by NOT IN (SELECT id FROM public.users);
-- Expected: 0 rows

SELECT follower_id FROM public.user_follows
 WHERE follower_id NOT IN (SELECT id FROM public.users)
UNION ALL
SELECT following_id FROM public.user_follows
 WHERE following_id NOT IN (SELECT id FROM public.users);
-- Expected: 0 rows

SELECT user_id FROM public.user_tryon_history
 WHERE user_id NOT IN (SELECT id FROM public.users);
-- Expected: 0 rows

SELECT reporter_id FROM public.content_reports
 WHERE reporter_id NOT IN (SELECT id FROM public.users);
-- Expected: 0 rows
\`\`\`

If any query returns rows → data integrity issue must be resolved before applying this migration.

## Test plan

- [x] \`cargo check -p migration\` — passes
- [x] \`cargo check\` (full workspace) — passes
- [x] \`cargo fmt --check\` — passes
- [ ] Run pre-check SQL on dev Supabase — expect 0 rows across all queries
- [ ] Apply to dev Supabase via api-server startup migrator — observe no errors, verify constraints recreated
- [ ] Verify Web auth flow still works (login → session → `/api/v1/*`)
- [ ] Verify admin approval on `post_magazines` still populates `approved_by`

## Follow-up (PR-4 #268)

- Move `migration/sql/*.sql` content to SeaORM migrations (content_reports, user_follows, user_tryon_history tables themselves)
- Env rename `SUPABASE_*` → `DATABASE_*` with dual-read fallback
- Local Postgres container in \`scripts/local-deps/\`
- JWT-verify → `public.users` upsert in auth middleware (for local dev where handle_new_user trigger doesn't fire)

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)