### PR TITLE
feat(daily-digest): 브랜치 맥락 노출 강화

### DIFF
--- a/.github/scripts/daily-digest.sh
+++ b/.github/scripts/daily-digest.sh
@@ -81,13 +81,17 @@ DATA_JSON=$(jq -n \
 PROMPT_TEXT='당신은 decoded 모노레포의 일일 리포트를 한국어로 작성합니다.
 아래 JSON은 지난 24시간의 GitHub 활동입니다.
 
+브랜치 맥락: decoded는 `feature/* → dev → main` 플로우. 대부분 작업은 dev에 병합되고, main은 릴리즈/CI 전용.
+
 요청:
 - 주요 변화 3~5개 bullet (가장 임팩트 큰 것부터)
+- 각 항목 끝에 **어느 브랜치로 갔는지** 명시 (예: "(→dev)", "(→main)")
+- open PR 언급 시 base 브랜치도 함께 명시
 - review 대기중이거나 오래된 open PR 있으면 "주의" 섹션
-- 전체 300자 이내, plain text (마크다운 금지)
+- 전체 350자 이내, plain text (마크다운 금지)
 - 형식:
 ✨ 하이라이트
-• ...
+• 내용 요약 (#PR번호, →baseBranch)
 
 ⚠️ 주의
 • ... (해당 없으면 이 섹션 생략)'
@@ -125,13 +129,23 @@ top_merged=$(echo "$MERGED_PRS" | jq -r '
   .[:5] | map("• #\(.number) \(.title) (→\(.baseRefName), by \(.author.login))") | join("\n")')
 top_open=$(echo "$OPEN_PRS" | jq -r '
   .[:5] | map(
-    "• #\(.number) \(.title) by \(.author.login)" +
+    "• #\(.number) \(.title) (→\(.baseRefName), by \(.author.login))" +
     (if .isDraft then " [draft]" else "" end)
   ) | join("\n")')
+top_commits_main=$(echo "$COMMITS_MAIN" | jq -r '
+  .[:3] | map("• \(.short) \(.subject) (by \(.author))") | join("\n")')
+top_commits_dev=$(echo "$COMMITS_DEV" | jq -r '
+  .[:3] | map("• \(.short) \(.subject) (by \(.author))") | join("\n")')
 top_issues=$(echo "$NEW_ISSUES" | jq -r '
   .[:5] | map("• #\(.number) \(.title) by \(.author.login)") | join("\n")')
 
 BODY=""
+if [ -n "$top_commits_main" ]; then
+  BODY+="📦 commits → main (${COMMITS_MAIN_COUNT})"$'\n'"$top_commits_main"$'\n\n'
+fi
+if [ -n "$top_commits_dev" ]; then
+  BODY+="📦 commits → dev (${COMMITS_DEV_COUNT})"$'\n'"$top_commits_dev"$'\n\n'
+fi
 if [ -n "$top_merged" ]; then
   BODY+="🔀 merged PRs (${MERGED_COUNT})"$'\n'"$top_merged"$'\n\n'
 fi


### PR DESCRIPTION
## Summary
- 일일 요약에서 "어느 브랜치로 간 작업인지" 불명확하던 문제 수정
- open PRs 에 `→base` 추가, commits 섹션 main/dev 분리 노출, Claude 하이라이트에 브랜치 명시 지시

## 변경
1. **open PRs**: `• #281 … (→dev, by cocoyoon)` 형태로 base 노출
2. **commits**: `📦 commits → main (N)` / `📦 commits → dev (M)` 섹션 분리, 상위 3개 SHA + subject
3. **Claude 프롬프트**: `feature/* → dev → main` 플로우 맥락 주입, 각 하이라이트 끝에 `(→branch)` 명시 요구

## Test plan
- [x] `bash -n` 통과
- [ ] `pull_request` 트리거 자동 실행 → 텔레그램 수신 확인
- [ ] 병합 후 main 에서 `workflow_dispatch` 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)