### PR TITLE
fix(web/admin): forward supabase token to rust admin API (#257)

### DIFF
--- a/packages/web/app/api/v1/admin/editorial-candidates/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/editorial-candidates/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for GET /api/v1/admin/editorial-candidates
+ *
+ * Verifies that:
+ * - 401 is returned when no Supabase session exists
+ * - 403 is returned when session exists but user is not admin
+ * - 401 is returned when session has no access_token
+ * - The Supabase session access_token (not the incoming request Authorization
+ *   header) is forwarded to the Rust backend as `Authorization: Bearer <token>`
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const checkIsAdminMock = vi.fn();
+const backendFetchMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdminMock(...args),
+}));
+
+vi.mock("@/lib/server-env", () => ({
+  API_BASE_URL: "http://api.test",
+}));
+
+// Supabase server client mock — returns configurable user/session
+const getUserMock = vi.fn();
+const getSessionMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: async () => ({
+    auth: {
+      getUser: () => getUserMock(),
+      getSession: () => getSessionMock(),
+    },
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(
+  url = "http://localhost/api/v1/admin/editorial-candidates"
+) {
+  return new NextRequest(url);
+}
+
+function mockAdminSession(accessToken = "test-token") {
+  getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+  checkIsAdminMock.mockResolvedValue(true);
+  getSessionMock.mockResolvedValue({
+    data: { session: { access_token: accessToken } },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/admin/editorial-candidates", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    getSessionMock.mockReset();
+    checkIsAdminMock.mockReset();
+    backendFetchMock.mockReset();
+    // Reset the global fetch stub before each test
+    vi.stubGlobal("fetch", backendFetchMock);
+  });
+
+  it("returns 401 when no user session", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    checkIsAdminMock.mockResolvedValue(false);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when session has no access_token", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    checkIsAdminMock.mockResolvedValue(true);
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("forwards Supabase access_token as Bearer to Rust backend", async () => {
+    mockAdminSession("supabase-jwt-abc123");
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({ data: [], total: 0, page: 1, per_page: 20 }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(makeRequest());
+
+    expect(backendFetchMock).toHaveBeenCalledOnce();
+    const [url, init] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/admin/editorial-candidates");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer supabase-jwt-abc123"
+    );
+  });
+
+  it("does NOT forward an empty Authorization header to Rust backend", async () => {
+    mockAdminSession("my-session-token");
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({ data: [], total: 0, page: 1, per_page: 20 }),
+    });
+
+    // Simulate a request with NO Authorization header (typical browser fetch)
+    const { GET } = await import("../route");
+    await GET(makeRequest());
+
+    const [, init] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    // Must be a real Bearer token, not an empty string
+    expect((init.headers as Record<string, string>)["Authorization"]).not.toBe(
+      ""
+    );
+    expect((init.headers as Record<string, string>)["Authorization"]).not.toBe(
+      "Bearer "
+    );
+  });
+
+  it("returns 200 with backend data on success", async () => {
+    mockAdminSession();
+
+    const payload = {
+      data: [{ id: "post-1" }],
+      total: 1,
+      page: 1,
+      per_page: 20,
+    };
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(1);
+  });
+
+  it("returns 502 when backend fetch throws", async () => {
+    mockAdminSession();
+    backendFetchMock.mockRejectedValue(new Error("connection refused"));
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("forwards page and perPage query params to backend", async () => {
+    mockAdminSession();
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({ data: [], total: 0, page: 2, per_page: 10 }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(
+      makeRequest(
+        "http://localhost/api/v1/admin/editorial-candidates?page=2&perPage=10"
+      )
+    );
+
+    const [url] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("page=2");
+    expect(url).toContain("per_page=10");
+  });
+});

--- a/packages/web/app/api/v1/admin/editorial-candidates/route.ts
+++ b/packages/web/app/api/v1/admin/editorial-candidates/route.ts
@@ -26,6 +26,13 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: "No session" }, { status: 401 });
+  }
+
   const { searchParams } = request.nextUrl;
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
   const perPage = Math.min(
@@ -38,7 +45,7 @@ export async function GET(request: NextRequest) {
       `${API_BASE_URL}/api/v1/admin/editorial-candidates?page=${page}&per_page=${perPage}`,
       {
         headers: {
-          Authorization: request.headers.get("Authorization") ?? "",
+          Authorization: `Bearer ${session.access_token}`,
         },
       }
     );

--- a/packages/web/app/api/v1/admin/posts/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/posts/__tests__/route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for GET /api/v1/admin/posts
+ *
+ * Verifies that:
+ * - 401 is returned when no Supabase session exists
+ * - 403 is returned when session exists but user is not admin
+ * - 401 is returned when session has no access_token
+ * - The Supabase session access_token is forwarded as `Authorization: Bearer <token>`
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const checkIsAdminMock = vi.fn();
+const backendFetchMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdminMock(...args),
+}));
+
+vi.mock("@/lib/server-env", () => ({
+  API_BASE_URL: "http://api.test",
+}));
+
+const getUserMock = vi.fn();
+const getSessionMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: async () => ({
+    auth: {
+      getUser: () => getUserMock(),
+      getSession: () => getSessionMock(),
+    },
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(url = "http://localhost/api/v1/admin/posts") {
+  return new NextRequest(url);
+}
+
+function mockAdminSession(accessToken = "test-token") {
+  getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+  checkIsAdminMock.mockResolvedValue(true);
+  getSessionMock.mockResolvedValue({
+    data: { session: { access_token: accessToken } },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/admin/posts", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    getSessionMock.mockReset();
+    checkIsAdminMock.mockReset();
+    backendFetchMock.mockReset();
+    vi.stubGlobal("fetch", backendFetchMock);
+  });
+
+  it("returns 401 when no user session", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    checkIsAdminMock.mockResolvedValue(false);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when session has no access_token", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    checkIsAdminMock.mockResolvedValue(true);
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("forwards Supabase access_token as Bearer to Rust backend", async () => {
+    mockAdminSession("supabase-jwt-posts");
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: [],
+          pagination: { current_page: 1, total_pages: 1 },
+        }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(makeRequest());
+
+    expect(backendFetchMock).toHaveBeenCalledOnce();
+    const [url, init] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/admin/posts");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer supabase-jwt-posts"
+    );
+  });
+
+  it("returns 200 with backend data on success", async () => {
+    mockAdminSession();
+
+    const payload = {
+      data: [{ id: "p1" }],
+      pagination: { current_page: 1, total_pages: 1 },
+    };
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("returns 502 when backend fetch throws", async () => {
+    mockAdminSession();
+    backendFetchMock.mockRejectedValue(new Error("network error"));
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("forwards status query param to backend URL", async () => {
+    mockAdminSession();
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: [],
+          pagination: { current_page: 1, total_pages: 1 },
+        }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(
+      makeRequest("http://localhost/api/v1/admin/posts?status=hidden&page=2")
+    );
+
+    const [url] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("status=hidden");
+    expect(url).toContain("page=2");
+  });
+});

--- a/packages/web/app/api/v1/admin/reports/__tests__/route.test.ts
+++ b/packages/web/app/api/v1/admin/reports/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for GET /api/v1/admin/reports
+ *
+ * Verifies that:
+ * - 401 is returned when no Supabase session exists
+ * - 403 is returned when session exists but user is not admin
+ * - 401 is returned when session has no access_token
+ * - The Supabase session access_token is forwarded as `Authorization: Bearer <token>`
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const checkIsAdminMock = vi.fn();
+const backendFetchMock = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  checkIsAdmin: (...args: unknown[]) => checkIsAdminMock(...args),
+}));
+
+vi.mock("@/lib/server-env", () => ({
+  API_BASE_URL: "http://api.test",
+}));
+
+const getUserMock = vi.fn();
+const getSessionMock = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: async () => ({
+    auth: {
+      getUser: () => getUserMock(),
+      getSession: () => getSessionMock(),
+    },
+  }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRequest(url = "http://localhost/api/v1/admin/reports") {
+  return new NextRequest(url);
+}
+
+function mockAdminSession(accessToken = "test-token") {
+  getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+  checkIsAdminMock.mockResolvedValue(true);
+  getSessionMock.mockResolvedValue({
+    data: { session: { access_token: accessToken } },
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/admin/reports", () => {
+  beforeEach(() => {
+    getUserMock.mockReset();
+    getSessionMock.mockReset();
+    checkIsAdminMock.mockReset();
+    backendFetchMock.mockReset();
+    vi.stubGlobal("fetch", backendFetchMock);
+  });
+
+  it("returns 401 when no user session", async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not admin", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    checkIsAdminMock.mockResolvedValue(false);
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 when session has no access_token", async () => {
+    getUserMock.mockResolvedValue({ data: { user: { id: "admin-1" } } });
+    checkIsAdminMock.mockResolvedValue(true);
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("forwards Supabase access_token as Bearer to Rust backend", async () => {
+    mockAdminSession("supabase-jwt-reports");
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: [],
+          pagination: { current_page: 1, total_pages: 1 },
+        }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(makeRequest());
+
+    expect(backendFetchMock).toHaveBeenCalledOnce();
+    const [url, init] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/admin/reports");
+    expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+      "Bearer supabase-jwt-reports"
+    );
+  });
+
+  it("returns 200 with backend data on success", async () => {
+    mockAdminSession();
+
+    const payload = {
+      data: [{ id: "r1" }],
+      pagination: { current_page: 1, total_pages: 1 },
+    };
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () => JSON.stringify(payload),
+    });
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("returns 502 when backend fetch throws", async () => {
+    mockAdminSession();
+    backendFetchMock.mockRejectedValue(new Error("network error"));
+
+    const { GET } = await import("../route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(502);
+  });
+
+  it("forwards status and target_type query params to backend URL", async () => {
+    mockAdminSession();
+
+    backendFetchMock.mockResolvedValue({
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          data: [],
+          pagination: { current_page: 1, total_pages: 1 },
+        }),
+    });
+
+    const { GET } = await import("../route");
+    await GET(
+      makeRequest(
+        "http://localhost/api/v1/admin/reports?status=pending&target_type=post"
+      )
+    );
+
+    const [url] = backendFetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("status=pending");
+    expect(url).toContain("target_type=post");
+  });
+});


