### PR TITLE
feat(upload): drag to reposition spots + undo delete (#291)

### DIFF
--- a/packages/web/lib/components/request/DetectionView.tsx
+++ b/packages/web/lib/components/request/DetectionView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useRef } from "react";
 import Image from "next/image";
 import {
   type UploadedImage,
@@ -15,9 +15,14 @@ interface DetectionViewProps {
   isRevealing?: boolean;
   selectedSpotId?: string | null;
   onSpotClick?: (spot: DetectedSpot) => void;
+  onSpotMove?: (spotId: string, x: number, y: number) => void; // normalized 0-1
   onImageClick?: (x: number, y: number) => void; // 이미지 클릭 시 normalized 좌표 전달
   layout?: "default" | "fullscreen";
 }
+
+// Pixel distance above which a pointer interaction is treated as a drag,
+// not a click. Below this threshold we keep the original click semantics.
+const DRAG_THRESHOLD_PX = 4;
 
 /**
  * DetectionView - AI 감지 결과를 보여주는 뷰
@@ -34,22 +39,93 @@ export const DetectionView = memo(
     isRevealing = false,
     selectedSpotId,
     onSpotClick,
+    onSpotMove,
     onImageClick,
     layout = "default",
   }: DetectionViewProps) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const dragStateRef = useRef<{
+      spotId: string | null;
+      startX: number;
+      startY: number;
+      moved: boolean;
+    }>({ spotId: null, startX: 0, startY: 0, moved: false });
+    // After a drag, suppress the synthetic click that would otherwise
+    // fire on pointer-up (from both the Hotspot button and the image
+    // overlay beneath it if the pointer ended outside the button).
+    const suppressNextClickRef = useRef(false);
+
+    const normalizedFromEvent = (
+      clientX: number,
+      clientY: number
+    ): { x: number; y: number } | null => {
+      if (!containerRef.current) return null;
+      const rect = containerRef.current.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return null;
+      return {
+        x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+        y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+      };
+    };
+
+    const handleSpotPointerDown = (
+      e: React.PointerEvent<HTMLButtonElement>,
+      spot: DetectedSpot
+    ) => {
+      if (!onSpotMove) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      dragStateRef.current = {
+        spotId: spot.id,
+        startX: e.clientX,
+        startY: e.clientY,
+        moved: false,
+      };
+    };
+
+    const handleSpotPointerMove = (
+      e: React.PointerEvent<HTMLButtonElement>
+    ) => {
+      const drag = dragStateRef.current;
+      if (!drag.spotId || !onSpotMove) return;
+      const dx = e.clientX - drag.startX;
+      const dy = e.clientY - drag.startY;
+      if (!drag.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+      drag.moved = true;
+      const coords = normalizedFromEvent(e.clientX, e.clientY);
+      if (!coords) return;
+      onSpotMove(drag.spotId, coords.x, coords.y);
+    };
+
+    const handleSpotPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+      const drag = dragStateRef.current;
+      if (!drag.spotId) return;
+      if (drag.moved) {
+        // Finalize position (last move already committed coords) and
+        // suppress the synthetic click that follows pointer-up.
+        const coords = normalizedFromEvent(e.clientX, e.clientY);
+        if (coords && onSpotMove) onSpotMove(drag.spotId, coords.x, coords.y);
+        suppressNextClickRef.current = true;
+      }
+      dragStateRef.current = {
+        spotId: null,
+        startX: 0,
+        startY: 0,
+        moved: false,
+      };
+    };
+
     // 이미지 클릭 핸들러 - normalized 좌표로 변환
     const handleImageClick = (e: React.MouseEvent<HTMLDivElement>) => {
       if (!onImageClick || isDetecting) return;
+      if (suppressNextClickRef.current) {
+        // Ate the click that terminated a drag — do not create a new spot.
+        suppressNextClickRef.current = false;
+        return;
+      }
 
-      const rect = e.currentTarget.getBoundingClientRect();
-      const x = (e.clientX - rect.left) / rect.width;
-      const y = (e.clientY - rect.top) / rect.height;
-
-      // 클램프 0-1
-      const clampedX = Math.max(0, Math.min(1, x));
-      const clampedY = Math.max(0, Math.min(1, y));
-
-      onImageClick(clampedX, clampedY);
+      const coords = normalizedFromEvent(e.clientX, e.clientY);
+      if (!coords) return;
+      onImageClick(coords.x, coords.y);
     };
     const containerClasses =
       layout === "fullscreen"
@@ -57,7 +133,7 @@ export const DetectionView = memo(
         : "relative w-full aspect-[3/4] max-w-md mx-auto rounded-xl overflow-hidden bg-foreground/5";
 
     return (
-      <div className={containerClasses}>
+      <div ref={containerRef} className={containerClasses}>
         {/* 이미지 */}
         <Image
           src={image.previewUrl}
