### PR TITLE
fix(auth): #296 Continue as Guest 세션 지속 + intercept 라우트 우회

### DIFF
--- a/packages/web/lib/components/auth/LoginCard.tsx
+++ b/packages/web/lib/components/auth/LoginCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { Card, CardContent, CardFooter } from "@/lib/components/ui/card";
 import { OAuthButton } from "./OAuthButton";
 import {
@@ -18,7 +18,6 @@ function getSafeRedirect(url: string | null): string {
 }
 
 export function LoginCard() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const redirectTo = getSafeRedirect(searchParams.get("redirect"));
   const signInWithOAuth = useAuthStore((s) => s.signInWithOAuth);
@@ -38,7 +37,11 @@ export function LoginCard() {
 
   const handleGuestLogin = () => {
     guestLogin();
-    router.push(redirectTo);
+    // Hard navigation: router.push는 @modal/(.)request/upload 같은 intercept 라우트를
+    // 통과시켜 login 페이지가 그대로 남음(#296). window.location.replace로 완전
+    // 재진입시켜 login layout을 언마운트하고 목적지 라우트를 소유권 있게 렌더.
+    // OAuth 콜백 경로와 동일한 패턴.
+    window.location.replace(redirectTo);
   };
 
   return (

--- a/packages/web/lib/stores/authStore.ts
+++ b/packages/web/lib/stores/authStore.ts
@@ -81,6 +81,40 @@ function mapSupabaseUser(supabaseUser: SupabaseUser): User {
   };
 }
 
+/**
+ * Guest 세션 sessionStorage 키. hard navigation 후(`/login` → `/request/upload`)
+ * 에도 `isGuest` 상태를 복원할 수 있도록 persist한다. `logout()` / `setUser(logged-in)`
+ * 시 클리어된다. #296.
+ */
+const GUEST_SESSION_STORAGE_KEY = "decoded_guest_session";
+
+function persistGuestSession(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(GUEST_SESSION_STORAGE_KEY, "1");
+  } catch {
+    // sessionStorage 접근 실패(프라이빗 모드/쿼터 초과 등)는 무시
+  }
+}
+
+function clearGuestSession(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(GUEST_SESSION_STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}
+
+function readGuestSession(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.sessionStorage.getItem(GUEST_SESSION_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
 export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   profile: null,
@@ -130,11 +164,25 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           }
         }
       } else {
-        set({ isInitialized: true, user: null, isAdmin: false });
+        // Supabase 세션 없으면 sessionStorage에서 guest 플래그 복원 (#296)
+        const guestRestored = readGuestSession();
+        set({
+          isInitialized: true,
+          user: null,
+          isAdmin: false,
+          isGuest: guestRestored,
+        });
       }
     } catch (error) {
       console.error("Auth initialization error:", error);
-      set({ isInitialized: true, user: null, isAdmin: false });
+      // 실패 경로에서도 guest 세션 복원 시도 (로컬 상태로 fallback)
+      const guestRestored = readGuestSession();
+      set({
+        isInitialized: true,
+        user: null,
+        isAdmin: false,
+        isGuest: guestRestored,
+      });
     }
   },
 
@@ -172,6 +220,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
    * 게스트 로그인
    */
   guestLogin: () => {
+    persistGuestSession();
     set({ isGuest: true, user: null, isAdmin: false, error: null });
   },
 
@@ -188,6 +237,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         throw error;
       }
 
