### PR TITLE
fix(admin): redirect to /admin/login after logout

### DIFF
--- a/packages/web/lib/components/admin/AdminSidebar.tsx
+++ b/packages/web/lib/components/admin/AdminSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import {
   Activity,
   ArrowLeft,
@@ -128,10 +128,15 @@ export function AdminSidebar({
   adminName,
 }: AdminSidebarProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const logout = useAuthStore((state) => state.logout);
 
-  function handleLogout() {
-    logout();
+  async function handleLogout() {
+    // AdminLayout is a Server Component — it does not re-render on client
+    // auth state changes. After signing out we must push to /admin/login
+    // ourselves, otherwise the admin chrome stays visible with stale data.
+    await logout();
+    router.replace("/admin/login");
   }
 
   return (


### PR DESCRIPTION
## Summary

Admin 사이드바 로그아웃 버튼 클릭 시 `DELETE /api/auth/session` 은 200 반환하고 클라이언트 store state는 클리어되지만, **화면은 admin chrome 그대로 유지**되고 로그인 페이지로 넘어가지 않는 UX 버그.

## Root cause

- `AdminSidebar.handleLogout` 은 `useAuthStore.logout()` 만 호출
- `AdminLayout` 은 **React Server Component** → 클라이언트 auth state 변경에 재실행되지 않음 → admin chrome 잔존
- 최초 도달한 admin 페이지는 user=null 이지만 이미 서버 렌더된 상태라 그대로 표시

## Fix

`AdminSidebar.handleLogout` 에서 `logout()` 대기 후 `router.replace("/admin/login")` 호출. Replace 로 back-navigation 방지. Client 전환 시 layout 이 다시 돌아 login 페이지 fallback 이 적용됨.

```tsx
async function handleLogout() {
  await logout();
  router.replace("/admin/login");
}
```

## Test plan

- [x] `bunx eslint lib/components/admin/AdminSidebar.tsx` — pre-existing warning 외 이슈 없음
- [x] `bunx tsc --noEmit` — 신규 에러 0
- [ ] 브라우저 수동 확인: admin 페이지에서 Logout 클릭 → 즉시 /admin/login 전환

## 스코프 외 (후속 후보)

- `SmartNav` / `profile-header-card` / `desktop-header` 의 logout 도 동일 패턴 점검 필요 (public 페이지는 서버 레이아웃 재실행 패턴이 달라 증상이 다를 수 있음). 본 PR 은 admin 영역만.