@@ -180,7 +256,19 @@ export const DetectionView = memo(
               revealDelay={spot.center.y * 1000}
               glow={true}
               label={`Spot ${spot.index}${spot.label ? `: ${spot.label}` : ""}`}
-              onClick={() => onSpotClick?.(spot)}
+              style={onSpotMove ? { touchAction: "none" } : undefined}
+              onPointerDown={(e) => handleSpotPointerDown(e, spot)}
+              onPointerMove={handleSpotPointerMove}
+              onPointerUp={handleSpotPointerUp}
+              onPointerCancel={handleSpotPointerUp}
+              onClick={(e) => {
+                if (suppressNextClickRef.current) {
+                  e.stopPropagation();
+                  suppressNextClickRef.current = false;
+                  return;
+                }
+                onSpotClick?.(spot);
+              }}
             />
           ))}
 

--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { toast } from "sonner";
 import {
   useRequestStore,
   getRequestActions,
@@ -119,9 +120,36 @@ export function UploadFlowSteps() {
     getRequestActions().selectSpot(spot.id);
   }, []);
 
-  const handleRemoveSpot = useCallback((spotId: string) => {
-    getRequestActions().removeSpot(spotId);
+  const handleSpotMove = useCallback((spotId: string, x: number, y: number) => {
+    getRequestActions().moveSpot(spotId, x, y);
   }, []);
+
+  const handleRemoveSpot = useCallback(
+    (spotId: string) => {
+      // Snapshot the spot (including solution + original index) so Undo
+      // can restore it intact after the store re-indexes remaining spots.
+      const snapshot = detectedSpots.find((s) => s.id === spotId);
+      const originalIndex = detectedSpots.findIndex((s) => s.id === spotId);
+      getRequestActions().removeSpot(spotId);
+      if (!snapshot) return;
+      const toastId = `spot-deleted-${spotId}`;
+      toast(`Spot ${snapshot.index} deleted`, {
+        id: toastId,
+        duration: 5000,
+        action: {
+          label: "Undo",
+          onClick: () => {
+            getRequestActions().restoreSpot(
+              snapshot,
+              originalIndex >= 0 ? originalIndex : undefined
+            );
+            toast.dismiss(toastId);
+          },
+        },
+      });
+    },
+    [detectedSpots]
+  );
 
   const handleSaveSolution = useCallback(
     (spotId: string, solution: SpotSolutionData) => {
@@ -232,6 +260,7 @@ export function UploadFlowSteps() {
                   isDetecting={false}
                   selectedSpotId={selectedSpotId}
                   onSpotClick={handleSpotClick}
+                  onSpotMove={handleSpotMove}
                   onImageClick={handleImageClick}
                   layout="default"
                 />

--- a/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
+++ b/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
@@ -3,10 +3,11 @@
  */
 import React from "react";
 import { describe, test, expect, vi, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { UploadFlowSteps } from "../UploadFlowSteps";
 import { useRequestStore, getRequestActions } from "@/lib/stores/requestStore";
+import { toast } from "sonner";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
@@ -114,5 +115,53 @@ describe("UploadFlowSteps — step indicator progression", () => {
     getRequestActions().addSpot(0.5, 0.5);
     render(<UploadFlowSteps />);
     expect(currentStepLabel()).toBe("Details");
+  });
+});
+
+describe("UploadFlowSteps — spot delete undo (#291)", () => {
+  beforeEach(() => {
+    cleanup();
+    useRequestStore.getState().resetRequestFlow();
+    useRequestStore.getState().setActiveInstance(null);
+    vi.mocked(toast).mockClear();
+  });
+
+  test("clicking trash deletes the spot and offers an Undo toast that restores it", () => {
+    const file = new File(["x"], "x.jpg", { type: "image/jpeg" });
+    getRequestActions().addImage(file);
+    const img = useRequestStore.getState().images[0];
+    getRequestActions().setImageUploadedUrl(img.id, "data:x");
+    getRequestActions().setUserKnowsItems(false);
+    getRequestActions().addSpot(0.25, 0.5);
+    getRequestActions().addSpot(0.75, 0.5);
+    const [, second] = useRequestStore.getState().detectedSpots;
+
+    render(<UploadFlowSteps />);
+
+    // Trash icons live on each spot row in the sidebar; pick the second.
+    const trashButtons = screen.getAllByRole("button", {
+      name: /remove spot/i,
+    });
+    expect(trashButtons).toHaveLength(2);
+    fireEvent.click(trashButtons[1]);
+
+    // Spot was removed from the store…
+    const afterDelete = useRequestStore.getState().detectedSpots;
+    expect(afterDelete).toHaveLength(1);
+    expect(afterDelete.find((s) => s.id === second.id)).toBeUndefined();
+
+    // …and a toast was raised with an Undo action.
+    const mockedToast = toast as unknown as ReturnType<typeof vi.fn>;
+    expect(mockedToast).toHaveBeenCalledTimes(1);
+    const [, options] = mockedToast.mock.calls[0];
+    expect(options.action?.label).toBe("Undo");
+
+    // Invoking the Undo action restores the deleted spot at its original slot
+    // with indices renumbered.
+    options.action.onClick();
+    const afterUndo = useRequestStore.getState().detectedSpots;
+    expect(afterUndo).toHaveLength(2);
+    expect(afterUndo.map((s) => s.index)).toEqual([1, 2]);
+    expect(afterUndo.find((s) => s.id === second.id)).toBeDefined();
   });
 });

--- a/packages/web/lib/stores/__tests__/requestStore.spot-actions.test.ts
+++ b/packages/web/lib/stores/__tests__/requestStore.spot-actions.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for spot-level actions: moveSpot and restoreSpot.
+ * Regression coverage for #291.
+ */
+import { describe, test, expect, beforeEach } from "vitest";
+import { useRequestStore, getRequestActions } from "@/lib/stores/requestStore";
+
+describe("requestStore — moveSpot", () => {
+  beforeEach(() => {
+    useRequestStore.getState().resetRequestFlow();
+  });
+
+  test("updates center coordinates of the matching spot", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.1, 0.2);
+    const [spot] = useRequestStore.getState().detectedSpots;
+
+    actions.moveSpot(spot.id, 0.7, 0.8);
+
+    const [updated] = useRequestStore.getState().detectedSpots;
+    expect(updated.id).toBe(spot.id);
+    expect(updated.center).toEqual({ x: 0.7, y: 0.8 });
+  });
+
+  test("clamps coordinates to the [0, 1] range", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.5, 0.5);
+    const [spot] = useRequestStore.getState().detectedSpots;
+
+    actions.moveSpot(spot.id, -0.3, 1.4);
+
+    const [updated] = useRequestStore.getState().detectedSpots;
+    expect(updated.center).toEqual({ x: 0, y: 1 });
+  });
+
+  test("is a no-op for unknown spot ids", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.5, 0.5);
+    const before = useRequestStore.getState().detectedSpots;
+
+    actions.moveSpot("does-not-exist", 0.1, 0.1);
+
+    const after = useRequestStore.getState().detectedSpots;
+    expect(after).toEqual(before);
+  });
+});
+
+describe("requestStore — restoreSpot", () => {
+  beforeEach(() => {
+    useRequestStore.getState().resetRequestFlow();
+  });
+
+  test("reinserts spot at original position and re-indexes numbering", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.1, 0.1);
+    actions.addSpot(0.2, 0.2);
+    actions.addSpot(0.3, 0.3);
+    const [, middle] = useRequestStore.getState().detectedSpots;
+    const middleSnapshot = { ...middle };
+    const originalIndex = 1;
+
+    actions.removeSpot(middle.id);
+    expect(useRequestStore.getState().detectedSpots).toHaveLength(2);
+
+    actions.restoreSpot(middleSnapshot, originalIndex);
+
+    const spots = useRequestStore.getState().detectedSpots;
+    expect(spots).toHaveLength(3);
+    expect(spots[originalIndex].id).toBe(middle.id);
+    // Reindexing keeps numbering contiguous even though the id of the
+    // middle slot matches the pre-removal snapshot.
+    expect(spots.map((s) => s.index)).toEqual([1, 2, 3]);
+  });
+
+  test("preserves solution data when restoring a deleted spot", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.5, 0.5);
+    const [spot] = useRequestStore.getState().detectedSpots;
+    actions.setSpotSolution(spot.id, {
+      title: "Example",
+      originalUrl: "https://example.com",
+    });
+    const withSolution = useRequestStore
+      .getState()
+      .detectedSpots.find((s) => s.id === spot.id)!;
+
+    actions.removeSpot(spot.id);
+    actions.restoreSpot(withSolution);
+
+    const restored = useRequestStore
+      .getState()
+      .detectedSpots.find((s) => s.id === spot.id);
+    expect(restored?.solution?.originalUrl).toBe("https://example.com");
+  });
+
+  test("ignores duplicates when the spot id already exists", () => {
+    const actions = getRequestActions();
+    actions.addSpot(0.5, 0.5);
+    const [spot] = useRequestStore.getState().detectedSpots;
+
+    actions.restoreSpot(spot);
+
+    expect(useRequestStore.getState().detectedSpots).toHaveLength(1);
+  });
+});

