### PR TITLE
fix(supabase): correct auth site_url + redirect_urls for local OAuth

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -147,9 +147,9 @@ max_indexes = 5
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["http://localhost:3000", "http://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).


### PR DESCRIPTION
## Summary
Supabase self-hosting 전환(#282) 이후 로컬 Google OAuth 회귀 수정.

- \`supabase/config.toml\`
  - \`site_url\`: \`127.0.0.1:3000\` → \`localhost:3000\` (앱 origin과 일치)
  - \`additional_redirect_urls\`:
    - \`https://\` → \`http://\` (로컬은 TLS 없음)
    - \`localhost:3000\` 추가

## 함께 필요한 설정 (이 PR 밖)
- Google Cloud Console OAuth Client
  - JavaScript origins: \`http://localhost:3000\`, \`http://127.0.0.1:3000\`
  - Redirect URIs: \`http://127.0.0.1:54321/auth/v1/callback\`
- \`supabase/.env\`
  - \`SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID\`
  - \`SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET\`
- 재시작: \`supabase stop && supabase start\`

## 검증
2026-04-23 로컬에서 \`/login\` → Google consent 화면 정상 도달 확인.

## Related
- 회귀 원인: #282 self-hosting 전환
- 별도 auth 이슈: #296 (Continue as Guest 동작 실패)
- QA 트리거 이슈: #145 (Upload 모달 UX)

## Test plan
- [ ] \`supabase stop && supabase start\` 후 GoTrue 컨테이너 env 확인
  - \`GOTRUE_SITE_URL=http://localhost:3000\`
  - \`GOTRUE_URI_ALLOW_LIST=http://localhost:3000,http://127.0.0.1:3000\`
- [ ] \`/login\` → Continue with Google → Google consent 페이지 도달
- [ ] 승인 후 \`/request/upload\` redirect 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)