### PR TITLE
feat(ci): decoded 일일 활동 요약을 텔레그램으로 전송

### DIFF
--- a/.github/scripts/daily-digest.sh
+++ b/.github/scripts/daily-digest.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Daily digest for decoded monorepo → Telegram
+# Required env:
+#   GH_TOKEN            (github actions token)
+#   ANTHROPIC_API_KEY
+#   TELEGRAM_BOT_TOKEN
+#   TELEGRAM_CHAT_ID
+#   GITHUB_REPOSITORY   (owner/repo)
+set -eo pipefail
+
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+WINDOW_HOURS="${WINDOW_HOURS:-24}"
+
+# GNU date (ubuntu runner). SINCE is ISO-8601 UTC for gh search filtering.
+SINCE_ISO=$(date -u -d "${WINDOW_HOURS} hours ago" +%Y-%m-%dT%H:%M:%SZ)
+SINCE_GIT=$(date -u -d "${WINDOW_HOURS} hours ago" +%Y-%m-%d\ %H:%M:%S)
+TODAY_KST=$(TZ='Asia/Seoul' date +%Y-%m-%d)
+
+echo "::group::collect"
+echo "window: since=${SINCE_ISO} (${WINDOW_HOURS}h)"
+
+# --- commits on main/dev ---
+git fetch --quiet origin main dev 2>/dev/null || git fetch --quiet origin main
+
+commits_json() {
+  local ref="$1"
+  git log "$ref" --since="$SINCE_GIT" --pretty=format:'%H%x09%h%x09%s%x09%an' 2>/dev/null \
+    | jq -R -s 'split("\n") | map(select(length > 0) | split("\t") | {sha:.[0], short:.[1], subject:.[2], author:.[3]})'
+}
+
+COMMITS_MAIN=$(commits_json origin/main)
+COMMITS_DEV=$(commits_json origin/dev 2>/dev/null || echo "[]")
+
+# --- PRs and issues via gh ---
+MERGED_PRS=$(gh pr list --repo "$REPO" --state merged --limit 50 \
+  --json number,title,author,mergedAt,baseRefName,headRefName,additions,deletions \
+  | jq --arg since "$SINCE_ISO" '[.[] | select(.mergedAt >= $since)]')
+
+OPEN_PRS=$(gh pr list --repo "$REPO" --state open --limit 50 \
+  --json number,title,author,isDraft,reviewDecision,createdAt,updatedAt,headRefName,baseRefName)
+
+NEW_ISSUES=$(gh issue list --repo "$REPO" --state all --limit 50 \
+  --json number,title,author,labels,createdAt,state \
+  | jq --arg since "$SINCE_ISO" '[.[] | select(.createdAt >= $since)]')
+
+OPEN_ISSUES_ASSIGNED=$(gh issue list --repo "$REPO" --state open --limit 50 \
+  --json number,title,author,assignees,labels \
+  | jq '[.[] | select(.assignees | length > 0)]')
+
+MERGED_COUNT=$(echo "$MERGED_PRS" | jq 'length')
+OPEN_COUNT=$(echo "$OPEN_PRS" | jq 'length')
+ISSUES_COUNT=$(echo "$NEW_ISSUES" | jq 'length')
+COMMITS_MAIN_COUNT=$(echo "$COMMITS_MAIN" | jq 'length')
+COMMITS_DEV_COUNT=$(echo "$COMMITS_DEV" | jq 'length')
+
+echo "merged PRs: $MERGED_COUNT"
+echo "open PRs: $OPEN_COUNT"
+echo "new issues: $ISSUES_COUNT"
+echo "commits main/dev: $COMMITS_MAIN_COUNT/$COMMITS_DEV_COUNT"
+echo "::endgroup::"
+
+# --- Claude Haiku summary ---
+echo "::group::summarize"
+
+DATA_JSON=$(jq -n \
+  --argjson merged_prs "$MERGED_PRS" \
+  --argjson open_prs "$OPEN_PRS" \
+  --argjson new_issues "$NEW_ISSUES" \
+  --argjson open_issues_assigned "$OPEN_ISSUES_ASSIGNED" \
+  --argjson commits_main "$COMMITS_MAIN" \
+  --argjson commits_dev "$COMMITS_DEV" \
+  '{
+    merged_prs: $merged_prs,
+    open_prs: $open_prs,
+    new_issues: $new_issues,
+    open_issues_assigned: $open_issues_assigned,
+    commits_main: $commits_main,
+    commits_dev: $commits_dev
+  }')
+
+PROMPT_TEXT='당신은 decoded 모노레포의 일일 리포트를 한국어로 작성합니다.
+아래 JSON은 지난 24시간의 GitHub 활동입니다.
+
+요청:
+- 주요 변화 3~5개 bullet (가장 임팩트 큰 것부터)
+- review 대기중이거나 오래된 open PR 있으면 "주의" 섹션
+- 전체 300자 이내, plain text (마크다운 금지)
+- 형식:
+✨ 하이라이트
+• ...
+
+⚠️ 주의
+• ... (해당 없으면 이 섹션 생략)'
+
+CLAUDE_REQ=$(jq -n \
+  --arg model "claude-haiku-4-5-20251001" \
+  --arg prompt "$PROMPT_TEXT" \
+  --arg data "$DATA_JSON" \
+  '{
+    model: $model,
+    max_tokens: 1024,
+    messages: [{
+      role: "user",
+      content: "\($prompt)\n\n데이터:\n\($data)"
+    }]
+  }')
+
+CLAUDE_RESP=$(curl -sS -X POST https://api.anthropic.com/v1/messages \
+  -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d "$CLAUDE_REQ")
+
+SUMMARY=$(echo "$CLAUDE_RESP" | jq -r '.content[0].text // empty')
+if [ -z "$SUMMARY" ]; then
+  echo "::warning::Claude API 응답 파싱 실패"
+  echo "$CLAUDE_RESP" | jq . || echo "$CLAUDE_RESP"
+  SUMMARY="(AI 요약 생성 실패 — raw 데이터만 전송)"
+fi
+echo "::endgroup::"
+
+# --- compose top-N bullet lists for telegram body ---
+
+top_merged=$(echo "$MERGED_PRS" | jq -r '
+  .[:5] | map("• #\(.number) \(.title) (→\(.baseRefName), by \(.author.login))") | join("\n")')
+top_open=$(echo "$OPEN_PRS" | jq -r '
+  .[:5] | map(
+    "• #\(.number) \(.title) by \(.author.login)" +
+    (if .isDraft then " [draft]" else "" end)
+  ) | join("\n")')
+top_issues=$(echo "$NEW_ISSUES" | jq -r '
+  .[:5] | map("• #\(.number) \(.title) by \(.author.login)") | join("\n")')
+
+section() {
+  local title="$1" body="$2"
+  [ -z "$body" ] && return 0
+  printf '%s\n%s\n\n' "$title" "$body"
+}
+
+BODY=""
+BODY+=$(section "🔀 merged PRs (${MERGED_COUNT})" "$top_merged")
+BODY+=$(section "📝 open PRs (${OPEN_COUNT})" "$top_open")
+BODY+=$(section "📌 new issues (${ISSUES_COUNT})" "$top_issues")
+
+MSG=$(cat <<EOF
+🌅 decoded 일일 요약 — ${TODAY_KST}
+━━━━━━━━━━━━━━━━
+📦 commits: main ${COMMITS_MAIN_COUNT} / dev ${COMMITS_DEV_COUNT}
+🔀 merged PRs: ${MERGED_COUNT}
+📝 open PRs: ${OPEN_COUNT}
+📌 new issues: ${ISSUES_COUNT}
+
+${BODY}${SUMMARY}
+
+🔗 https://github.com/${REPO}/pulls
+EOF
+)
+
+# --- send to Telegram ---
+echo "::group::telegram"
+PAYLOAD=$(jq -n \
+  --arg chat_id "$TELEGRAM_CHAT_ID" \
+  --arg text "$MSG" \
+  '{
+    chat_id: $chat_id,
+    text: ($text | if length > 4096 then .[0:4090] + "\n…" else . end),
+    disable_web_page_preview: true
+  }')
+
+RESP=$(curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+
+echo "$RESP" | jq .
+echo "$RESP" | jq -e '.ok == true' >/dev/null
+echo "::endgroup::"

--- a/.github/scripts/daily-digest.sh
+++ b/.github/scripts/daily-digest.sh
@@ -131,16 +131,16 @@ top_open=$(echo "$OPEN_PRS" | jq -r '
 top_issues=$(echo "$NEW_ISSUES" | jq -r '
   .[:5] | map("• #\(.number) \(.title) by \(.author.login)") | join("\n")')
 
-section() {
-  local title="$1" body="$2"
-  [ -z "$body" ] && return 0
-  printf '%s\n%s\n\n' "$title" "$body"
-}
-
 BODY=""
-BODY+=$(section "🔀 merged PRs (${MERGED_COUNT})" "$top_merged")
-BODY+=$(section "📝 open PRs (${OPEN_COUNT})" "$top_open")
-BODY+=$(section "📌 new issues (${ISSUES_COUNT})" "$top_issues")
+if [ -n "$top_merged" ]; then
+  BODY+="🔀 merged PRs (${MERGED_COUNT})"$'\n'"$top_merged"$'\n\n'
+fi
+if [ -n "$top_open" ]; then
+  BODY+="📝 open PRs (${OPEN_COUNT})"$'\n'"$top_open"$'\n\n'
+fi
+if [ -n "$top_issues" ]; then
+  BODY+="📌 new issues (${ISSUES_COUNT})"$'\n'"$top_issues"$'\n\n'
+fi
 
 MSG=$(cat <<EOF
 🌅 decoded 일일 요약 — ${TODAY_KST}

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -1,0 +1,51 @@
+# Daily digest of decoded monorepo activity → Telegram.
+# Required repo secrets: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID, ANTHROPIC_API_KEY
+name: Daily digest
+
+on:
+  schedule:
+    # Daily 00:00 UTC = 09:00 KST. Schedule only runs on default branch.
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      window_hours:
+        description: "Look-back window in hours"
+        required: false
+        default: "24"
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate secrets
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          missing=()
+          [ -z "$TELEGRAM_BOT_TOKEN" ] && missing+=("TELEGRAM_BOT_TOKEN")
+          [ -z "$TELEGRAM_CHAT_ID" ] && missing+=("TELEGRAM_CHAT_ID")
+          [ -z "$ANTHROPIC_API_KEY" ] && missing+=("ANTHROPIC_API_KEY")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing repo secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Run daily digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WINDOW_HOURS: ${{ github.event.inputs.window_hours || '24' }}
+        run: bash .github/scripts/daily-digest.sh

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -12,6 +12,11 @@ on:
         description: "Look-back window in hours"
         required: false
         default: "24"
+  # Lets PRs that touch the digest itself verify end-to-end before landing.
+  pull_request:
+    paths:
+      - ".github/workflows/daily-digest.yml"
+      - ".github/scripts/daily-digest.sh"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- 매일 09:00 KST에 decoded 모노레포의 지난 24h 활동(commit/PR/issue)을 텔레그램으로 요약 전송
- `gh` CLI로 수집 → Claude Haiku 4.5로 한국어 요약 → 기존 `TELEGRAM_*` secret으로 sendMessage
- 기존 `ANTHROPIC_API_KEY` / `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` repo secret 재사용 (신규 secret 불필요)

## 구성
- `.github/workflows/daily-digest.yml` — cron (`0 0 * * *` UTC = 09:00 KST) + `workflow_dispatch` + `pull_request`(자기 검증용)
- `.github/scripts/daily-digest.sh` — 수집/요약/전송 스크립트

## 수집 범위
- merged PRs (last 24h)
- open PRs (최대 50, 상위 5개 표시)
- new issues (last 24h)
- `main`/`dev` 커밋 수

## Test plan
- [x] shellcheck / `bash -n` 통과
- [ ] 이 PR 자체가 `pull_request` 트리거로 자동 실행 → 텔레그램 메시지 수신 확인
- [ ] 머지 후 `workflow_dispatch`로 수동 실행 재확인
- [ ] 다음 09:00 KST 스케줄 실행 확인

## 머지 전 정리
검증이 끝나면 `pull_request` 트리거는 제거해도 됩니다 (디지트 자체 변경 시에만 발사되므로 유지해도 노이즈 적음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)