### PR TITLE
fix(api-server): swap admin middleware layer order so auth runs first (#257 follow-up)

### DIFF
--- a/packages/api-server/src/domains/admin/categories.rs
+++ b/packages/api-server/src/domains/admin/categories.rs
@@ -229,11 +229,15 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
         .route("/{id}", patch(update_category))
         .route("/order", put(update_category_order))
         .route("/{id}/status", patch(update_category_status))
+        // Layer order matters: last .layer() is outermost → runs first.
+        // admin_middleware needs the User extension set by auth_middleware, so
+        // auth must be OUTER (added last). Reversed order sent every admin
+        // request to 401 "Authentication required" — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }

--- a/packages/api-server/src/domains/admin/curations.rs
+++ b/packages/api-server/src/domains/admin/curations.rs
@@ -235,12 +235,13 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
         .route("/", post(create_curation))
         .route("/{id}", patch(update_curation).delete(delete_curation))
         .route("/order", put(update_curation_order))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }
 

--- a/packages/api-server/src/domains/admin/posts.rs
+++ b/packages/api-server/src/domains/admin/posts.rs
@@ -158,11 +158,12 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
         .route("/", get(list_posts))
         .route("/{id}", patch(admin_update_post))
         .route("/{id}/status", patch(update_post_status))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }

--- a/packages/api-server/src/domains/admin/solutions.rs
+++ b/packages/api-server/src/domains/admin/solutions.rs
@@ -130,11 +130,12 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
     Router::new()
         .route("/", get(list_solutions))
         .route("/{id}/status", patch(update_solution_status))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }

--- a/packages/api-server/src/domains/admin/spots.rs
+++ b/packages/api-server/src/domains/admin/spots.rs
@@ -85,11 +85,12 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
     Router::new()
         .route("/", get(list_spots))
         .route("/{id}/subcategory", patch(update_spot_subcategory))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }

--- a/packages/api-server/src/domains/admin/synonyms.rs
+++ b/packages/api-server/src/domains/admin/synonyms.rs
@@ -256,12 +256,13 @@ pub fn router(app_config: AppConfig) -> Router<AppState> {
         .route("/", get(list_synonyms).post(create_synonym))
         .route("/{id}", patch(update_synonym).delete(delete_synonym))
         .route("/sync", post(sync_synonyms))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }
 

--- a/packages/api-server/src/domains/reports/handlers.rs
+++ b/packages/api-server/src/domains/reports/handlers.rs
@@ -147,11 +147,12 @@ pub fn admin_router(app_config: AppConfig) -> Router<AppState> {
     Router::new()
         .route("/", get(admin_list_reports))
         .route("/{id}", patch(admin_update_report))
+        // Layer order: admin INNER, auth OUTER — see #257.
+        .layer(axum::middleware::from_fn(
+            crate::middleware::admin_middleware,
+        ))
         .layer(axum::middleware::from_fn_with_state(
             app_config.clone(),
             crate::middleware::auth_middleware,
-        ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
         ))
 }


### PR DESCRIPTION
## Summary

QA 중 admin `/posts` · `/reports` 가 **여전히** `{\"error\":{\"code\":401,\"message\":\"Authentication required\"}}` 를 던지는 문제 발견. PR #319가 Next.js에서 Supabase access_token forward를 고쳤지만 Rust 쪽 별도 버그가 남아 있었음.

## Root cause

7개 admin 서브라우터가 Axum middleware를 **역순**으로 레이어링:

\`\`\`rust
.layer(auth_middleware)   // added first → INNER → runs SECOND
.layer(admin_middleware)  // added second → OUTER → runs FIRST
\`\`\`

Axum은 마지막 \`.layer()\` 호출이 OUTERMOST이고 요청 시 가장 먼저 실행됨. admin_middleware는 auth_middleware가 삽입한 \`User\` Extension을 요구하므로, 순서가 뒤집히면 admin이 먼저 실행해서 \`User\` 없음 → \`AppError::Unauthorized(\"Authentication required\")\` → 401.

PR #252 (Rust audit 통합) 때 이 순서로 들어왔거나 이전부터 존재했던 버그.

## Fix

7개 admin 서브라우터에서 \`.layer()\` 두 줄을 스왑:

\`\`\`rust
.layer(admin_middleware)                    // INNER — runs after auth sets User
.layer(auth_middleware_with_state(config))  // OUTER — runs first, injects User
\`\`\`

이미 올바른 \`editorial_candidates\` / \`dashboard\` / \`magazine_sessions\` 패턴과 동일해짐.

## Affected routes

- \`/api/v1/admin/categories\`
- \`/api/v1/admin/curations\`
- \`/api/v1/admin/posts\` (#257)
- \`/api/v1/admin/solutions\`
- \`/api/v1/admin/spots\`
- \`/api/v1/admin/synonyms\`
- \`/api/v1/admin/reports\` (#257)

## Test plan

- [x] \`cargo check\` — ok
- [x] \`cargo test --lib middleware::\` — 39/39 passed
- [ ] **로컬/PRD 실행 테스트**: admin 로그인 후 \`/api/v1/admin/{posts,reports}\` 200 응답 확인
- [ ] 다른 5개 admin 도메인(\`/categories\`, \`/curations\`, \`/solutions\`, \`/spots\`, \`/synonyms\`) 회귀 smoke

## 관련

- Refs #257 (closed by #319 — Next.js 단만 수정됨, Rust 보완 PR)
- Follow-up: 나중에 admin route 공통 helper fn으로 감싸서 순서 실수를 컴파일 단에서 잡도록 리팩터 고려