### PR TITLE
fix(web): R2 썸네일 400 — /_next/image 이중 래핑 제거 (#253)

### DIFF
--- a/packages/web/lib/__tests__/image-loader.test.ts
+++ b/packages/web/lib/__tests__/image-loader.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import imageLoader from "../image-loader";
+
+/**
+ * Regression coverage for #253 — Vercel image optimizer rejected double-wrapped
+ * URLs (`/_next/image?url=/api/v1/image-proxy?url=...`) with
+ * `x-vercel-error: INVALID_IMAGE_OPTIMIZE_REQUEST` (HTTP 400).
+ *
+ * Contract:
+ * - Hosts listed in `images.remotePatterns` (R2 public bucket) → direct
+ *   `/_next/image` optimization, no proxy.
+ * - Other external hosts → bare `/api/v1/image-proxy` (no `/_next/image`
+ *   wrapping). Loses Next optimization but avoids the 400.
+ * - Local/relative src → `/_next/image`.
+ */
+
+const R2_HOST = "pub-6354054b117b46b9a0fe99e4a546e681.r2.dev";
+
+describe("image-loader", () => {
+  it("routes R2 URLs directly through /_next/image (optimized)", () => {
+    const url = `https://${R2_HOST}/items/abc/1.jpg`;
+    const out = imageLoader({ src: url, width: 384, quality: 75 });
+    expect(out).toBe(`/_next/image?url=${encodeURIComponent(url)}&w=384&q=75`);
+    expect(out).not.toContain("image-proxy");
+  });
+
+  it("handles blur-placeholder width/quality for R2 URLs", () => {
+    const url = `https://${R2_HOST}/items/abc/2.jpg`;
+    const out = imageLoader({ src: url, width: 32, quality: 1 });
+    expect(out).toBe(`/_next/image?url=${encodeURIComponent(url)}&w=32&q=1`);
+  });
+
+  it("routes non-allowlisted external URLs through bare image-proxy (no /_next/image wrap)", () => {
+    const url = "https://i.pinimg.com/originals/ab/cd/ef/ghi.jpg";
+    const out = imageLoader({ src: url, width: 384, quality: 75 });
+    expect(out).toBe(`/api/v1/image-proxy?url=${encodeURIComponent(url)}`);
+    expect(out).not.toContain("_next/image");
+  });
+
+  it("defaults quality to 75 when undefined", () => {
+    const url = `https://${R2_HOST}/items/abc/3.jpg`;
+    const out = imageLoader({ src: url, width: 128, quality: undefined });
+    expect(out).toContain("q=75");
+  });
+
+  it("routes local/relative paths through /_next/image", () => {
+    const out = imageLoader({ src: "/logo.png", width: 256, quality: 90 });
+    expect(out).toBe(
+      `/_next/image?url=${encodeURIComponent("/logo.png")}&w=256&q=90`
+    );
+  });
+
+  it("does not double-wrap R2 URL with nested ?url= query (#253 regression)", () => {
+    const url = `https://${R2_HOST}/items/abc/4.jpg`;
+    const out = imageLoader({ src: url, width: 32, quality: 1 });
+    expect(out).not.toMatch(/url=.*image-proxy.*%3Furl%3D/);
+  });
+
+  it("falls back to proxy when URL parse fails (malformed host)", () => {
+    // No throw; degrades to proxy path.
+    const out = imageLoader({
+      src: "https://not a valid host/x.jpg",
+      width: 128,
+      quality: 75,
+    });
+    expect(out).toContain("/api/v1/image-proxy");
+  });
+});

--- a/packages/web/lib/image-loader.ts
+++ b/packages/web/lib/image-loader.ts
@@ -1,25 +1,51 @@
 import type { ImageLoaderProps } from "next/image";
 
 /**
- * Custom image loader — routes external images through our proxy
- * so Next.js can optimize them (resize, WebP/AVIF) regardless of hostname.
+ * Custom image loader.
  *
- * Flow: browser → /_next/image → /api/v1/image-proxy → external origin
- * After first request, Next.js caches the optimized result.
+ * Historical behavior (pre-#253): every external URL was wrapped as
+ * `/_next/image?url=/api/v1/image-proxy?url=<external>`. Vercel's image
+ * optimizer rejects that shape with `INVALID_IMAGE_OPTIMIZE_REQUEST` (HTTP 400)
+ * because the inner URL contains an embedded `?url=` query, breaking its
+ * local-pattern validation. Every external image on PRD failed at /_next/image.
+ *
+ * Current behavior:
+ * - Hosts in `ALLOWED_OPTIMIZER_HOSTS` (must ALSO be in
+ *   `next.config.js` → `images.remotePatterns`) → direct `/_next/image`.
+ *   Gets AVIF/WebP + resize.
+ * - Other external hosts (Pinterest, unknown origins, etc.) → bare
+ *   `/api/v1/image-proxy`. No optimization, but works and keeps the SSRF /
+ *   referer / size-cap hardening from #256/#229.
+ * - Local/relative → `/_next/image`.
+ *
+ * Keep `ALLOWED_OPTIMIZER_HOSTS` in sync with `next.config.js` remotePatterns.
  */
+const ALLOWED_OPTIMIZER_HOSTS = new Set<string>([
+  "pub-6354054b117b46b9a0fe99e4a546e681.r2.dev",
+]);
+
+function hostOf(src: string): string | null {
+  try {
+    return new URL(src).hostname;
+  } catch {
+    return null;
+  }
+}
+
 export default function imageLoader({
   src,
   width,
   quality,
 }: ImageLoaderProps): string {
-  const q = quality || 75;
+  const q = quality ?? 75;
 
-  // External URLs: proxy through our API so Next.js sees them as local
   if (src.startsWith("http://") || src.startsWith("https://")) {
-    const proxied = `/api/v1/image-proxy?url=${encodeURIComponent(src)}`;
-    return `/_next/image?url=${encodeURIComponent(proxied)}&w=${width}&q=${q}`;
+    const host = hostOf(src);
+    if (host && ALLOWED_OPTIMIZER_HOSTS.has(host)) {
+      return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${q}`;
+    }
+    return `/api/v1/image-proxy?url=${encodeURIComponent(src)}`;
   }
 
-  // Local/relative URLs: standard Next.js optimization
   return `/_next/image?url=${encodeURIComponent(src)}&w=${width}&q=${q}`;
 }

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -7,6 +7,15 @@ const nextConfig = {
   transpilePackages: ["@decoded/shared"],
   images: {
     localPatterns: [{ pathname: "/**" }],
+    // Direct-optimization allowlist — must stay in sync with
+    // `lib/image-loader.ts` ALLOWED_OPTIMIZER_HOSTS (see #253).
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "pub-6354054b117b46b9a0fe99e4a546e681.r2.dev",
+        pathname: "/**",
+      },
+    ],
     loaderFile: "./lib/image-loader.ts",
     formats: ["image/avif", "image/webp"],
     deviceSizes: [640, 750, 1080, 1920],


### PR DESCRIPTION
## Summary

홈 R2 아이템 썸네일이 PRD에서 **HTTP 400 + `x-vercel-error: INVALID_IMAGE_OPTIMIZE_REQUEST`** 로 반복 실패하던 버그 수정.

## Root cause

`lib/image-loader.ts`가 모든 외부 URL을 이중 래핑:

```
/_next/image?url=/api/v1/image-proxy?url=<external>&w=32&q=1
```

Vercel image optimizer는 내부 `url` 값에 embedded `?url=` 쿼리가 있으면 localPatterns 검증을 실패시키고 400 반환. 이 버그는 R2뿐 아니라 이 loader를 타는 **모든 외부 소스**가 PRD에서 이미지 못 뜨게 만들고 있었음.

증거:
- R2 직접: 200 ✅
- `/api/v1/image-proxy` 직접: 200 ✅ (#256 하드닝 정상 동작)
- `/_next/image?url=<proxied with ?url= inside>`: 400 with `INVALID_IMAGE_OPTIMIZE_REQUEST`

## 수정

- `lib/image-loader.ts`:
  - `ALLOWED_OPTIMIZER_HOSTS` (R2 public bucket 포함) → `/_next/image?url=<src>&w=…&q=…` 직접 최적화. AVIF/WebP + resize 그대로.
  - 그 외 외부 호스트(Pinterest, 미지정 origin) → `/api/v1/image-proxy?url=<src>` 단독. `/_next/image`는 래핑하지 않음 → 400 회피. 최적화는 없지만 #256/#229 SSRF/referer/size-cap 하드닝은 유지.
  - 로컬/상대 경로: 변경 없음.
- `next.config.js` → `images.remotePatterns`에 R2 공개 버킷 추가 (loader allowlist와 동기화).

## Test plan

- [x] `bunx vitest run lib/__tests__/image-loader.test.ts` — 7/7 passed (TDD 회귀 커버리지: R2 직접 최적화 / blur placeholder(w=32) / 비허용 외부→proxy / local / 이중 래핑 방지 / malformed URL fallback)
- [x] `bunx eslint lib/image-loader.ts lib/__tests__/image-loader.test.ts` — no errors
- [x] `bunx tsc --noEmit` — 변경 파일 관련 신규 에러 0
- [ ] Vercel Preview 배포 후 홈에서 R2 썸네일 + blur placeholder 실제 로드 확인

## 참고

- #229/#256 image-proxy 하드닝과 공존. 이 PR은 **loader 레벨**만 수정, proxy 자체는 손대지 않음.
- 외부 호스트를 추가로 optimizer 경로로 태우고 싶으면 `ALLOWED_OPTIMIZER_HOSTS` + `remotePatterns` 둘 다 갱신 (주석에 명시).

Closes #253