### PR DESCRIPTION
## Summary

- `editorial-candidates/route.ts` was using `request.headers.get("Authorization")` to forward the auth header from the incoming browser request to the Rust backend. Browser-to-Next.js admin requests are cookie-authenticated and carry no Authorization header, so an empty string was forwarded → Rust returned 401.
- Applied the same `getSession()` + `Authorization: Bearer <access_token>` pattern already used by the `posts` and `reports` routes.
- Added route-level unit tests for all three endpoints (`posts`, `reports`, `editorial-candidates`) verifying auth guards (401/403) and that the Supabase session token (not an empty header) is forwarded to the Rust backend.

## Root cause

`editorial-candidates/route.ts:41` used `request.headers.get("Authorization") ?? ""` — forwarding the incoming HTTP request's Authorization header. Admin sessions are cookie-based (synced via `POST /api/auth/session` on login); browser fetch calls carry no Authorization header, so the forwarded value was always an empty string `""`, causing the Rust API to reject with 401.

## Test plan

- [x] `bunx vitest run app/api/v1/admin/editorial-candidates/__tests__/route.test.ts app/api/v1/admin/posts/__tests__/route.test.ts app/api/v1/admin/reports/__tests__/route.test.ts` — 22 tests pass
- [x] Full unit test suite: 224 tests pass (4 pre-existing transform failures unrelated to this change)
- [x] Lint: no new errors in changed files
- [x] TypeScript: no new errors in changed files

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)