### PR TITLE
feat(upload): expand Context picker to full 12-option ContextSelector (#292 Part A)

### DIFF
--- a/packages/web/lib/components/request/MetadataInputForm.tsx
+++ b/packages/web/lib/components/request/MetadataInputForm.tsx
@@ -2,6 +2,7 @@
 
 import { memo } from "react";
 import type { ContextType, MediaSourceType } from "@/lib/api/mutation-types";
+import { ContextSelector } from "@/lib/components/request/ContextSelector";
 
 const MEDIA_TYPES = [
   { value: "user_upload", label: "Direct upload" },
@@ -12,17 +13,6 @@ const MEDIA_TYPES = [
   { value: "event", label: "Event" },
   { value: "other", label: "Other" },
 ] as const;
-
-const CONTEXT_OPTIONS: { value: ContextType; label: string }[] = [
-  { value: "airport", label: "Airport" },
-  { value: "stage", label: "Stage" },
-  { value: "drama", label: "TV Drama" },
-  { value: "variety", label: "Variety Show" },
-  { value: "daily", label: "Daily" },
-  { value: "photoshoot", label: "Editorial" },
-  { value: "event", label: "Event" },
-  { value: "other", label: "Other" },
-];
 
 // Helper text + dynamic placeholders ported verbatim from PR #230
 // (ArtistInput.tsx, MediaSourceInput.tsx).
@@ -159,28 +149,13 @@ export const MetadataInputForm = memo(
           />
         </div>
 
-        {/* Context */}
-        <div className="space-y-1">
-          <label className="text-xs text-muted-foreground">Context</label>
-          <select
-            value={values.context ?? ""}
-            onChange={(e) =>
-              onChange({
-                ...values,
-                context: (e.target.value || null) as ContextType | null,
-              })
-            }
-            className="w-full px-3 py-2 text-sm bg-background border border-border rounded-lg
-                       focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary"
-          >
-            <option value="">Not specified</option>
-            {CONTEXT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        {/* Context — delegated to ContextSelector so the full 12-option
+            set stays in one place. Clicking the selected chip toggles back
+            to null, which preserves the "Not specified" empty state. */}
+        <ContextSelector
+          value={values.context}
+          onChange={(next) => onChange({ ...values, context: next })}
+        />
       </div>
     );
   }

--- a/packages/web/lib/components/request/__tests__/MetadataInputForm.helperText.test.tsx
+++ b/packages/web/lib/components/request/__tests__/MetadataInputForm.helperText.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { describe, test, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import {
   MetadataInputForm,
@@ -85,5 +85,56 @@ describe("MetadataInputForm — helper text + dynamic placeholder (ported from P
     expect(
       screen.getByPlaceholderText("e.g., 2024 Met Gala, Coachella")
     ).toBeInTheDocument();
+  });
+});
+
+describe("MetadataInputForm — context picker (#292 Part A)", () => {
+  afterEach(() => cleanup());
+
+  const expectedLabels = [
+    "Daily",
+    "Street",
+    "Airport",
+    "Stage",
+    "Photoshoot",
+    "Campaign",
+    "Event",
+    "Drama",
+    "Variety",
+    "SNS",
+    "Fan Meeting",
+    "Interview",
+  ];
+
+  test("renders all 12 context chips including the newly added options", () => {
+    renderForm();
+    for (const label of expectedLabels) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(label, "i") })
+      ).toBeInTheDocument();
+    }
+  });
+
+  test("clicking a chip emits the value through onChange", () => {
+    const onChange = vi.fn();
+    render(<MetadataInputForm values={baseValues} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /street/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ context: "street" })
+    );
+  });
+
+  test("clicking the already-selected chip toggles the value back to null", () => {
+    const onChange = vi.fn();
+    render(
+      <MetadataInputForm
+        values={{ ...baseValues, context: "airport" }}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /airport/i }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ context: null })
+    );
   });
 });


### PR DESCRIPTION
## Summary
#292 "ContextSelector 다중 선택 + 옵션 보강"을 **2단계로 분할** 후 첫 번째 단계 (FE-only, 옵션 보강)만 이 PR에서 다룹니다.

### 발견 (2026-04-23 audit)
- `MetadataInputForm.tsx`의 Context `<select>`는 옛 8-option 목록을 별도로 보유 (QA에서 누락 옵션 지적)
- 반면 **`ContextSelector.tsx` 컴포넌트는 이미 canonical 12-option chip UI를 제공**하고, 생성된 `ContextType` union과도 일치
- 즉, 소스 of truth 중복 → 한 쪽(ContextSelector)로 합치면 BE 변경 없이 누락 옵션 해소

### 변경
- `MetadataInputForm.tsx`의 Context 블록을 `<ContextSelector value onChange>` delegation으로 교체
- 로컬 `CONTEXT_OPTIONS` 배열 제거 (드리프트 방지)
- "Not specified" 빈 상태는 ContextSelector의 토글 동작 (선택된 칩 재클릭 → null)으로 유지

### 범위 외 (별도 이슈로 tracking)
- Multi-select (여러 context 저장) — DB `posts.context varchar(50)` → `text[]` / 별도 테이블, Rust DTO `Option<String>` → `Vec<String>`, `spawn_extract_post_context()` 경로, 인덱스, read-side 카드/필터, 데이터 백필까지 전부 필요. 백엔드 팀 합의 필요. 별도 이슈 생성 예정.

## 완료 기준 (Part A)
- [x] MetadataInputForm에서 12개 옵션 전부 노출 (Street, Photoshoot, Campaign, SNS, Fan Meeting, Interview 포함)
- [x] 단일 값 선택/해제 동작
- [x] `ContextType` 타입 일관성 유지 (generated union과 매칭)
- [x] 유닛 테스트 3건 추가 (옵션 렌더 / 선택 / 토글 off)

## Test plan
- [x] `bun run test lib/components/request/__tests__/MetadataInputForm.helperText.test.tsx` → 11 passed
- [x] `bun run typecheck` → exit 0
- [ ] 수동 QA:
  - [ ] Details 단계에서 12개 chip 표시 확인
  - [ ] 선택 / 해제 동작
  - [ ] 제출 payload에 선택값 그대로 전송되는지 (기존 단일 문자열 계약 유지)

Refs #292 (Part B 후속 이슈 별도 생성 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)