--- a/packages/web/lib/stores/requestStore.ts
+++ b/packages/web/lib/stores/requestStore.ts
@@ -128,7 +128,9 @@ interface RequestState {
   setDetectedSpots: (spots: DetectedSpot[]) => void;
   selectSpot: (spotId: string | null) => void;
   addSpot: (x: number, y: number, categoryCode?: string) => void;
+  moveSpot: (spotId: string, x: number, y: number) => void;
   removeSpot: (spotId: string) => void;
+  restoreSpot: (spot: DetectedSpot, atIndex?: number) => void;
 
   // Actions - Solution
   setSpotSolution: (spotId: string, solution: SpotSolutionData) => void;
@@ -390,6 +392,18 @@ export const useRequestStore = create<RequestState>((set, get) => ({
     }));
   },
 
+  moveSpot: (spotId, x, y) => {
+    const clampedX = Math.max(0, Math.min(1, x));
+    const clampedY = Math.max(0, Math.min(1, y));
+    set((state) => ({
+      detectedSpots: state.detectedSpots.map((spot) =>
+        spot.id === spotId
+          ? { ...spot, center: { x: clampedX, y: clampedY } }
+          : spot
+      ),
+    }));
+  },
+
   removeSpot: (spotId) => {
     set((state) => {
       const filteredSpots = state.detectedSpots.filter((s) => s.id !== spotId);
@@ -404,6 +418,26 @@ export const useRequestStore = create<RequestState>((set, get) => ({
         selectedSpotId:
           state.selectedSpotId === spotId ? null : state.selectedSpotId,
       };
+    });
+  },
+
+  restoreSpot: (spot, atIndex) => {
+    set((state) => {
+      // Reject duplicates (e.g., if the user already re-added the same id manually)
+      if (state.detectedSpots.some((s) => s.id === spot.id)) return {};
+      const insertAt =
+        atIndex !== undefined && atIndex >= 0
+          ? Math.min(atIndex, state.detectedSpots.length)
+          : state.detectedSpots.length;
+      const next = [...state.detectedSpots];
+      next.splice(insertAt, 0, spot);
+      // Re-index after insertion so numbering stays contiguous
+      const reindexed = next.map((s, idx) => ({
+        ...s,
+        index: idx + 1,
+        title: s.solution?.title || s.title || `Spot ${idx + 1}`,
+      }));
+      return { detectedSpots: reindexed };
     });
   },
 
@@ -587,7 +621,9 @@ export const getRequestActions = () => {
     setDetectedSpots: state.setDetectedSpots,
     selectSpot: state.selectSpot,
     addSpot: state.addSpot,
+    moveSpot: state.moveSpot,
     removeSpot: state.removeSpot,
+    restoreSpot: state.restoreSpot,
     setSpotSolution: state.setSpotSolution,
     clearSpotSolution: state.clearSpotSolution,
     setDescription: state.setDescription,


### PR DESCRIPTION
## Summary
#145 QA에서 확인된 Spot UX 두 가지 공백 해소.

### 1. Spot 드래그 재배치
- 기존: 마커를 drag → 새 spot이 추가되어 기존 위치 수정 불가
- Hotspot에 pointer capture + 4px drag threshold 적용
  - threshold 미만: 기존 click 동작(spot 선택) 유지
  - threshold 이상: normalized (0-1) 좌표로 `moveSpot` 호출 (live update)
  - 드래그 종료 시 synthetic click 억제 → 클릭-투-추가 오버레이가 새 spot 생성하지 않음
- 신규 store action: `moveSpot(spotId, x, y)` (clamp 포함)

### 2. 삭제 Undo 토스트
- 기존: 🗑 클릭 → 즉시 삭제, solution/link 입력 데이터 복구 불가
- 삭제 시 spot snapshot(solution 포함)을 캡처하고 Sonner toast 5초간 노출
- Undo 클릭 시 `restoreSpot(snapshot, originalIndex)` 호출해 원래 슬롯 복원, index 재계산
- 신규 store action: `restoreSpot(spot, atIndex?)` (duplicate reject, re-indexing)

## 완료 기준 (#291)
- [x] 기존 spot 마커 드래그로 위치 이동 가능
- [x] 드래그 중 새 spot 추가되지 않음
- [x] 삭제 시 Undo 토스트 노출 (5초)
- [x] Undo 시 spot + 입력 데이터 복원
- [ ] Playwright E2E 추가 — follow-up (현재 유닛/컴포넌트 테스트 7건 추가)

## Test plan
- [x] `bun run test` → 171 passed (신규 7건 포함)
- [x] `bun run typecheck` → exit 0
- [ ] 수동 QA:
  - [ ] 스팟 drag하여 위치 변경 (터치/마우스)
  - [ ] 짧은 tap은 여전히 select로 동작
  - [ ] 삭제 → 토스트 Undo 클릭 → 복원 확인 (solution 데이터 포함)
  - [ ] 토스트 타임아웃 후 복원 불가 동작

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)