### PR TITLE
fix(migration): backfill users.ink_credits/style_dna/studio_config columns (#202)

### DIFF
--- a/packages/api-server/migration/src/lib.rs
+++ b/packages/api-server/migration/src/lib.rs
@@ -59,6 +59,7 @@ mod m20260502_000002_warehouse_schema_tables_and_rls;
 mod m20260502_000003_public_missing_tables_and_rls;
 mod m20260502_000004_embeddings_and_search_similar;
 mod m20260502_000005_magazine_approval_and_rpcs;
+mod m20260502_000006_backfill_public_columns;
 
 pub struct Migrator;
 
@@ -132,6 +133,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260502_000003_public_missing_tables_and_rls::Migration),
             Box::new(m20260502_000004_embeddings_and_search_similar::Migration),
             Box::new(m20260502_000005_magazine_approval_and_rpcs::Migration),
+            Box::new(m20260502_000006_backfill_public_columns::Migration),
         ]
     }
 }

--- a/packages/api-server/migration/src/m20260502_000006_backfill_public_columns.rs
+++ b/packages/api-server/migration/src/m20260502_000006_backfill_public_columns.rs
@@ -1,0 +1,36 @@
+use sea_orm_migration::prelude::*;
+
+/// Backfill public.* columns that live in prod (added via `supabase/migrations/`
+/// remote_schema.sql) but weren't in the SeaORM migration set.
+///
+/// Discovered while booting api-server against fresh local Postgres: calls to
+/// /api/v1/posts failed with "column users.ink_credits does not exist" because
+/// the SeaORM `users` entity expects `ink_credits` + `style_dna` but the
+/// `m20240101_000001_create_users` migration never created them.
+///
+/// Idempotent — `ADD COLUMN IF NOT EXISTS` no-ops on prod where they exist.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                r#"
+                ALTER TABLE public.users
+                    ADD COLUMN IF NOT EXISTS ink_credits integer NOT NULL DEFAULT 5,
+                    ADD COLUMN IF NOT EXISTS style_dna jsonb,
+                    ADD COLUMN IF NOT EXISTS studio_config jsonb;
+                "#,
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let _ = manager;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #276. Post-merge verification against a fresh local Postgres revealed a schema gap: \`/api/v1/posts\` returned 500 with \`column users.ink_credits does not exist\`. These columns live in prod (added via \`supabase/migrations/20260409075040_remote_schema.sql\` — which #276 retained but didn't fully port) and are referenced by the SeaORM entity at \`packages/api-server/src/entities/users.rs\`.

## Changes

New migration \`m20260502_000006_backfill_public_columns\` adds:

- \`users.ink_credits\` — integer NOT NULL DEFAULT 5
- \`users.style_dna\` — jsonb (nullable)
- \`users.studio_config\` — jsonb (nullable)

All idempotent (\`ADD COLUMN IF NOT EXISTS\`). Prod no-ops; local closes the gap.

## Verification

Booted \`cargo run --bin decoded-api\` against fresh \`pgvector/pgvector:pg17\` local container with \`DATABASE_URL=postgresql://postgres:postgres@localhost:5432/decoded\`. Before this migration:

\`\`\`
GET /api/v1/posts → 500 "column users.ink_credits does not exist"
\`\`\`

After:

\`\`\`
GET /api/v1/health              → 200
GET /api/v1/posts?per_page=3    → 200 {"data":[],"pagination":{...}}
GET /api/v1/warehouse/profiles  → 200 {"artists":[],"groups":[],"brands":[]}
GET /api/v1/categories          → 200 [6 seed categories]
\`\`\`

## Follow-up

This is the first column backfill discovered during smoke-testing. A systematic \`pg_dump --schema-only\` diff between prod and fresh-local SeaORM output would catch any remaining gaps in one pass — tracking as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)