### PR TITLE
fix(db): seed system/uncategorized + boot validation (#312)

### DIFF
--- a/packages/api-server/src/domains/subcategories/service.rs
+++ b/packages/api-server/src/domains/subcategories/service.rs
@@ -119,7 +119,12 @@ pub async fn resolve_uncategorized_subcategory_id(db: &impl ConnectionTrait) -> 
         .await
         .map_err(AppError::DatabaseError)?
         .ok_or_else(|| {
-            AppError::InternalError("system category not found; run migrations".to_string())
+            AppError::InternalError(
+                "system category not found — apply \
+                 supabase/migrations/20260423075700_seed_system_uncategorized.sql \
+                 (or SeaORM m20260320_000001_add_system_uncategorized_subcategory)"
+                    .to_string(),
+            )
         })?;
 
     let sub = Subcategories::find()
@@ -130,7 +135,10 @@ pub async fn resolve_uncategorized_subcategory_id(db: &impl ConnectionTrait) -> 
         .map_err(AppError::DatabaseError)?
         .ok_or_else(|| {
             AppError::InternalError(
-                "uncategorized subcategory not found; run migrations".to_string(),
+                "uncategorized subcategory not found — apply \
+                 supabase/migrations/20260423075700_seed_system_uncategorized.sql \
+                 (or SeaORM m20260320_000001_add_system_uncategorized_subcategory)"
+                    .to_string(),
             )
         })?;
 

--- a/packages/api-server/src/domains/subcategories/service.rs
+++ b/packages/api-server/src/domains/subcategories/service.rs
@@ -16,6 +16,11 @@ use crate::{
 
 use super::dto::{CategoryWithSubcategories, SubcategoryName, SubcategoryResponse};
 
+/// 운영자용 remediation 메시지 (로그 전용 — HTTP 응답에는 노출하지 않음).
+pub const MIGRATION_HINT: &str =
+    "apply supabase/migrations/20260423075700_seed_system_uncategorized.sql \
+     (or SeaORM m20260320_000001_add_system_uncategorized_subcategory)";
+
 /// 모든 Subcategories 조회 (Category별 그룹화)
 pub async fn list_all_with_categories(
     db: &DatabaseConnection,
@@ -119,12 +124,8 @@ pub async fn resolve_uncategorized_subcategory_id(db: &impl ConnectionTrait) -> 
         .await
         .map_err(AppError::DatabaseError)?
         .ok_or_else(|| {
-            AppError::InternalError(
-                "system category not found — apply \
-                 supabase/migrations/20260423075700_seed_system_uncategorized.sql \
-                 (or SeaORM m20260320_000001_add_system_uncategorized_subcategory)"
-                    .to_string(),
-            )
+            tracing::error!(hint = %MIGRATION_HINT, "system category seed missing");
+            AppError::InternalError("service misconfigured".to_string())
         })?;
 
     let sub = Subcategories::find()
@@ -134,12 +135,8 @@ pub async fn resolve_uncategorized_subcategory_id(db: &impl ConnectionTrait) -> 
         .await
         .map_err(AppError::DatabaseError)?
         .ok_or_else(|| {
-            AppError::InternalError(
-                "uncategorized subcategory not found — apply \
-                 supabase/migrations/20260423075700_seed_system_uncategorized.sql \
-                 (or SeaORM m20260320_000001_add_system_uncategorized_subcategory)"
-                    .to_string(),
-            )
+            tracing::error!(hint = %MIGRATION_HINT, "uncategorized subcategory seed missing");
+            AppError::InternalError("service misconfigured".to_string())
         })?;
 
     Ok(sub.id)

--- a/packages/api-server/src/main.rs
+++ b/packages/api-server/src/main.rs
@@ -103,16 +103,22 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
     // #312: system/uncategorized 시드 존재 검증.
     // 부재 시 POST /api/v1/posts 가 500 으로 실패하므로 부팅 시 명확히 로깅.
     // 서버 기동은 계속한다 — 운영자가 로그를 보고 마이그레이션을 적용할 수 있게.
+    // dev 에서는 Supabase CLI 가 out-of-band 로 마이그레이션을 적용하므로,
+    // api-server 가 먼저 떠 있으면 false alarm 이 날 수 있음 — 메시지에 명시.
     match decoded_api::domains::subcategories::service::resolve_uncategorized_subcategory_id(
         &db_connection,
     )
     .await
     {
         Ok(_) => tracing::info!("system/uncategorized seed verified"),
+        Err(decoded_api::error::AppError::InternalError(_)) => tracing::error!(
+            hint = %decoded_api::domains::subcategories::service::MIGRATION_HINT,
+            "system/uncategorized seed missing — POST /api/v1/posts will 500 until applied. \
+             (dev: run `supabase db push` / `just dev-reset` then restart api-server)"
+        ),
         Err(e) => tracing::error!(
             error = %e,
-            "system/uncategorized seed missing — POST /api/v1/posts will fail until \
-             supabase/migrations/20260423075700_seed_system_uncategorized.sql is applied"
+            "seed validation failed to query DB — retry after DB is reachable"
         ),
     }
 

--- a/packages/api-server/src/main.rs
+++ b/packages/api-server/src/main.rs
@@ -100,6 +100,22 @@ async fn async_main() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("Database migrations completed successfully");
     }
 
+    // #312: system/uncategorized 시드 존재 검증.
+    // 부재 시 POST /api/v1/posts 가 500 으로 실패하므로 부팅 시 명확히 로깅.
+    // 서버 기동은 계속한다 — 운영자가 로그를 보고 마이그레이션을 적용할 수 있게.
+    match decoded_api::domains::subcategories::service::resolve_uncategorized_subcategory_id(
+        &db_connection,
+    )
+    .await
+    {
+        Ok(_) => tracing::info!("system/uncategorized seed verified"),
+        Err(e) => tracing::error!(
+            error = %e,
+            "system/uncategorized seed missing — POST /api/v1/posts will fail until \
+             supabase/migrations/20260423075700_seed_system_uncategorized.sql is applied"
+        ),
+    }
+
     // AppState 생성 (마이그레이션용 연결 재사용)
     let state = AppState::with_db_connection(config.clone(), Some(db_connection)).await?;
 

--- a/supabase/migrations/20260423075700_seed_system_uncategorized.sql
+++ b/supabase/migrations/20260423075700_seed_system_uncategorized.sql
@@ -1,0 +1,52 @@
+-- Seed: `system` category + `uncategorized` subcategory (idempotent)
+--
+-- Why: `api-server` Post creation path calls `resolve_uncategorized_subcategory_id`
+--      in `packages/api-server/src/domains/subcategories/service.rs`. Without this
+--      seed, POST /api/v1/posts fails with 500
+--      "system category not found; run migrations" whenever the request has no
+--      pre-tagged spot (most no-solution uploads). See GitHub issue #312.
+--
+-- SOT: this file (Supabase CLI migrations). The equivalent SeaORM migration
+--      (`m20260320_000001_add_system_uncategorized_subcategory.rs`) is skipped
+--      on dev (`SKIP_DB_MIGRATIONS=1`), so the Supabase path must carry it.
+--
+-- Idempotent: uses unique constraints `categories_code_key` and
+-- `idx_subcategories_category_code_unique (category_id, code)`.
+
+BEGIN;
+
+INSERT INTO public.categories (id, code, name, display_order, is_active, created_at, updated_at)
+VALUES (
+    gen_random_uuid(),
+    'system',
+    '{"ko": "시스템", "en": "System"}'::json,
+    99,
+    true,
+    NOW(),
+    NOW()
+)
+ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO public.subcategories (id, category_id, code, name, display_order, is_active, created_at, updated_at)
+SELECT
+    gen_random_uuid(),
+    c.id,
+    'uncategorized',
+    '{"ko": "카테고리 없음", "en": "Uncategorized"}'::json,
+    1,
+    true,
+    NOW(),
+    NOW()
+FROM public.categories c
+WHERE c.code = 'system'
+ON CONFLICT (category_id, code) DO NOTHING;
+
+UPDATE public.spots
+SET subcategory_id = s.id
+FROM public.subcategories s
+INNER JOIN public.categories c ON c.id = s.category_id
+WHERE public.spots.subcategory_id IS NULL
+  AND c.code = 'system'
+  AND s.code = 'uncategorized';
+
+COMMIT;

--- a/supabase/migrations/20260423075700_seed_system_uncategorized.sql
+++ b/supabase/migrations/20260423075700_seed_system_uncategorized.sql
@@ -12,6 +12,15 @@
 --
 -- Idempotent: uses unique constraints `categories_code_key` and
 -- `idx_subcategories_category_code_unique (category_id, code)`.
+--
+-- `name` is `json` (not `jsonb`) per `remote_schema.sql:408, 911` — the
+-- SeaORM sibling uses `::jsonb` which PG coerces implicitly; this file
+-- matches the actual column type.
+--
+-- RLS note: `public.spots` has RLS enabled, but Supabase CLI migrations
+-- run as `postgres` (table owner) and bypass RLS, so the UPDATE below is
+-- allowed to backfill rows owned by any user. Only NULL rows are touched,
+-- so re-applies are no-ops.
 
 BEGIN;
 


### PR DESCRIPTION
## Summary

Fixes #312 — POST /api/v1/posts returning 500 `system category not found; run migrations` on no-solution uploads.

Root cause: `resolve_uncategorized_subcategory_id` (`packages/api-server/src/domains/subcategories/service.rs`) is called for every Post create, but the `system` / `uncategorized` seed was only in the SeaORM migration (`m20260320_000001_add_system_uncategorized_subcategory`), which dev skips via `SKIP_DB_MIGRATIONS=1`. The Supabase CLI SOT never carried it.

## Changes

- **`supabase/migrations/20260423075700_seed_system_uncategorized.sql` (new)** — idempotent `categories(code='system')` + `subcategories(code='uncategorized')` insert, plus NULL `spots.subcategory_id` backfill. Uses existing unique constraints (`categories_code_key`, `idx_subcategories_category_code_unique`).
- **`packages/api-server/src/domains/subcategories/service.rs`** — error messages no longer leak migration filenames into HTTP responses; operator hint is logged via `tracing::error!` instead. `MIGRATION_HINT` extracted as a module const.
- **`packages/api-server/src/main.rs`** — boot-time probe logs `system/uncategorized seed verified` on success, or a variant-specific error (seed missing vs DB unreachable) so the 500 symptom surfaces in logs before the first POST.

## Review outcomes (resolved before shipping)

| Finding | Fix |
|---|---|
| Security M1 — error msg leaked filename to client | Opaque `"service misconfigured"` msg, detail to tracing |
| Code M3 — probe conflated DB error vs seed-missing | `match` on `AppError::InternalError` vs other variants |
| Code M1/M2 — json/jsonb parity + RLS context | SQL header comments added |
| Code L1 — duplicated error strings | `MIGRATION_HINT` const |

## Follow-up (not in this PR)

- Integration test for migration idempotency + spots backfill behavior (code review H2).
- `APP_ENV=production` fail-closed on the boot probe (security review L2).

## Test plan

- [x] `cargo check` passes on api-server
- [x] Local DEV — `supabase migration up --local` applied cleanly (confirmed)
- [ ] api-server restart → log shows `system/uncategorized seed verified`
- [ ] POST /api/v1/posts with no solution/link → 200 (was 500)
- [ ] `psql` verify: `SELECT count(*) FROM subcategories s JOIN categories c ON c.id = s.category_id WHERE c.code='system' AND s.code='uncategorized';` → `1`

## Prod note

Supabase Cloud prod also needs this seed row. After merge, the migration runs as part of the normal Supabase CLI deploy path (`supabase db push` on the prod project), so no manual SQL needed — but worth watching the first deploy.

Refs #312