### PR TITLE
feat(upload): #306 upload UX polish — Back, spot counter, disabled hint

### DIFF
--- a/packages/web/lib/components/request/DiscardProgressDialog.tsx
+++ b/packages/web/lib/components/request/DiscardProgressDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface Props {
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DiscardProgressDialog({ open, onCancel, onConfirm }: Props) {
+  const ref = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    if (open && !el.open) el.showModal();
+    if (!open && el.open) el.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      onCancel={(e) => {
+        e.preventDefault();
+        onCancel();
+      }}
+      onKeyDown={(e) => {
+        // RequestFlowModal.tsx의 window keydown 구독이 Esc에 반응하므로,
+        // 다이얼로그 내부 Esc가 바깥으로 전파되면 외부 모달까지 닫힘. 차단 필수.
+        if (e.key === "Escape") e.stopPropagation();
+      }}
+      className="w-[min(22rem,92vw)] rounded-xl bg-background p-6 shadow-xl backdrop:bg-black/50"
+    >
+      <h2 className="text-lg font-semibold">Discard progress?</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        You&rsquo;ll lose spots and details you&rsquo;ve added so far.
+      </p>
+      <div className="mt-6 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-sm rounded-lg hover:bg-muted"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          className="px-4 py-2 text-sm rounded-lg bg-destructive text-destructive-foreground hover:bg-destructive/90"
+        >
+          Discard and go back
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -14,6 +14,7 @@ import {
   selectArtistName,
   selectGroupName,
   selectContext,
+  selectHasInProgressWork,
   type DetectedSpot,
   type SpotSolutionData,
 } from "@/lib/stores/requestStore";
@@ -29,7 +30,16 @@ import {
   type MetadataFormValues,
 } from "@/lib/components/request/MetadataInputForm";
 import { ImageEditor } from "@/lib/components/request/ImageEditor";
-import { Trash2, Plus, Loader2, RefreshCw, Crop } from "lucide-react";
+import { DiscardProgressDialog } from "@/lib/components/request/DiscardProgressDialog";
+import { clearDraft } from "@/lib/utils/offlineDraft";
+import {
+  Trash2,
+  Plus,
+  Loader2,
+  RefreshCw,
+  Crop,
+  ArrowLeft,
+} from "lucide-react";
 
 /**
  * Renders the full step-switch UI for the upload request flow.
@@ -78,6 +88,32 @@ export function UploadFlowSteps() {
       : hasImages && userKnowsItems !== null
         ? 2
         : 1;
+
+  const hasInProgressWork = useRequestStore(selectHasInProgressWork);
+  const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+
+  // Back button 노출/활성화
+  const anyImageUploading = images.some((img) => img.status === "uploading");
+  const showBackButton = currentStep === 2 || currentStep === 3;
+  const backDisabled = anyImageUploading;
+
+  const performBack = useCallback(() => {
+    if (currentStep === 3) {
+      getRequestActions().backToFork();
+    } else if (currentStep === 2) {
+      getRequestActions().backToUpload();
+    }
+    // 어떤 경로든 draft는 의미 없어짐
+    clearDraft();
+  }, [currentStep]);
+
+  const handleBackClick = useCallback(() => {
+    if (currentStep === 3 && hasInProgressWork) {
+      setShowDiscardDialog(true);
+      return;
+    }
+    performBack();
+  }, [currentStep, hasInProgressWork, performBack]);
 
   const handleUserTypeSelect = useCallback((knows: boolean) => {
     getRequestActions().setUserKnowsItems(knows);
@@ -181,7 +217,18 @@ export function UploadFlowSteps() {
   const localImage = images[0];
 
   return (
-    <div data-testid="upload-flow-steps">
+    <div data-testid="upload-flow-steps" className="relative">
+      {showBackButton && (
+        <button
+          type="button"
+          onClick={handleBackClick}
+          disabled={backDisabled}
+          aria-label="Go back"
+          className="absolute top-4 left-4 z-20 rounded-full p-2 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </button>
+      )}
       <main className="flex-1 min-h-0 flex flex-col px-4 py-4 md:py-6">
         <StepProgress currentStep={currentStep} className="py-4" />
 
@@ -435,6 +482,15 @@ export function UploadFlowSteps() {
           onCancel={() => setShowEditor(false)}
         />
       )}
+
+      <DiscardProgressDialog
+        open={showDiscardDialog}
+        onCancel={() => setShowDiscardDialog(false)}
+        onConfirm={() => {
+          setShowDiscardDialog(false);
+          performBack();
+        }}
+      />
     </div>
   );
 }

--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -15,8 +15,10 @@ import {
   selectGroupName,
   selectContext,
   selectHasInProgressWork,
+  selectDisabledReason,
   type DetectedSpot,
   type SpotSolutionData,
+  type DisabledReason,
 } from "@/lib/stores/requestStore";
 import { useImageUpload } from "@/lib/hooks/useImageUpload";
 import { useUploadFlow } from "./useUploadFlow";
@@ -91,7 +93,24 @@ export function UploadFlowSteps() {
         : 1;
 
   const hasInProgressWork = useRequestStore(selectHasInProgressWork);
+  const disabledReason = useRequestStore(selectDisabledReason);
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+
+  const disabledReasonCopy = (r: DisabledReason): string | null => {
+    switch (r) {
+      case "need_image":
+        return "Upload an image";
+      case "need_fork_choice":
+        return "Choose how you'll add info";
+      case "need_spot":
+        return "Tap the image to add at least 1 spot";
+      case "need_solution":
+        return "Add a link and title for each spot";
+      case "submitting":
+      case null:
+        return null;
+    }
+  };
 
   // Back button 노출/활성화
   const anyImageUploading = images.some((img) => img.status === "uploading");
@@ -448,40 +467,68 @@ export function UploadFlowSteps() {
               </div>
             </div>
 
-            <div className="flex items-center justify-end gap-3 pt-4 border-t border-border flex-shrink-0">
-              {flow.submitError && (
-                <div className="flex items-center gap-2 mr-auto">
-                  <p className="text-sm text-destructive">{flow.submitError}</p>
-                  <button
-                    type="button"
-                    onClick={handleSubmit}
-                    disabled={flow.isSubmitting}
-                    className="px-3 py-1.5 text-sm bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors flex items-center gap-1.5"
-                  >
-                    <RefreshCw className="w-3.5 h-3.5" />
-                    Retry
-                  </button>
-                </div>
+            <div
+              className="flex flex-col gap-2 pt-4 border-t border-border flex-shrink-0"
+              style={{
+                paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))",
+              }}
+            >
+              {disabledReasonCopy(disabledReason) && (
+                <p
+                  id="post-disabled-reason"
+                  className="text-xs text-muted-foreground"
+                >
+                  {disabledReasonCopy(disabledReason)}
+                </p>
               )}
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={!canProceed}
-                className={`
-                  px-6 py-2.5 rounded-lg font-medium transition-all
-                  flex items-center gap-2
-                  ${
-                    canProceed
-                      ? "bg-foreground text-background hover:bg-foreground/90"
-                      : "bg-foreground/20 text-foreground/40 cursor-not-allowed"
-                  }
-                `}
-              >
-                {flow.isSubmitting && (
-                  <Loader2 className="w-4 h-4 animate-spin" />
+              <div className="flex items-center justify-end gap-3">
+                {flow.submitError && (
+                  <div className="flex items-center gap-2 mr-auto">
+                    <p className="text-sm text-destructive">
+                      {flow.submitError}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleSubmit}
+                      disabled={flow.isSubmitting}
+                      className="px-3 py-1.5 text-sm bg-destructive text-destructive-foreground rounded-lg hover:bg-destructive/90 transition-colors flex items-center gap-1.5"
+                    >
+                      <RefreshCw className="w-3.5 h-3.5" />
+                      Retry
+                    </button>
+                  </div>
                 )}
-                {flow.isSubmitting ? "Posting..." : "Post"}
-              </button>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={!canProceed}
+                  aria-describedby={
+                    disabledReason && disabledReason !== "submitting"
+                      ? "post-disabled-reason"
+                      : undefined
+                  }
+                  className={`
+                    px-6 py-2.5 rounded-lg font-medium transition-all
+                    flex items-center gap-2
+                    ${
+                      canProceed
+                        ? "bg-foreground text-background hover:bg-foreground/90"
+                        : "bg-foreground/20 text-foreground/40 cursor-not-allowed"
+                    }
+                  `}
+                >
+                  {flow.isSubmitting && (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  )}
+                  {flow.isSubmitting ? "Posting..." : "Post"}
+                  {detectedSpots.length > 0 && !flow.isSubmitting && (
+                    <span className="ml-1 opacity-80">
+                      · {detectedSpots.length}{" "}
+                      {detectedSpots.length === 1 ? "spot" : "spots"}
+                    </span>
+                  )}
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/components/request/MetadataInputForm";
 import { ImageEditor } from "@/lib/components/request/ImageEditor";
 import { DiscardProgressDialog } from "@/lib/components/request/DiscardProgressDialog";
+import { RECOMMENDED_SPOT_COUNT } from "@/lib/components/request/constants";
 import { clearDraft } from "@/lib/utils/offlineDraft";
 import {
   Trash2,
@@ -330,18 +331,30 @@ export function UploadFlowSteps() {
               {/* Spot list + Metadata panel */}
               <div className="w-full md:w-80 flex-shrink-0 overflow-y-auto space-y-4">
                 <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-medium">
-                      Spots ({detectedSpots.length})
-                    </h3>
-                    {detectedSpots.length > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        {userKnowsItems
-                          ? "Tap a spot to add a link"
-                          : "Curious locations marked"}
-                      </p>
-                    )}
-                  </div>
+                  {detectedSpots.length >= 1 && (
+                    <div className="flex flex-col gap-1">
+                      <div className="text-sm font-medium text-foreground">
+                        <span className="tabular-nums">
+                          Spots {detectedSpots.length}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {" "}
+                          / {RECOMMENDED_SPOT_COUNT}
+                        </span>
+                      </div>
+                      {detectedSpots.length < RECOMMENDED_SPOT_COUNT && (
+                        <p className="text-xs text-muted-foreground">
+                          Tap image to add more, or drag to reposition
+                        </p>
+                      )}
+                      {detectedSpots.length === RECOMMENDED_SPOT_COUNT && (
+                        <p className="text-xs text-muted-foreground">
+                          Nice. Add more if needed.
+                        </p>
+                      )}
+                      {/* count > RECOMMENDED_SPOT_COUNT: no subtext (intentional, per spec) */}
+                    </div>
+                  )}
 
                   {detectedSpots.length === 0 && (
                     <div className="py-8 text-center space-y-2">

--- a/packages/web/lib/components/request/constants.ts
+++ b/packages/web/lib/components/request/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Shared constants for the request/upload flow.
+ */
+export const RECOMMENDED_SPOT_COUNT = 3;

--- a/packages/web/lib/stores/requestStore.ts
+++ b/packages/web/lib/stores/requestStore.ts
@@ -22,6 +22,14 @@ import {
 export type UploadStatus = "pending" | "uploading" | "uploaded" | "error";
 export type RequestStep = 1 | 2 | 3;
 
+export type DisabledReason =
+  | "need_image"
+  | "need_fork_choice"
+  | "need_spot"
+  | "need_solution"
+  | "submitting"
+  | null;
+
 export interface UploadedImage {
   id: string;
   file: File;
@@ -152,6 +160,14 @@ interface RequestState {
   // Actions - Navigation
   setStep: (step: RequestStep) => void;
   canProceedToNextStep: () => boolean;
+
+  // Actions - Back navigation
+  backToFork: () => void;
+  backToUpload: () => void;
+
+  // Selectors
+  hasInProgressWork: () => boolean;
+  disabledReason: () => DisabledReason;
 
   // Actions - Reset
   resetRequestFlow: () => void;
@@ -518,6 +534,52 @@ export const useRequestStore = create<RequestState>((set, get) => ({
     }
   },
 
+  backToFork: () => {
+    set({
+      detectedSpots: [],
+      selectedSpotId: null,
+      mediaSource: { type: "user_upload", title: "" },
+      groupName: "",
+      artistName: "",
+      context: null,
+    });
+  },
+
+  backToUpload: () => {
+    const { images } = get();
+    images.forEach((img) => revokePreviewUrl(img.previewUrl));
+    set({
+      images: [],
+      userKnowsItems: null,
+    });
+  },
+
+  hasInProgressWork: () => {
+    const { detectedSpots, mediaSource, context, artistName } = get();
+    return (
+      detectedSpots.length > 0 ||
+      !!mediaSource?.title?.trim() ||
+      context !== null ||
+      !!artistName?.trim()
+    );
+  },
+
+  disabledReason: () => {
+    const { images, userKnowsItems, detectedSpots, isSubmitting } = get();
+    if (isSubmitting) return "submitting";
+    const hasUploaded = images.some((img) => img.status === "uploaded");
+    if (!hasUploaded) return "need_image";
+    if (userKnowsItems === null) return "need_fork_choice";
+    if (detectedSpots.length === 0) return "need_spot";
+    if (
+      userKnowsItems === true &&
+      !detectedSpots.every((s) => s.solution?.originalUrl && s.solution?.title)
+    ) {
+      return "need_solution";
+    }
+    return null;
+  },
+
   resetRequestFlow: () => {
     const { images } = get();
     images.forEach((img) => revokePreviewUrl(img.previewUrl));
@@ -604,6 +666,13 @@ export const selectContext = (state: RequestState) => state.context;
 export const selectIsSubmitting = (state: RequestState) => state.isSubmitting;
 export const selectSubmitError = (state: RequestState) => state.submitError;
 
+// Back navigation selectors
+export const selectHasInProgressWork = (state: RequestState): boolean =>
+  state.hasInProgressWork();
+
+export const selectDisabledReason = (state: RequestState): DisabledReason =>
+  state.disabledReason();
+
 /**
  * Action들을 렌더링 없이 직접 접근
  * 컴포넌트에서 action만 필요할 때 사용 (구독 없음)
@@ -638,5 +707,7 @@ export const getRequestActions = () => {
     setStep: state.setStep,
     resetRequestFlow: state.resetRequestFlow,
     setUserKnowsItems: state.setUserKnowsItems,
+    backToFork: state.backToFork,
+    backToUpload: state.backToUpload,
   };
 };

--- a/packages/web/tests/DiscardProgressDialog.test.tsx
+++ b/packages/web/tests/DiscardProgressDialog.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { describe, test, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { DiscardProgressDialog } from "@/lib/components/request/DiscardProgressDialog";
+
+// jsdom은 HTMLDialogElement.showModal을 구현하지 않음 — 폴리필
+function polyfillDialog() {
+  if (!HTMLDialogElement.prototype.showModal) {
+    HTMLDialogElement.prototype.showModal = function () {
+      this.setAttribute("open", "");
+    };
+    HTMLDialogElement.prototype.close = function () {
+      this.removeAttribute("open");
+    };
+  }
+}
+
+describe("DiscardProgressDialog", () => {
+  test("renders when open=true", () => {
+    polyfillDialog();
+    render(
+      <DiscardProgressDialog open onCancel={vi.fn()} onConfirm={vi.fn()} />
+    );
+    expect(screen.getByText("Discard progress?")).toBeInTheDocument();
+  });
+
+  test("calls onCancel when Cancel button clicked", () => {
+    polyfillDialog();
+    const onCancel = vi.fn();
+    render(
+      <DiscardProgressDialog open onCancel={onCancel} onConfirm={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("calls onConfirm when Discard button clicked", () => {
+    polyfillDialog();
+    const onConfirm = vi.fn();
+    render(
+      <DiscardProgressDialog open onCancel={vi.fn()} onConfirm={onConfirm} />
+    );
+    fireEvent.click(screen.getByText("Discard and go back"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape keydown inside dialog stops propagation", () => {
+    polyfillDialog();
+    const outerHandler = vi.fn();
+    window.addEventListener("keydown", outerHandler);
+    render(
+      <DiscardProgressDialog open onCancel={vi.fn()} onConfirm={vi.fn()} />
+    );
+    const dialog = document.querySelector("dialog");
+    fireEvent.keyDown(dialog!, { key: "Escape" });
+    expect(outerHandler).not.toHaveBeenCalled();
+    window.removeEventListener("keydown", outerHandler);
+  });
+});

--- a/packages/web/tests/requestStore-back-navigation.test.ts
+++ b/packages/web/tests/requestStore-back-navigation.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, test, expect, beforeEach, vi } from "vitest";
+import { useRequestStore } from "@/lib/stores/requestStore";
+
+vi.mock("@/lib/utils/imageCompression", () => ({
+  createPreviewUrl: vi.fn(() => "blob:mock"),
+  revokePreviewUrl: vi.fn(),
+}));
+
+describe("requestStore — back navigation", () => {
+  beforeEach(() => {
+    useRequestStore.getState().resetRequestFlow();
+  });
+
+  describe("backToFork", () => {
+    test("clears detectedSpots and metadata, preserves images and userKnowsItems", () => {
+      // Arrange: Step 3 state (image + fork choice + spots + metadata)
+      useRequestStore.setState({
+        images: [
+          {
+            id: "img1",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:mock",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+        userKnowsItems: true,
+        detectedSpots: [
+          {
+            id: "s1",
+            index: 1,
+            center: { x: 0.5, y: 0.5 },
+            title: "TOP",
+            description: "",
+          },
+        ],
+        selectedSpotId: "s1",
+        mediaSource: { type: "drama", title: "My Drama" },
+        groupName: "G",
+        artistName: "A",
+        context: "airport",
+      });
+
+      // Act
+      useRequestStore.getState().backToFork();
+
+      // Assert
+      const s = useRequestStore.getState();
+      expect(s.detectedSpots).toEqual([]);
+      expect(s.selectedSpotId).toBeNull();
+      expect(s.mediaSource).toEqual({ type: "user_upload", title: "" });
+      expect(s.groupName).toBe("");
+      expect(s.artistName).toBe("");
+      expect(s.context).toBeNull();
+      // Preserved:
+      expect(s.images.length).toBe(1);
+      expect(s.userKnowsItems).toBe(true);
+    });
+  });
+
+  describe("backToUpload", () => {
+    test("clears images and userKnowsItems, revokes preview URLs", async () => {
+      const { revokePreviewUrl } = await import("@/lib/utils/imageCompression");
+      (revokePreviewUrl as ReturnType<typeof vi.fn>).mockClear();
+
+      useRequestStore.setState({
+        images: [
+          {
+            id: "img1",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:foo",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+        userKnowsItems: false,
+      });
+
+      useRequestStore.getState().backToUpload();
+
+      const s = useRequestStore.getState();
+      expect(s.images).toEqual([]);
+      expect(s.userKnowsItems).toBeNull();
+      expect(revokePreviewUrl).toHaveBeenCalledWith("blob:foo");
+    });
+  });
+
+  describe("hasInProgressWork selector", () => {
+    test("false when only userKnowsItems is set", () => {
+      useRequestStore.setState({ userKnowsItems: true });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(false);
+    });
+
+    test("true when detectedSpots has at least one item", () => {
+      useRequestStore.setState({
+        detectedSpots: [
+          {
+            id: "s1",
+            index: 1,
+            center: { x: 0.5, y: 0.5 },
+            title: "",
+            description: "",
+          },
+        ],
+      });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(true);
+    });
+
+    test("true when context is set", () => {
+      useRequestStore.setState({ context: "airport" });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(true);
+    });
+
+    test("false when mediaSource.title is whitespace only", () => {
+      useRequestStore.setState({
+        mediaSource: { type: "drama", title: "   " },
+      });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(false);
+    });
+
+    test("true when mediaSource.title is non-empty", () => {
+      useRequestStore.setState({
+        mediaSource: { type: "drama", title: "Hi" },
+      });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(true);
+    });
+
+    test("true when artistName is non-empty", () => {
+      useRequestStore.setState({ artistName: "A" });
+      expect(useRequestStore.getState().hasInProgressWork()).toBe(true);
+    });
+  });
+
+  describe("disabledReason selector", () => {
+    test("need_image when no uploaded image", () => {
+      expect(useRequestStore.getState().disabledReason()).toBe("need_image");
+    });
+
+    test("need_fork_choice when image uploaded but userKnowsItems=null", () => {
+      useRequestStore.setState({
+        images: [
+          {
+            id: "i",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:m",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+      });
+      expect(useRequestStore.getState().disabledReason()).toBe(
+        "need_fork_choice"
+      );
+    });
+
+    test("need_spot when fork chosen but no spots", () => {
+      useRequestStore.setState({
+        images: [
+          {
+            id: "i",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:m",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+        userKnowsItems: false,
+      });
+      expect(useRequestStore.getState().disabledReason()).toBe("need_spot");
+    });
+
+    test("need_solution when userKnowsItems=true but spots lack solution", () => {
+      useRequestStore.setState({
+        images: [
+          {
+            id: "i",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:m",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+        userKnowsItems: true,
+        detectedSpots: [
+          {
+            id: "s",
+            index: 1,
+            center: { x: 0.5, y: 0.5 },
+            title: "",
+            description: "",
+          },
+        ],
+      });
+      expect(useRequestStore.getState().disabledReason()).toBe("need_solution");
+    });
+
+    test("null when userKnowsItems=false and spots > 0", () => {
+      useRequestStore.setState({
+        images: [
+          {
+            id: "i",
+            file: new File([], "a.jpg"),
+            previewUrl: "blob:m",
+            status: "uploaded",
+            progress: 100,
+          },
+        ],
+        userKnowsItems: false,
+        detectedSpots: [
+          {
+            id: "s",
+            index: 1,
+            center: { x: 0.5, y: 0.5 },
+            title: "",
+            description: "",
+          },
+        ],
+      });
+      expect(useRequestStore.getState().disabledReason()).toBeNull();
+    });
+
+    test("submitting when isSubmitting=true", () => {
+      useRequestStore.setState({ isSubmitting: true });
+      expect(useRequestStore.getState().disabledReason()).toBe("submitting");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

#306 업로드 모달 UX 개선 3종을 한 번에 반영. 모두 `packages/web/lib/components/request/UploadFlowSteps.tsx`와 `requestStore.ts` 주변으로 범위 제한.

### Part A — Back 버튼 + Discard confirm
- `selectHasInProgressWork`, `selectDisabledReason`, `backToFork`, `backToUpload`를 `requestStore`에 단일 진실 공급원으로 추가 (`DisabledReason` enum 포함)
- `DiscardProgressDialog` (native `<dialog>`) 신규. `onKeyDown.stopPropagation`으로 외부 `RequestFlowModal`의 window Esc 리스너까지 Esc가 전파되지 않도록 차단
- Step 2/3에서 상단 좌측 Back 버튼 노출. Step 2 → Step 1은 즉시, Step 3 → fork는 진행 중 작업이 있으면 confirm 후 전이. 확정 시 `clearDraft()` 호출하여 리로드 복원 방지

### Part B — Spot 카운터/가이드
- `constants.ts` 신설, `RECOMMENDED_SPOT_COUNT = 3`
- Sidebar Spot 헤더를 `Spots N / 3` + 상태별 subtext(권장/만족/초과 무 subtext)로 교체

### Part C — Submit 영역
- `disabledReason` 셀렉터 기반 4가지 inline 힌트 (`need_image`, `need_fork_choice`, `need_spot`, `need_solution`)
- `aria-describedby`로 스크린 리더 연결
- Post 라벨에 `· N spot[s]` 배지
- Footer `paddingBottom: max(0.75rem, env(safe-area-inset-bottom))`로 iOS 하단 간섭 방지

### Spec 편차
Spec의 `DisabledReason.need_media_title`은 제외했습니다. 현재 `canProceed` 규칙(`UploadFlowSteps.tsx:62-69`)은 `userKnowsItems===false`일 때 `mediaSource.title`을 요구하지 않으므로 발생 불가한 상태입니다. 플랜 헤더에도 명시되어 있습니다.

### Notes on plan execution
Plan은 PR 3개 분할을 제안했지만 세 파트 모두 동일 브랜치의 `UploadFlowSteps.tsx`를 건드리기 때문에 stacked branch 없이는 3 PR로 분할이 불가능하여, 리뷰 편의를 위해 A/B/C를 섹션 구분하되 단일 PR로 제출합니다.

## Test plan
- [x] `bun run test:unit` — 194 passed (requestStore-back-navigation 14개 + DiscardProgressDialog 4개 포함)
- [x] `bunx tsc --noEmit` — 변경 파일에서 새 오류 없음 (기존 `detail/adapters/...test.ts`의 unrelated TS2322만 잔존)
- [ ] Manual (E2E): `/request/upload` intercept 모달
  - Step 2에서 Back 클릭 → Step 1 복귀, 이미지 제거 확인
  - Step 3에서 spot 추가 후 Back 클릭 → Discard confirm 표시, Cancel 시 상태 유지
  - Discard 확정 → spots/metadata 제거되고 이미지/fork 보존, reload 시 draft 복원 토스트 없음
  - DiscardProgressDialog 내부 Esc → 외부 모달 닫히지 않음
  - Post 버튼 disabled 시 이유 힌트 표시 (4 케이스) + `aria-describedby` 연결 확인
  - iOS safe-area 하단 inset 확인 (프리뷰 배포 또는 devtools 시뮬)
- [ ] Plan Task 6의 Playwright 시나리오(`/tmp/playwright-qa-upload-flow.js` Back/Discard 3종)는 dev 서버 필요로 별도 세션에서 실행 권장

## Refs
- Spec: \`docs/superpowers/specs/2026-04-23-306-upload-ux-polish-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-23-306-upload-ux-polish.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)