### PR TITLE
fix(upload): show image preview on the fork screen (#295)

### DIFF
--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -218,10 +218,11 @@ export function UploadFlowSteps() {
             >
               <Image
                 src={localImage.previewUrl}
-                alt={localImage.file.name}
+                alt={`Uploaded image preview: ${localImage.file.name}`}
                 fill
                 className="object-cover"
                 sizes="(max-width: 640px) 220px, 320px"
+                priority
               />
             </div>
             <p className="text-lg font-medium text-center">

--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import Image from "next/image";
 import { toast } from "sonner";
 import {
   useRequestStore,
@@ -209,8 +210,20 @@ export function UploadFlowSteps() {
         {localImage && userKnowsItems === null && (
           <div
             data-testid="upload-flow-fork"
-            className="flex-1 flex flex-col items-center justify-center max-w-md mx-auto w-full space-y-8 py-12"
+            className="flex-1 flex flex-col items-center justify-center max-w-md mx-auto w-full space-y-6 py-8"
           >
+            <div
+              data-testid="upload-flow-fork-preview"
+              className="relative w-full aspect-[3/4] max-w-[220px] sm:max-w-xs rounded-xl overflow-hidden bg-foreground/5"
+            >
+              <Image
+                src={localImage.previewUrl}
+                alt={localImage.file.name}
+                fill
+                className="object-cover"
+                sizes="(max-width: 640px) 220px, 320px"
+              />
+            </div>
             <p className="text-lg font-medium text-center">
               Do you know the items in this photo?
             </p>

--- a/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
+++ b/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
@@ -72,11 +72,16 @@ describe("UploadFlowSteps — step branches", () => {
 
     const preview = screen.getByTestId("upload-flow-fork-preview");
     expect(preview).toBeInTheDocument();
-    // next/image renders an <img> with the previewUrl as src and the file
-    // name as alt text so screen readers and users both get context.
     const imgEl = preview.querySelector("img");
     expect(imgEl).not.toBeNull();
-    expect(imgEl?.getAttribute("alt")).toBe("outfit.jpg");
+    // Screen readers should announce this as an uploaded preview, not
+    // just the raw (often cryptic) filename.
+    expect(imgEl?.getAttribute("alt")).toBe(
+      "Uploaded image preview: outfit.jpg"
+    );
+    // Loader may wrap the URL, but the mocked previewUrl token must be
+    // referenced so the rendered <img> reflects the uploaded file.
+    expect(imgEl?.getAttribute("src")).toContain(img.previewUrl);
   });
 });
 

--- a/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
+++ b/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
@@ -62,6 +62,22 @@ describe("UploadFlowSteps — step branches", () => {
     render(<UploadFlowSteps />);
     expect(screen.getByTestId("upload-flow-fork")).toBeInTheDocument();
   });
+
+  test("fork screen shows an image preview so users can confirm the upload (#295)", () => {
+    const file = new File(["x"], "outfit.jpg", { type: "image/jpeg" });
+    getRequestActions().addImage(file);
+    const img = useRequestStore.getState().images[0];
+    getRequestActions().setImageUploadedUrl(img.id, "data:x");
+    render(<UploadFlowSteps />);
+
+    const preview = screen.getByTestId("upload-flow-fork-preview");
+    expect(preview).toBeInTheDocument();
+    // next/image renders an <img> with the previewUrl as src and the file
+    // name as alt text so screen readers and users both get context.
+    const imgEl = preview.querySelector("img");
+    expect(imgEl).not.toBeNull();
+    expect(imgEl?.getAttribute("alt")).toBe("outfit.jpg");
+  });
 });
 
 describe("UploadFlowSteps — step indicator progression", () => {


### PR DESCRIPTION
## Summary
업로드 직후 "Do you know the items?" 분기 화면에 이미지 preview가 없어 사용자가 올바른 파일을 올렸는지 확인할 방법이 없던 문제 수정.

- 분기 섹션 상단에 `aspect-[3/4]` 고정 비율 preview 추가 (`localImage.previewUrl` + `next/image fill`)
- 모바일: `max-w-[220px]`, sm+: `max-w-xs(320px)` — `SingleImagePreview`/`DetectionView`와 동일한 3:4 비율로 시각 일관성 유지
- `data-testid="upload-flow-fork-preview"` 추가로 E2E/유닛 훅

## 완료 기준 (#295)
- [x] 분기 화면에 업로드한 이미지 preview 노출
- [x] 모바일 viewport에서도 적절한 크기로 표시 (220px cap)
- [ ] 시각 회귀 스냅샷 업데이트 — 프로젝트에 visual regression 인프라가 아직 없어 후속 작업 대상
- [x] 유닛 테스트 추가 (fork-preview testid + alt 확인)

## Test plan
- [x] `bun run test` → 8 passed (UploadFlowSteps suite)
- [x] `bun run typecheck` → exit 0
- [ ] 수동 QA:
  - [ ] 데스크탑에서 분기 화면 이미지 잘림 없이 표시
  - [ ] 모바일 viewport에서 preview가 버튼 밀어내지 않음
  - [ ] 다양한 비율 이미지 (1:1, 16:9, 3:4, 4:3) 업로드 시 object-cover 동작

## Follow-ups
- 이슈에서 언급된 Back 버튼(이미지 다시 고르기)은 별개 이슈로 남겨둠

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)