### PR TITLE
fix(upload): #306 Back 버튼 fork 화면 + Discard confirm 한 번에 전이

### DIFF
--- a/packages/web/lib/components/request/UploadFlowSteps.tsx
+++ b/packages/web/lib/components/request/UploadFlowSteps.tsx
@@ -114,26 +114,30 @@ export function UploadFlowSteps() {
 
   // Back button 노출/활성화
   const anyImageUploading = images.some((img) => img.status === "uploading");
-  const showBackButton = currentStep === 2 || currentStep === 3;
-  const backDisabled = anyImageUploading;
+  // fork 화면(이미지만 업로드, 분기 미선택)도 포함하기 위해 hasImages 기준으로 노출.
+  const showBackButton = hasImages;
+  const backDisabled = anyImageUploading || flow.isSubmitting;
 
   const performBack = useCallback(() => {
-    if (currentStep === 3) {
-      getRequestActions().backToFork();
-    } else if (currentStep === 2) {
+    // fork 화면(userKnowsItems === null) → DropZone
+    // 스팟 마킹/디테일 → fork 화면 (backToFork가 userKnowsItems까지 클리어)
+    if (userKnowsItems === null) {
       getRequestActions().backToUpload();
+    } else {
+      getRequestActions().backToFork();
     }
     // 어떤 경로든 draft는 의미 없어짐
     clearDraft();
-  }, [currentStep]);
+  }, [userKnowsItems]);
 
   const handleBackClick = useCallback(() => {
-    if (currentStep === 3 && hasInProgressWork) {
+    // 진행 중 작업이 있으면 Discard 확인. fork 화면은 hasInProgressWork=false라 바로 전이.
+    if (hasInProgressWork) {
       setShowDiscardDialog(true);
       return;
     }
     performBack();
-  }, [currentStep, hasInProgressWork, performBack]);
+  }, [hasInProgressWork, performBack]);
 
   const handleUserTypeSelect = useCallback((knows: boolean) => {
     getRequestActions().setUserKnowsItems(knows);

--- a/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
+++ b/packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx
@@ -186,3 +186,76 @@ describe("UploadFlowSteps — spot delete undo (#291)", () => {
     expect(afterUndo.find((s) => s.id === second.id)).toBeDefined();
   });
 });
