### PR TITLE
fix(auth): allow guest session to pass AuthGuard (#296)

### DIFF
--- a/packages/web/lib/components/auth/AuthGuard.tsx
+++ b/packages/web/lib/components/auth/AuthGuard.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import {
   useAuthStore,
-  selectIsLoggedIn,
+  selectIsAuthenticated,
   selectIsInitialized,
 } from "@/lib/stores/authStore";
 
@@ -14,16 +14,16 @@ interface AuthGuardProps {
 }
 
 export function AuthGuard({ children, fallback }: AuthGuardProps) {
-  const isLoggedIn = useAuthStore(selectIsLoggedIn);
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
   const isInitialized = useAuthStore(selectIsInitialized);
   const router = useRouter();
 
   useEffect(() => {
-    if (isInitialized && !isLoggedIn) {
+    if (isInitialized && !isAuthenticated) {
       const currentPath = window.location.pathname;
       router.push(`/login?redirect=${encodeURIComponent(currentPath)}`);
     }
-  }, [isInitialized, isLoggedIn, router]);
+  }, [isInitialized, isAuthenticated, router]);
 
   if (!isInitialized) {
     return (
@@ -35,7 +35,7 @@ export function AuthGuard({ children, fallback }: AuthGuardProps) {
     );
   }
 
-  if (!isLoggedIn) {
+  if (!isAuthenticated) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- `AuthGuard`가 `selectIsLoggedIn`(= `!!user`)만 체크해, `guestLogin()`으로 설정된 `isGuest: true` 상태를 비인증으로 판정하던 문제 수정
- `selectIsAuthenticated`(`!!user || isGuest`)로 교체해 게스트 세션도 `/request/*` 보호 라우트에 접근 가능
- `AuthGuard`는 현재 `/request/*`에만 사용되며, 로그인 페이지에 "Continue as Guest" 진입점이 이미 노출되어 있어 게스트 접근이 의도된 정책

## 재현 (해결 전)
1. 로그아웃 상태로 `/request/upload` 접근 → `/login?redirect=/request/upload`로 이동
2. "Continue as Guest" 클릭
3. URL은 `/request/upload`로 바뀌지만 login DOM이 잔존(타이틀 `Login - Decoded`, 버튼 유지)

## 검증 후 동작
- "Continue as Guest" → `isGuest=true` → `/request/upload`로 정상 라우팅, 업로드 플로우 렌더

## Test plan
- [ ] 로그아웃 상태에서 `/request/upload` 진입 시 login 페이지로 redirect 되는지
- [ ] "Continue as Guest" 클릭 시 업로드 플로우로 이동하는지
- [ ] OAuth 로그인 사용자도 기존과 동일하게 보호 라우트 접근 가능한지
- [ ] Nav의 UPLOAD 버튼이 guest 상태에서도 /request/upload로 정상 이동하는지

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)