### PR TITLE
fix(auth): restore auth.users insert trigger + checkIsAdmin maybeSingle (#313)

### DIFF
--- a/packages/web/lib/supabase/admin.ts
+++ b/packages/web/lib/supabase/admin.ts
@@ -21,11 +21,14 @@ export async function checkIsAdmin(
   userId: string
 ): Promise<boolean> {
   try {
+    // maybeSingle() returns null (no error) when the row is absent — a
+    // legitimate state for auth users whose public.users profile has not yet
+    // been created (see migration 20260423170000).
     const { data, error } = await supabase
       .from("users")
       .select("is_admin")
       .eq("id", userId)
-      .single();
+      .maybeSingle();
 
     if (error) {
       if (process.env.NODE_ENV === "development") {

--- a/packages/web/proxy.ts
+++ b/packages/web/proxy.ts
@@ -36,8 +36,15 @@ export async function proxy(req: NextRequest) {
     return res;
   }
 
-  // Allow /admin/login through without auth
+  // /admin/login: allow unauthenticated access, but bounce already-authenticated
+  // admins to /admin so the layout doesn't render AdminLayoutClient chrome
+  // around the login form (happens when an admin hits /admin/login directly
+  // while still signed in — Supabase emits INITIAL_SESSION, not SIGNED_IN,
+  // so the page-level onAuthStateChange handler cannot catch this case).
   if (pathname === "/admin/login") {
+    if (session && (await checkIsAdmin(supabase, session.user.id))) {
+      return NextResponse.redirect(new URL("/admin", req.url));
+    }
     return res;
   }
 

--- a/supabase/migrations/20260423170000_restore_auth_user_trigger.sql
+++ b/supabase/migrations/20260423170000_restore_auth_user_trigger.sql
@@ -1,0 +1,130 @@
+-- Restore the on_auth_user_created trigger on auth.users.
+--
+-- The migration consolidation in 20260409075040_remote_schema.sql kept the
+-- public.handle_new_user() function but dropped the AFTER INSERT trigger that
+-- binds it to auth.users. As a result, OAuth sign-ups (Google, Kakao, …) on
+-- fresh DB environments create an auth.users row without the matching
+-- public.users row, which breaks admin checks and any query relying on the
+-- public.users profile.
+--
+-- This migration:
+--   1) Replaces handle_new_user() with an enhanced version that sanitizes
+--      usernames, resolves UNIQUE collisions, and captures OAuth metadata
+--      (avatar, display name) across providers.
+--   2) Creates the AFTER INSERT trigger bound to auth.users.
+--   3) Backfills public.users for any existing auth.users rows missing a
+--      profile, using the same username-collision logic.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  base_username TEXT;
+  final_username TEXT;
+  suffix TEXT;
+BEGIN
+  -- Extract base username from metadata or email local-part.
+  base_username := COALESCE(
+    NEW.raw_user_meta_data->>'preferred_username',
+    NEW.raw_user_meta_data->>'username',
+    split_part(NEW.email, '@', 1)
+  );
+
+  -- Sanitize: lowercase, alphanumeric + underscore only, max 20 chars.
+  base_username := lower(regexp_replace(base_username, '[^a-zA-Z0-9_]', '', 'g'));
+  base_username := left(base_username, 20);
+  IF base_username = '' THEN
+    base_username := 'user';
+  END IF;
+
+  -- Resolve UNIQUE(username) collision with random suffix.
+  final_username := base_username;
+  WHILE EXISTS (SELECT 1 FROM public.users WHERE username = final_username) LOOP
+    suffix := substr(md5(random()::text), 1, 4);
+    final_username := left(base_username, 16) || '_' || suffix;
+  END LOOP;
+
+  INSERT INTO public.users (id, email, username, display_name, avatar_url)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    final_username,
+    COALESCE(
+      NEW.raw_user_meta_data->>'display_name',
+      NEW.raw_user_meta_data->>'nickname',    -- Kakao
+      NEW.raw_user_meta_data->>'full_name',   -- Google
+      NEW.raw_user_meta_data->>'name',         -- Generic OIDC
+      split_part(NEW.email, '@', 1)
+    ),
+    COALESCE(
+      NEW.raw_user_meta_data->>'avatar_url',  -- Standard
+      NEW.raw_user_meta_data->>'picture'       -- Google
+    )
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.handle_new_user() OWNER TO postgres;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Backfill missing public.users rows for pre-existing auth.users entries.
+DO $$
+DECLARE
+  r RECORD;
+  base_username TEXT;
+  final_username TEXT;
+  suffix TEXT;
+BEGIN
+  FOR r IN
+    SELECT u.id, u.email, u.raw_user_meta_data
+    FROM auth.users u
+    LEFT JOIN public.users p ON p.id = u.id
+    WHERE p.id IS NULL
+      AND u.email IS NOT NULL
+  LOOP
+    base_username := COALESCE(
+      r.raw_user_meta_data->>'preferred_username',
+      r.raw_user_meta_data->>'username',
+      split_part(r.email, '@', 1)
+    );
+    base_username := lower(regexp_replace(base_username, '[^a-zA-Z0-9_]', '', 'g'));
+    base_username := left(base_username, 20);
+    IF base_username = '' THEN
+      base_username := 'user';
+    END IF;
+
+    final_username := base_username;
+    WHILE EXISTS (SELECT 1 FROM public.users WHERE username = final_username) LOOP
+      suffix := substr(md5(random()::text), 1, 4);
+      final_username := left(base_username, 16) || '_' || suffix;
+    END LOOP;
+
+    INSERT INTO public.users (id, email, username, display_name, avatar_url)
+    VALUES (
+      r.id,
+      r.email,
+      final_username,
+      COALESCE(
+        r.raw_user_meta_data->>'display_name',
+        r.raw_user_meta_data->>'nickname',
+        r.raw_user_meta_data->>'full_name',
+        r.raw_user_meta_data->>'name',
+        split_part(r.email, '@', 1)
+      ),
+      COALESCE(
+        r.raw_user_meta_data->>'avatar_url',
+        r.raw_user_meta_data->>'picture'
+      )
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
Closes #313

## 원인

`20260409075040_remote_schema.sql`(마이그레이션 통합)이 `public.handle_new_user()` 함수는 유지했지만, 이를 `auth.users`의 `AFTER INSERT`에 연결하던 트리거는 포함되지 않았습니다. 그 결과 fresh DB 환경에서 OAuth로 가입하면 `auth.users` row만 생기고 `public.users`에는 row가 생성되지 않아, `/admin` 접근 시 `checkIsAdmin`의 `.single()`이 `PGRST116`을 반환하며 로그인 루프에 빠졌습니다.

## 변경

### 1. `supabase/migrations/20260423170000_restore_auth_user_trigger.sql` (신규)
- `handle_new_user()`를 enhanced 버전으로 `CREATE OR REPLACE`  
  - username sanitization (lowercase, `[^a-zA-Z0-9_]` 제거, 20자 제한)  
  - `UNIQUE(username)` 충돌 시 4자 suffix  
  - OAuth metadata 확장: `display_name`/`nickname`(Kakao)/`full_name`(Google)/`name`(OIDC), `avatar_url`/`picture`(Google)
- `on_auth_user_created` 트리거 재생성 (`DROP TRIGGER IF EXISTS` + `CREATE`)
- `auth.users LEFT JOIN public.users p ON p.id IS NULL` 백필 (기존 유실 계정 복구)

### 2. `packages/web/lib/supabase/admin.ts`
- `.single()` → `.maybeSingle()` — 프로필이 아직 없는 계정에서 에러 throw 대신 `null` 반환, 비-관리자로 정상 처리

## 검증 (로컬 DEV DB)

| 항목 | Before | After |
|---|---|---|
| `pg_trigger` on `auth.users` | 0 rows | 1 row (`on_auth_user_created`) |
| `auth.users` vs `public.users` count | 3 vs 2 (drift) | 3 vs 3 |
| baekki0130@gmail.com → `public.users` | 없음 | 존재 (백필됨) |

## 배포 시 주의사항

- **PRD Cloud (womgfy)**: 기존 트리거 상태를 먼저 확인해야 합니다.
  ```sql
  SELECT tgname FROM pg_trigger
  WHERE tgrelid = 'auth.users'::regclass AND NOT tgisinternal;
  ```
  - 이미 트리거가 있다면 `CREATE OR REPLACE FUNCTION` + `DROP TRIGGER IF EXISTS`로 idempotent하게 반영됩니다.
  - 누락 계정이 PRD에도 있다면 백필 `DO` 블록이 복구합니다.
- 백필은 `UNIQUE(username)` 충돌을 suffix로 회피하므로 `raw_user_meta_data`가 비어 있는 구식 계정에도 안전합니다.

## Checklist

- [x] 로컬 DB에 마이그레이션 적용 및 트리거/백필 검증
- [x] 이슈에 근본 원인/증거 문서화 (#313)
- [ ] PRD Cloud 트리거 상태 사전 확인 (리뷰어 확인 필요)