+
+describe("UploadFlowSteps — Back button (#306)", () => {
+  beforeEach(() => {
+    cleanup();
+    useRequestStore.getState().resetRequestFlow();
+    useRequestStore.getState().setActiveInstance(null);
+    // jsdom doesn't implement HTMLDialogElement.showModal — polyfill for dialog tests
+    if (!HTMLDialogElement.prototype.showModal) {
+      HTMLDialogElement.prototype.showModal = function () {
+        this.setAttribute("open", "");
+      };
+      HTMLDialogElement.prototype.close = function () {
+        this.removeAttribute("open");
+      };
+    }
+  });
+
+  const uploadImage = () => {
+    const file = new File(["x"], "x.jpg", { type: "image/jpeg" });
+    getRequestActions().addImage(file);
+    const img = useRequestStore.getState().images[0];
+    getRequestActions().setImageUploadedUrl(img.id, "data:x");
+  };
+
+  test("fork screen (hasImages && userKnowsItems === null) renders Back button", () => {
+    uploadImage();
+    render(<UploadFlowSteps />);
+    expect(screen.getByTestId("upload-flow-fork")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go back")).toBeInTheDocument();
+  });
+
+  test("clicking Back on fork screen clears image (returns to DropZone)", () => {
+    uploadImage();
+    render(<UploadFlowSteps />);
+    fireEvent.click(screen.getByLabelText("Go back"));
+    const s = useRequestStore.getState();
+    expect(s.images).toEqual([]);
+    expect(s.userKnowsItems).toBeNull();
+  });
+
+  test("Back on Step 2 (spot marking, 0 spots) immediately returns to fork screen", () => {
+    uploadImage();
+    getRequestActions().setUserKnowsItems(false);
+    render(<UploadFlowSteps />);
+    fireEvent.click(screen.getByLabelText("Go back"));
+    const s = useRequestStore.getState();
+    // userKnowsItems cleared → fork 화면으로 가시적 전이
+    expect(s.userKnowsItems).toBeNull();
+    // 이미지는 보존
+    expect(s.images.length).toBe(1);
+  });
+
+  test("Back on Step 3 with spots shows Discard confirm, Confirm transitions to fork screen in one click", () => {
+    uploadImage();
+    getRequestActions().setUserKnowsItems(true);
+    getRequestActions().addSpot(0.5, 0.5);
+    render(<UploadFlowSteps />);
+
+    fireEvent.click(screen.getByLabelText("Go back"));
+    // Dialog가 뜸
+    expect(screen.getByText("Discard progress?")).toBeInTheDocument();
+    // 아직 상태는 변하지 않음
+    expect(useRequestStore.getState().detectedSpots.length).toBe(1);
+    expect(useRequestStore.getState().userKnowsItems).toBe(true);
+
+    // Confirm 클릭 한 번에 spots+userKnowsItems 모두 클리어되어 fork 화면으로 이동
+    fireEvent.click(screen.getByText("Discard and go back"));
+    const s = useRequestStore.getState();
+    expect(s.detectedSpots).toEqual([]);
+    expect(s.userKnowsItems).toBeNull();
+    expect(s.images.length).toBe(1);
+  });
+});

--- a/packages/web/lib/stores/requestStore.ts
+++ b/packages/web/lib/stores/requestStore.ts
@@ -535,6 +535,8 @@ export const useRequestStore = create<RequestState>((set, get) => ({
   },
 
   backToFork: () => {
+    // Step 2/3에서 fork 화면(userKnowsItems === null)으로 가시적 전이.
+    // Confirm 후에도 "같은 화면에 머무는" 느낌을 주지 않기 위해 userKnowsItems까지 클리어한다.
     set({
       detectedSpots: [],
       selectedSpotId: null,
@@ -542,6 +544,7 @@ export const useRequestStore = create<RequestState>((set, get) => ({
       groupName: "",
       artistName: "",
       context: null,
+      userKnowsItems: null,
     });
   },
 

--- a/packages/web/tests/requestStore-back-navigation.test.ts
+++ b/packages/web/tests/requestStore-back-navigation.test.ts
@@ -15,7 +15,7 @@ describe("requestStore — back navigation", () => {
   });
 
   describe("backToFork", () => {
-    test("clears detectedSpots and metadata, preserves images and userKnowsItems", () => {
+    test("clears detectedSpots, metadata and userKnowsItems, preserves images", () => {
       // Arrange: Step 3 state (image + fork choice + spots + metadata)
       useRequestStore.setState({
         images: [
@@ -55,9 +55,10 @@ describe("requestStore — back navigation", () => {
       expect(s.groupName).toBe("");
       expect(s.artistName).toBe("");
       expect(s.context).toBeNull();
+      // userKnowsItems는 이제 클리어되어 fork 화면으로 돌아감
+      expect(s.userKnowsItems).toBeNull();
       // Preserved:
       expect(s.images.length).toBe(1);
-      expect(s.userKnowsItems).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

PR #307의 QA 누락으로 발견된 두 가지 버그를 수정합니다.

### 1) fork 화면에서 Back 버튼이 렌더링되지 않음
이미지 업로드 후 \"Do you know the items in this photo?\" 분기 화면은 \`currentStep\` 파생 로직상 Step 1로 분류됨. 기존 \`showBackButton = currentStep === 2 || currentStep === 3\` 조건이 이 화면을 포함하지 않아 Back 버튼이 아예 표시되지 않았습니다. 이슈 #306의 원문(\"fork 화면 / 스팟 마킹 화면에서 다른 이미지로 바꾸고 싶다\")과 불일치.

**수정**: \`showBackButton = hasImages\` — 이미지가 올라간 모든 상태에서 노출.

### 2) Step 3 Discard confirm 후 가시적 전이 없음
\`backToFork\`가 \`userKnowsItems\`를 보존하도록 구현되어 있어 Confirm 후에도 spot-marking 화면(빈 상태)에 머물렀고, 사용자는 \"아무 일도 안 일어났다\"고 인지하여 Back을 한 번 더 눌러야 했습니다.

**수정**: \`backToFork\`가 \`userKnowsItems\`까지 null로 클리어 → Confirm 한 번으로 fork 화면으로 가시적 전이.

### 부가 개선
- \`performBack\` 라우팅을 \`currentStep\` 분기 → \`userKnowsItems\` 분기로 단순화 (fork 화면 케이스 포함)
- \`handleBackClick\`의 confirm 조건을 \`currentStep === 3 && hasInProgressWork\` → \`hasInProgressWork\`로 일반화 (Step 2에서 context만 입력했을 때도 보호)
- \`backDisabled\`에 \`flow.isSubmitting\` 포함 (submit 중 Back 실수 방지)

## Files changed
- \`packages/web/lib/stores/requestStore.ts\` — \`backToFork\`에 \`userKnowsItems: null\` 추가
- \`packages/web/lib/components/request/UploadFlowSteps.tsx\` — Back 버튼 로직 재배선
- \`packages/web/tests/requestStore-back-navigation.test.ts\` — \`backToFork\` 어설션 업데이트
- \`packages/web/lib/components/request/__tests__/UploadFlowSteps.test.tsx\` — fork/Step 2/Step 3 Confirm 시나리오 4개 추가

## Test plan
- [x] \`bun run test:unit\` — 198 passed (Back button 4종 추가)
- [x] \`bunx tsc --noEmit\` — 관련 파일 새 오류 없음
- [ ] Manual: \`/request/upload\`
  - fork 화면에서 Back 버튼 보이는지, 클릭 시 DropZone 복귀
  - Step 3에서 spots 추가 후 Back → Discard \"확인\" **한 번**에 fork 화면으로 복귀
  - Submit 중 Back 비활성 확인

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)