+      clearGuestSession();
       set({
         user: null,
         profile: null,
@@ -222,6 +272,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
    */
   setUser: async (supabaseUser: SupabaseUser | null) => {
     if (supabaseUser) {
+      // 실제 user가 설정되면 guest 세션을 폐기 (권한/상태 충돌 방지)
+      clearGuestSession();
       set({
         user: mapSupabaseUser(supabaseUser),
         isGuest: false,

--- a/packages/web/tests/authStore-guest-session.test.ts
+++ b/packages/web/tests/authStore-guest-session.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, test, expect, beforeEach, vi } from "vitest";
+
+// Supabase 클라이언트 mock — initialize()에서 호출
+vi.mock("@/lib/supabase/client", () => ({
+  supabaseBrowserClient: {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: null }, error: null })),
+      onAuthStateChange: vi.fn(() => ({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      })),
+      signInWithOAuth: vi.fn(),
+      signOut: vi.fn(async () => ({ error: null })),
+    },
+  },
+}));
+
+// users API mock
+vi.mock("@/lib/api/generated/users/users", () => ({
+  getMyProfile: vi.fn(),
+  updateMyProfile: vi.fn(),
+}));
+
+// authStore를 lazy import — 각 테스트마다 fresh 인스턴스
+import { useAuthStore } from "@/lib/stores/authStore";
+
+const GUEST_STORAGE_KEY = "decoded_guest_session";
+
+describe("authStore — guest session persistence (#296)", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    // 스토어 리셋 (간단히 초기 상태로)
+    useAuthStore.setState({
+      user: null,
+      profile: null,
+      isAdmin: false,
+      isGuest: false,
+      isLoading: false,
+      isInitialized: false,
+      needsOnboarding: false,
+      sessionExpired: false,
+      loadingProvider: null,
+      error: null,
+    });
+  });
+
+  test("guestLogin sets isGuest=true AND writes sessionStorage", () => {
+    useAuthStore.getState().guestLogin();
+
+    expect(useAuthStore.getState().isGuest).toBe(true);
+    expect(sessionStorage.getItem(GUEST_STORAGE_KEY)).toBe("1");
+  });
+
+  test("initialize restores isGuest from sessionStorage even without Supabase session", async () => {
+    // Arrange: prior session persisted guest flag
+    sessionStorage.setItem(GUEST_STORAGE_KEY, "1");
+
+    // Act
+    await useAuthStore.getState().initialize();
+
+    // Assert: isGuest restored, user remains null (no Supabase session)
+    const s = useAuthStore.getState();
+    expect(s.isGuest).toBe(true);
+    expect(s.user).toBeNull();
+    expect(s.isInitialized).toBe(true);
+  });
+
+  test("initialize does not set isGuest when sessionStorage is empty", async () => {
+    await useAuthStore.getState().initialize();
+    expect(useAuthStore.getState().isGuest).toBe(false);
+  });
+
+  test("logout clears sessionStorage guest flag", async () => {
+    useAuthStore.getState().guestLogin();
+    expect(sessionStorage.getItem(GUEST_STORAGE_KEY)).toBe("1");
+
+    await useAuthStore.getState().logout();
+    expect(sessionStorage.getItem(GUEST_STORAGE_KEY)).toBeNull();
+    expect(useAuthStore.getState().isGuest).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Continue as Guest 버튼이 동작하지 않던(URL만 바뀌고 login 페이지가 잔존) 문제를 복합 원인으로 진단해 수정합니다.

### 원인
1. **Intercept route 캡처**: \`app/@modal/(.)request/upload/page.tsx\`가 \`router.push(\"/request/upload\")\`를 parallel slot으로 캡처하여 \`/login\` layout이 언마운트되지 않고 modal만 오버레이됨. URL은 \`/request/upload\`로 바뀌지만 실제 렌더 트리는 login 페이지 + 모달 조합.
2. **isGuest persist 부재**: \`authStore\`에 persist 미들웨어가 없어 hard navigation 후 \`isGuest\`가 초기화됨.

### 수정

#### \`authStore.ts\` — \`isGuest\` sessionStorage 영속화
- \`decoded_guest_session\` 키로 guest 세션 플래그 저장
- \`guestLogin()\`: 쓰기
- \`initialize()\`: Supabase 세션이 없을 때 sessionStorage 플래그를 읽어 \`isGuest\` 복원 (정상/에러 경로 모두)
- \`setUser(logged-in)\`: 실제 user가 설정되면 guest 세션 폐기
- \`logout()\`: 클리어

sessionStorage를 쓴 이유: guest는 탭 닫히면 의미 없고, localStorage처럼 오래 남으면 \"내가 언제 guest 로그인했지?\" 혼란 유발.

#### \`LoginCard.tsx\` — Hard navigation
- \`handleGuestLogin\`: \`router.push(redirectTo)\` → \`window.location.replace(redirectTo)\`로 변경
- Intercept route를 우회해 login layout이 완전히 언마운트되고 목적지 라우트가 정상 소유권으로 렌더됨
- OAuth 콜백 경로(\`authStore\` line 129의 \`window.location.replace\`)와 동일 패턴

## Test plan

- [x] \`bun run test:unit\` — 202 passed (\`tests/authStore-guest-session.test.ts\` 4개 포함)
- [x] \`bunx tsc --noEmit\` — 새 오류 없음
- [ ] Manual: 로컬 Supabase self-hosting 환경에서
  - \`/login?redirect=/request/upload\` 직접 접근
  - \"Continue as Guest\" 클릭
  - URL이 \`/request/upload\`로 바뀌고 **login 페이지 요소가 DOM에서 사라져야 함**
  - Upload modal/page가 정상 렌더
  - Home nav의 UPLOAD 버튼이 인증 상태로 인식되어야 함

## 보류한 정책 결정 (별도 이슈 권장)
- guest 상태에서 protected route(\`/profile\`, \`/request/*\`) 접근 허용 여부 — 현재 \`selectIsAuthenticated = user || isGuest\`로 허용. guest별 제한 필요하면 별도 셀렉터/가드 신설.
- guest가 upload API 호출 가능 여부 — 서버 정책 정리 필요.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)