### PR TITLE
refactor(admin): unify content tab status URL typeguard (#240)

### DIFF
--- a/packages/web/app/admin/content/page.tsx
+++ b/packages/web/app/admin/content/page.tsx
@@ -18,8 +18,11 @@ import {
 } from "@/lib/components/admin/magazines";
 import { Pagination } from "@/lib/components/admin/audit/Pagination";
 import { AdminEmptyState } from "@/lib/components/admin/common";
-import type { PostStatus } from "@/lib/api/admin/posts";
-import type { ReportStatus } from "@/lib/api/admin/reports";
+import { isValidPostStatus, type PostStatus } from "@/lib/api/admin/posts";
+import {
+  isValidReportStatus,
+  type ReportStatus,
+} from "@/lib/api/admin/reports";
 import {
   isValidMagazineStatus,
   type MagazineStatus,
@@ -142,13 +145,13 @@ function ContentManagementContent() {
   const statusParam = searchParams.get("status");
 
   const postStatus =
-    currentTab === "posts" && statusParam
-      ? (statusParam as PostStatus)
+    currentTab === "posts" && statusParam && isValidPostStatus(statusParam)
+      ? statusParam
       : undefined;
 
   const reportStatus =
-    currentTab === "reports" && statusParam
-      ? (statusParam as ReportStatus)
+    currentTab === "reports" && statusParam && isValidReportStatus(statusParam)
+      ? statusParam
       : undefined;
 
   const magazineStatus =

--- a/packages/web/lib/api/admin/__tests__/posts.test.ts
+++ b/packages/web/lib/api/admin/__tests__/posts.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  POST_STATUSES,
+  isValidPostStatus,
+  type PostStatus,
+} from "../posts";
+
+describe("PostStatus", () => {
+  it("exports all 3 statuses", () => {
+    expect(POST_STATUSES).toEqual(["active", "hidden", "deleted"]);
+  });
+
+  it("isValidPostStatus returns true for valid", () => {
+    expect(isValidPostStatus("active")).toBe(true);
+    expect(isValidPostStatus("hidden")).toBe(true);
+    expect(isValidPostStatus("deleted")).toBe(true);
+  });
+
+  it("isValidPostStatus returns false for invalid", () => {
+    expect(isValidPostStatus("foo")).toBe(false);
+    expect(isValidPostStatus("")).toBe(false);
+    expect(isValidPostStatus("ACTIVE")).toBe(false);
+  });
+
+  it("PostStatus type narrows correctly", () => {
+    const value: string = "active";
+    if (isValidPostStatus(value)) {
+      const narrowed: PostStatus = value;
+      expect(narrowed).toBe("active");
+    }
+  });
+});

--- a/packages/web/lib/api/admin/__tests__/reports.test.ts
+++ b/packages/web/lib/api/admin/__tests__/reports.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import {
+  REPORT_STATUSES,
+  isValidReportStatus,
+  type ReportStatus,
+} from "../reports";
+
+describe("ReportStatus", () => {
+  it("exports all 4 statuses", () => {
+    expect(REPORT_STATUSES).toEqual([
+      "pending",
+      "reviewed",
+      "dismissed",
+      "actioned",
+    ]);
+  });
+
+  it("isValidReportStatus returns true for valid", () => {
+    expect(isValidReportStatus("pending")).toBe(true);
+    expect(isValidReportStatus("reviewed")).toBe(true);
+    expect(isValidReportStatus("dismissed")).toBe(true);
+    expect(isValidReportStatus("actioned")).toBe(true);
+  });
+
+  it("isValidReportStatus returns false for invalid", () => {
+    expect(isValidReportStatus("foo")).toBe(false);
+    expect(isValidReportStatus("")).toBe(false);
+    expect(isValidReportStatus("PENDING")).toBe(false);
+  });
+
+  it("ReportStatus type narrows correctly", () => {
+    const value: string = "pending";
+    if (isValidReportStatus(value)) {
+      const narrowed: ReportStatus = value;
+      expect(narrowed).toBe("pending");
+    }
+  });
+});

--- a/packages/web/lib/api/admin/posts.ts
+++ b/packages/web/lib/api/admin/posts.ts
@@ -2,7 +2,13 @@
  * Admin Posts types — matches Rust API response shapes.
  */
 
-export type PostStatus = "active" | "hidden" | "deleted";
+export const POST_STATUSES = ["active", "hidden", "deleted"] as const;
+
+export type PostStatus = (typeof POST_STATUSES)[number];
+
+export function isValidPostStatus(s: string): s is PostStatus {
+  return (POST_STATUSES as readonly string[]).includes(s);
+}
 
 export interface PostUserInfo {
   id: string;

--- a/packages/web/lib/api/admin/reports.ts
+++ b/packages/web/lib/api/admin/reports.ts
@@ -2,7 +2,18 @@
  * Admin Reports types — matches Rust API response shapes.
  */
 
-export type ReportStatus = "pending" | "reviewed" | "dismissed" | "actioned";
+export const REPORT_STATUSES = [
+  "pending",
+  "reviewed",
+  "dismissed",
+  "actioned",
+] as const;
+
+export type ReportStatus = (typeof REPORT_STATUSES)[number];
+
+export function isValidReportStatus(s: string): s is ReportStatus {
+  return (REPORT_STATUSES as readonly string[]).includes(s);
+}
 
 export interface ReporterInfo {
   id: string;


### PR DESCRIPTION
## Summary
- `posts.ts` / `reports.ts`에 `POST_STATUSES` / `REPORT_STATUSES` const 배열 추가 및 `isValidPostStatus` / `isValidReportStatus` 타입가드 export — `magazines.ts` 패턴과 일관화
- `admin/content/page.tsx`의 `as PostStatus` / `as ReportStatus` unsafe 캐스팅을 타입가드로 교체, URL 파라미터 파싱 런타임 안전성 확보
- `lib/api/admin/__tests__/posts.test.ts` / `reports.test.ts` 단위 테스트 추가 (TDD RED→GREEN, `magazines.test.ts` 구조 동일)

## Test plan
- [x] bun run lint (변경 파일 오류 없음)
- [x] bunx tsc --noEmit (기존 pre-existing 에러만, 변경 파일 무관)
- [x] bun run test:unit — 16 tests passed (posts×4, reports×4, magazines×4, content/page×4)

Closes #240