### PR TITLE
docs(harness): Sub-4 Finding 1·2 — summary-first routing + harness wiki expansion (#232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,18 +20,39 @@ Monorepo for the decoded platform — image/item discovery and curation with beh
 
 ## Agent reference (`docs/agent/`)
 
-| 문서                                                                             | 용도                                   |
-| -------------------------------------------------------------------------------- | -------------------------------------- |
-| [`docs/agent/README.md`](docs/agent/README.md)                                   | 목차·언제 무엇을 읽을지                |
+### Topic routing (1순위: `*-summary.md` → canonical)
+
+Topic 질의(아키텍처 / API / DB / 디자인 시스템 / AI playbook)는 **먼저 summary**를 읽고, summary가 가리키는 canonical(`.planning/codebase/*`, `docs/architecture/`, `docs/api/`, `docs/database/`, `docs/ai-playbook/`) 으로 내려간다. canonical을 먼저 열면 설계 의도와 스냅샷을 혼동한다.
+
+| Topic         | Summary (먼저 읽기)                                                          |
+| ------------- | ---------------------------------------------------------------------------- |
+| architecture  | [`docs/agent/architecture-summary.md`](docs/agent/architecture-summary.md)   |
+| api           | [`docs/agent/api-summary.md`](docs/agent/api-summary.md)                     |
+| database      | [`docs/agent/database-summary.md`](docs/agent/database-summary.md)           |
+| design-system | [`docs/agent/design-system-summary.md`](docs/agent/design-system-summary.md) |
+| ai-playbook   | [`docs/agent/ai-playbook-summary.md`](docs/agent/ai-playbook-summary.md)     |
+
+### 참조 인벤토리 (표·라우트·훅)
+
+| 문서                                                                             | 용도                                             |
+| -------------------------------------------------------------------------------- | ------------------------------------------------ |
+| [`docs/agent/README.md`](docs/agent/README.md)                                   | 목차·언제 무엇을 읽을지                          |
 | [`docs/agent/environments.md`](docs/agent/environments.md)                       | **env matrix (dev=local / prod=Cloud Supabase)** |
-| [`docs/DATABASE-MIGRATIONS.md`](docs/DATABASE-MIGRATIONS.md)                     | **DB 마이그레이션 SOT / 워크플로우**   |
-| [`docs/agent/staging.md`](docs/agent/staging.md)                                 | staging 정의 (현재 없음)               |
-| [`docs/agent/web-routes-and-features.md`](docs/agent/web-routes-and-features.md) | 웹 라우트·기능 영역                    |
-| [`docs/agent/api-v1-routes.md`](docs/agent/api-v1-routes.md)                     | Next.js `/api/v1/*` 표                 |
-| [`docs/agent/web-hooks-and-stores.md`](docs/agent/web-hooks-and-stores.md)       | 훅·스토어·주요 경로                    |
-| [`docs/agent/design-system-llm.md`](docs/agent/design-system-llm.md)             | 디자인 시스템 import·컴포넌트 목록     |
-| [`docs/agent/warehouse-schema.md`](docs/agent/warehouse-schema.md)               | Warehouse 스키마 (ETL·Seed 파이프라인) |
-| [`packages/api-server/AGENT.md`](packages/api-server/AGENT.md)                   | Rust API 크레이트 전용                 |
+| [`docs/DATABASE-MIGRATIONS.md`](docs/DATABASE-MIGRATIONS.md)                     | **DB 마이그레이션 SOT / 워크플로우**             |
+| [`docs/agent/staging.md`](docs/agent/staging.md)                                 | staging 정의 (현재 없음)                         |
+| [`docs/agent/web-routes-and-features.md`](docs/agent/web-routes-and-features.md) | 웹 라우트·기능 영역                              |
+| [`docs/agent/api-v1-routes.md`](docs/agent/api-v1-routes.md)                     | Next.js `/api/v1/*` 표                           |
+| [`docs/agent/web-hooks-and-stores.md`](docs/agent/web-hooks-and-stores.md)       | 훅·스토어·주요 경로                              |
+| [`docs/agent/design-system-llm.md`](docs/agent/design-system-llm.md)             | 디자인 시스템 import·컴포넌트 목록               |
+| [`docs/agent/warehouse-schema.md`](docs/agent/warehouse-schema.md)               | Warehouse 스키마 (ETL·Seed 파이프라인)           |
+| [`packages/api-server/AGENT.md`](packages/api-server/AGENT.md)                   | Rust API 크레이트 전용                           |
+
+### Harness knowledge (세션 규율)
+
+- [`docs/wiki/wiki/harness/claude-code.md`](docs/wiki/wiki/harness/claude-code.md) — Claude Code 세션·worktree·Draft PR·Auto Mode
+- [`docs/wiki/wiki/harness/session-discipline.md`](docs/wiki/wiki/harness/session-discipline.md) — 세션 분리, 상태 격리, cwd 리셋
+- [`docs/wiki/wiki/harness/commit-protocol.md`](docs/wiki/wiki/harness/commit-protocol.md) — Conventional Commits, fmt/check, PR 범위
+- [`docs/wiki/wiki/harness/review-flow.md`](docs/wiki/wiki/harness/review-flow.md) — 리뷰/검증 레인 분리, self-approve 금지
 
 ## Conventions (SSOT)
 

--- a/docs/wiki/wiki/INDEX.md
+++ b/docs/wiki/wiki/INDEX.md
@@ -2,7 +2,7 @@
 title: LLM Wiki — Index
 owner: llm
 status: draft
-updated: 2026-04-17
+updated: 2026-04-23
 tags: [agent, llm-write]
 related:
   - docs/wiki/schema/README.md
@@ -16,6 +16,9 @@ related:
 ## Harness
 
 - [harness/claude-code.md](harness/claude-code.md) — Claude Code 세션 규율·worktree·Draft PR·Auto Mode
+- [harness/session-discipline.md](harness/session-discipline.md) — 세션 분리·state 격리·cwd·브랜치
+- [harness/commit-protocol.md](harness/commit-protocol.md) — Conventional Commits·패키지 스코프·pre-commit
+- [harness/review-flow.md](harness/review-flow.md) — write/review 레인 분리·self-approve 금지·evidence
 
 ## (비어 있음)
 

--- a/docs/wiki/wiki/harness/commit-protocol.md
+++ b/docs/wiki/wiki/harness/commit-protocol.md
@@ -1,0 +1,92 @@
+---
+title: Commit Protocol — Harness Knowledge
+owner: llm
+status: draft
+updated: 2026-04-23
+tags: [harness, agent, git, commit]
+related:
+  - CLAUDE.md
+  - docs/GIT-WORKFLOW.md
+  - docs/wiki/schema/conventions.md
+  - packages/api-server/CLAUDE.md
+---
+
+# Commit Protocol
+
+Conventional Commits + 패키지 스코프 + 사전 체크가 전제. 로컬에서 실패할 체크는 커밋하지 않는다.
+
+## Message format
+
+`<type>(<scope>): <subject>` — Conventional Commits 준수.
+
+- **type**: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `build`, `style`
+- **scope**: 보통 패키지 이름. `web`, `api-server`, `ai-server`, `shared`, `mobile` 중 하나. 여러 패키지에 걸친 구조 변경은 `monorepo` / `harness` / `docs` 사용.
+- **subject**: 60자 내, 명령형, 마침표 없음.
+
+예:
+
+- `feat(web): add editorial carousel skeleton`
+- `fix(api-server): swap admin middleware layer order (#257 follow-up)`
+- `chore(harness): promote *-summary.md as first-read in CLAUDE.md`
+
+## Scope by package
+
+- `packages/web/**` → `web`
+- `packages/api-server/**` → `api-server`
+- `packages/ai-server/**` → `ai-server`
+- `packages/shared/**` → `shared`
+- `packages/mobile/**` → `mobile`
+- `docs/**`, `.cursor/**`, `CLAUDE.md` → `docs` 또는 `harness`
+- 여러 패키지 동시 변경 → `monorepo`
+
+여러 커밋으로 분할하는 편이 진단에 유리하다 — 패키지 경계를 넘어가는 단일 커밋은 지양.
+
+## Pre-commit checks
+
+리포의 pre-push hook(`just ci-web`, `cargo check` 등)은 로컬에서 먼저 돌린다. 실패한 채로 push하지 말 것.
+
+### web / shared (TypeScript)
+
+```bash
+bun run lint
+just ci-web   # lint + format + tsc
+```
+
+### api-server (Rust)
+
+```bash
+cargo fmt --check
+cargo check
+# 필요시: cargo clippy --all-targets
+```
+
+추가 규칙은 [`packages/api-server/CLAUDE.md`](../../../../packages/api-server/CLAUDE.md) §1 참고 — 라인 카운트 업데이트, REQUIREMENT.md 변경 이력 등.
+
+### docs
+
+- 내부 링크 깨짐 여부를 에디터 프리뷰로 확인.
+- YAML frontmatter 유지(owner / status / updated / tags).
+
+## Branch / PR 범위
+
+- **Feature branch 1개 = PR 1개 = 이슈 1개**가 기본.
+- 작은 cross-cutting chore는 묶어도 되지만, 패키지가 2개 이상 바뀌면 PR 설명에 각 패키지의 영향 범위를 명시.
+- `feat`와 `refactor`를 섞지 않는다 — 리뷰어가 diff에서 기능 변경과 기계적 변경을 분리할 수 있어야 한다.
+- 생성 코드(`packages/web/lib/api/generated/**`)는 **커밋하지 않는다** — diff에 등장하면 revert 대상.
+
+## Forbidden
+
+- `--no-verify`, `--no-gpg-sign`: 훅/서명을 의도적으로 우회하지 않는다.
+- `git push --force` to `main` / `dev`: 금지. feature 브랜치에만 허용, 그마저도 `--force-with-lease`.
+- Amend after push: PR 리뷰가 시작된 뒤엔 amend 대신 **새 커밋**으로 대응.
+- secrets (.env, token, key) 커밋: 사고 발생 시 rotate + `git-filter-repo`로 이력 정리.
+
+## Co-author / attribution
+
+- AI 생성 보조가 있을 때는 trailer에 명시:
+  - `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- 여러 에이전트 협업이면 각 에이전트를 trailer에 나열.
+
+## Recent changes
+
+- 2026-04-23: 초기 작성 (Phase 1 Finding 2 follow-up, #232)

--- a/docs/wiki/wiki/harness/commit-protocol.md
+++ b/docs/wiki/wiki/harness/commit-protocol.md
@@ -3,7 +3,7 @@ title: Commit Protocol — Harness Knowledge
 owner: llm
 status: draft
 updated: 2026-04-23
-tags: [harness, agent, git, commit]
+tags: [harness, agent]
 related:
   - CLAUDE.md
   - docs/GIT-WORKFLOW.md
@@ -11,7 +11,7 @@ related:
   - packages/api-server/CLAUDE.md
 ---
 
-# Commit Protocol
+# Commit Protocol — Harness Knowledge
 
 Conventional Commits + 패키지 스코프 + 사전 체크가 전제. 로컬에서 실패할 체크는 커밋하지 않는다.
 

--- a/docs/wiki/wiki/harness/review-flow.md
+++ b/docs/wiki/wiki/harness/review-flow.md
@@ -1,0 +1,71 @@
+---
+title: Review Flow — Harness Knowledge
+owner: llm
+status: draft
+updated: 2026-04-23
+tags: [harness, agent, review, verification]
+related:
+  - CLAUDE.md
+  - docs/wiki/wiki/harness/commit-protocol.md
+  - docs/GIT-WORKFLOW.md
+---
+
+# Review Flow
+
+작성(write) 레인과 검토(review/verify) 레인을 **같은 세션에서 겸하지 않는다**. self-approve는 금지.
+
+## 두 개의 레인
+
+| Lane    | 역할                                   | 담당                                                   |
+| ------- | -------------------------------------- | ------------------------------------------------------ |
+| Write   | 구현, 편집, 생성 (feat/fix/refactor)   | executor / designer / writer / human                   |
+| Review  | 정합성·품질·보안 평가, evidence 수집   | code-reviewer / verifier / critic / security-reviewer  |
+
+- Write 세션이 방금 만든 diff를 **같은 활성 컨텍스트**에서 자기 승인하지 않는다.
+- Review 레인은 항상 별도 세션/서브에이전트/사람이 돌린다. 결과는 PR 코멘트·체크리스트로 축적.
+
+## PR 생성 전 self-check
+
+실행자 본인이 수행 — 이건 review가 아니라 "완료 선언 전 최소 증거 수집":
+
+1. `cargo fmt --check`, `bun run lint`, `just ci-web`, `cargo check` 등 로컬 체크 통과 확인.
+2. 타겟 기능을 **실제로 구동**하여 기대 동작을 확인 (UI면 dev server, API면 curl / `just api-smoke`).
+3. 테스트가 관련되어 있으면 해당 테스트만이라도 돌려 pass 확인.
+4. PR 본문에 "검증 방법" 섹션 — reviewer가 같은 절차로 재현할 수 있어야 한다.
+
+통과하지 않은 상태로 PR을 열지 않는다. Draft PR이면 예외이지만 Draft 해제 전에는 반드시 통과.
+
+## Reviewer 역할
+
+- **code-reviewer**: SOLID, 스타일, 로직 결함, 회귀 위험 지적. severity-rated.
+- **verifier**: 요구사항 vs 구현 대조. "완료 주장"에 대한 evidence 확보.
+- **security-reviewer**: OWASP / secrets / unsafe patterns 스캔.
+- **critic**: 계획·접근 자체를 여러 관점에서 재검토.
+
+OMC 사용 시 리뷰는 `code-reviewer` 또는 `verifier` 서브에이전트에게 위임한다. 리뷰 결과는 main 세션의 최종 approval을 대체하지 않는다 — 사람 eyes-on은 merge 전 필수.
+
+## Merge 규칙
+
+- `dev` ← `feature/*`: review 1명 이상 승인 + CI green + 셀프 체크 완료.
+- `main` ← `dev`: 릴리스 기준 체크리스트(`/ship` 또는 `/land-and-deploy`). hotfix 예외는 `docs/GIT-WORKFLOW.md` 참조.
+- Force merge, admin override는 사용하지 않는다. 실패한 체크가 있으면 수정 후 재실행.
+
+## Evidence & audit trail
+
+- PR 설명에 다음을 남긴다:
+  - **What**: 변경 요약 (bullet 3~5개)
+  - **Why**: 연결된 이슈/링크, 의사결정 컨텍스트
+  - **How verified**: 명령, 화면, 로그, 테스트 이름
+  - **Risk**: rollback 방법, feature flag / kill switch
+- 승인 코멘트도 evidence에 포함: "CI green / manual smoke: X·Y·Z pass".
+
+## Anti-patterns
+
+- 같은 세션에서 구현 → 자기 PR 코멘트로 approve → merge. (self-approve 금지)
+- "테스트는 있는데 검증은 안 돌려봤다"는 완료 주장. (pass ≠ 검증)
+- 리뷰 코멘트를 "agreed" 한 줄로 닫고 수정 없이 merge. (agree-but-ignore)
+- Review 레인이 Write 레인의 실패를 숨기기 위한 형식상 승인. (performative review)
+
+## Recent changes
+
+- 2026-04-23: 초기 작성 (Phase 1 Finding 2 follow-up, #232)

--- a/docs/wiki/wiki/harness/review-flow.md
+++ b/docs/wiki/wiki/harness/review-flow.md
@@ -3,14 +3,14 @@ title: Review Flow — Harness Knowledge
 owner: llm
 status: draft
 updated: 2026-04-23
-tags: [harness, agent, review, verification]
+tags: [harness, agent, testing]
 related:
   - CLAUDE.md
   - docs/wiki/wiki/harness/commit-protocol.md
   - docs/GIT-WORKFLOW.md
 ---
 
-# Review Flow
+# Review Flow — Harness Knowledge
 
 작성(write) 레인과 검토(review/verify) 레인을 **같은 세션에서 겸하지 않는다**. self-approve는 금지.
 

--- a/docs/wiki/wiki/harness/session-discipline.md
+++ b/docs/wiki/wiki/harness/session-discipline.md
@@ -1,0 +1,59 @@
+---
+title: Session Discipline — Harness Knowledge
+owner: llm
+status: draft
+updated: 2026-04-23
+tags: [harness, agent, session, worktree]
+related:
+  - CLAUDE.md
+  - docs/wiki/wiki/harness/claude-code.md
+  - docs/wiki/schema/conventions.md
+  - docs/GIT-WORKFLOW.md
+---
+
+# Session Discipline
+
+한 repo를 여러 에이전트 세션이 동시에 다룬다는 가정에서 세션을 충돌 없이 운영하기 위한 규율 모음.
+
+## Worktree per issue
+
+- 작업 브랜치는 **반드시** 별도 worktree에서 다룬다: `.worktrees/<issue-or-slug>`
+- 생성: `git worktree add -b <type>/<N>-<slug> .worktrees/<slug> origin/dev`
+- 종료: `git worktree remove .worktrees/<slug>` (PR 머지 후)
+- 루트 체크아웃은 오래 돌아가는 관찰 세션 전용. 실제 편집은 worktree에서.
+
+## State / artifact 격리
+
+- `.omc/`, `.claude/state`, `.planning/` 하위 세션 아티팩트(jsonl, state json 등)는 **현재 세션 산출물**. 다른 worktree로 끌고 오지 않는다.
+- 루트에 남은 dirty `.omc/**` 변경은 worktree PR에 포함시키지 않는다 — worktree는 `origin/dev`에서 잘라낸 깨끗한 상태로 출발.
+- `.omc/project-memory.json`, `.omc/notepad.md`, `.omc/logs/` 등 대부분의 state는 gitignore 대상이거나 agent-owned. PR diff에서 보이면 제거.
+
+## cwd / 절대경로
+
+- Bash 호출 간 `cd` 효과는 유지되지 않는다 (hook이 cwd를 초기화). 매 호출에 **절대경로** 사용.
+- 어쩔 수 없이 `cd`가 필요하면 같은 호출에서 `&&`로 체이닝.
+- Read/Edit/Write 도구 인자도 항상 절대경로. 상대경로는 예기치 않은 root에서 실패한다.
+
+## Branching & push
+
+- Feature 작업은 `feature/<N>-<slug>` → `dev` → `main`.
+- `main`/`dev`에 **직접 push 금지**. dev는 PR 머지만 허용.
+- 긴급 hotfix는 `hotfix/*` → `main` PR (상세: [`docs/GIT-WORKFLOW.md`](../../../GIT-WORKFLOW.md)).
+- Draft PR은 `scripts/start-issue.sh <N> [type]`로 생성하면 프로젝트 보드가 자동 In Progress 전환.
+
+## Session handoff
+
+- `compact` / `clear` 전에 **무엇이 durable한지** 확인:
+  - 커밋됨? 푸시됨? PR에 반영됨? 문서 업데이트됨?
+- 휘발 상태(in-memory plan, unwritten todo)는 commit 또는 `.planning/` 아티팩트로 내려놔야 한다.
+- `/gsd:pause-work`, `/gsd:resume-work`, memory 시스템(`.claude-pers/**`)이 공식 핸드오프 채널.
+
+## Gotchas
+
+- `EnterWorktree` 후에도 원래 브랜치의 dirty 파일은 그대로 남아 있다 — 의도적이지 않으면 버리거나 stash.
+- worktree 안에서 `git fetch origin <branch>` 이후 `git rebase origin/<branch>`로 최신화. `git pull`은 기본 전략이 다를 수 있어 피한다.
+- PR merge 후 worktree 제거를 잊으면 `.worktrees/` 폴더가 오래된 브랜치로 누적된다. 주기적 청소 필요.
+
+## Recent changes
+
+- 2026-04-23: 초기 작성 (Phase 1 Finding 2 follow-up, #232)

--- a/docs/wiki/wiki/harness/session-discipline.md
+++ b/docs/wiki/wiki/harness/session-discipline.md
@@ -3,7 +3,7 @@ title: Session Discipline — Harness Knowledge
 owner: llm
 status: draft
 updated: 2026-04-23
-tags: [harness, agent, session, worktree]
+tags: [harness, agent, claude-code]
 related:
   - CLAUDE.md
   - docs/wiki/wiki/harness/claude-code.md
@@ -11,7 +11,7 @@ related:
   - docs/GIT-WORKFLOW.md
 ---
 
-# Session Discipline
+# Session Discipline — Harness Knowledge
 
 한 repo를 여러 에이전트 세션이 동시에 다룬다는 가정에서 세션을 충돌 없이 운영하기 위한 규율 모음.
 


### PR DESCRIPTION
## Summary

Issue #232 (Sub-4) 코멘트의 Phase 1 동적 점검 Finding 2건에 대응.

- **Finding 1 — topic summary 진입 유도력 약함**: `CLAUDE.md` "Agent reference" 섹션을 재구성하여 topic 질의(architecture / api / db / design-system / ai-playbook)에 대해 `docs/agent/*-summary.md` → canonical 순서로 진입하도록 routing rule을 명문화. fresh subagent가 `.planning/codebase/STRUCTURE.md` 등 canonical을 먼저 열어 설계 의도와 스냅샷을 혼동하던 문제 해소.
- **Finding 2 — `wiki/wiki/harness/` POC 1건 한계**: `session-discipline.md` · `commit-protocol.md` · `review-flow.md` 3개 문서 추가하여 세션 규율 · 커밋 규약 · 리뷰/검증 레인 분리를 패턴으로 축적. `INDEX.md` 등재 + `CLAUDE.md`에서 직접 노출.

## Changes

- `CLAUDE.md`: "Agent reference" 섹션 2단 구성(summary-first → 참조 인벤토리) + "Harness knowledge" 블록 추가
- `docs/wiki/wiki/harness/session-discipline.md` (신규)
- `docs/wiki/wiki/harness/commit-protocol.md` (신규)
- `docs/wiki/wiki/harness/review-flow.md` (신규)
- `docs/wiki/wiki/INDEX.md`: Harness 섹션에 3건 등재 + updated 날짜 갱신

## Test plan

- [x] CLAUDE.md 내부 링크(`docs/agent/*-summary.md`, `docs/wiki/wiki/harness/*.md`) 모두 실파일 존재 확인
- [x] 새 harness 문서 내부 상대경로(`../../../GIT-WORKFLOW.md`, `../../../../packages/api-server/CLAUDE.md`) 유효성 확인
- [x] `INDEX.md` 링크 → 추가 파일로 정상 연결
- [ ] Reviewer: fresh subagent 1회 체크 — "admin 아키텍처 구조 설명해줘" 질의 시 `architecture-summary.md`를 먼저 펼치는지 (회귀 확인용)
- [ ] Reviewer: "worktree 병렬 작업 규칙은?" 질의 시 `harness/session-discipline.md`가 `.gitignore`보다 먼저 참조되는지

## Refs

- Closes part of #232 (Sub-4 Finding 1 / Finding 2 — 남은 scope: `.cursor/rules/*.mdc` 일관화, `/ingest`·`/wiki` slash command 정의, ai-playbook deprecation)
- Related: #153 (Phase 1 메타), #231 / PR #233 (Sub-3 ingest CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)