### PR TITLE
docs(ai-playbook): deprecate Codex profile + update workflow (#232 Sub-4)

### DIFF
--- a/docs/agent/ai-playbook-summary.md
+++ b/docs/agent/ai-playbook-summary.md
@@ -2,7 +2,7 @@
 title: AI Playbook — Agent Summary
 owner: llm
 status: draft
-updated: 2026-04-17
+updated: 2026-04-23
 tags: [agent, harness, claude-code, cursor]
 related:
   - docs/ai-playbook/01-principles.md
@@ -15,7 +15,7 @@ related:
 
 ## Purpose
 
-에이전트별(Claude / Cursor / Gemini / Codex) 사용 프로필 요약. 세션 시작 시 "어느 프로필을 읽어야 하는가"를 안내.
+에이전트별(Claude / Cursor / Gemini) 사용 프로필 요약. 세션 시작 시 "어느 프로필을 읽어야 하는가"를 안내. Codex는 2026-04-23부로 deprecated (#232 Sub-4) — 프로필 파일은 히스토리 참고용으로만 남아 있음.
 
 ## Canonical sources
 
@@ -24,7 +24,7 @@ related:
 - Claude: [`docs/ai-playbook/claude-profile.md`](../ai-playbook/claude-profile.md)
 - Cursor: [`docs/ai-playbook/cursor-profile.md`](../ai-playbook/cursor-profile.md)
 - Gemini: [`docs/ai-playbook/gemini-profile.md`](../ai-playbook/gemini-profile.md)
-- Codex: [`docs/ai-playbook/codex-profile.md`](../ai-playbook/codex-profile.md)
+- ~~Codex: [`docs/ai-playbook/codex-profile.md`](../ai-playbook/codex-profile.md)~~ (deprecated 2026-04-23)
 
 ## Key files / concepts
 
@@ -34,9 +34,10 @@ related:
 
 ## Gotchas
 
-- Codex 프로필은 stale 가능성 있음 (구독 상태: "No Codex (미구독)"). Sub-4에서 deprecation 검토.
+- Codex 프로필은 **deprecated (2026-04-23)** — 새 워크플로우에서 참조하지 않는다. 대체 경로: `/gsd:discuss-phase` → `/gsd:plan-phase` + gstack `/plan-eng-review`. 상세는 `codex-profile.md` 상단 배너.
 - Claude / Cursor는 같은 repo에서 공존. 충돌 영역은 `docs/wiki/schema/conventions.md`에서 관리.
 
 ## Recent changes
 
+- 2026-04-23: Codex 프로필 deprecated 명시, 대체 경로 링크 (#232 Sub-4)
 - 2026-04-17: 초기 작성 (Phase 1)

--- a/docs/ai-playbook/02-workflow-overview.md
+++ b/docs/ai-playbook/02-workflow-overview.md
@@ -2,14 +2,16 @@
 title: AI Playbook — Workflow Overview
 owner: human
 status: approved
-updated: 2026-04-17
+updated: 2026-04-23
 tags: [agent, harness]
 ---
 
 # AI Playbook — Workflow Overview
 
-**최종 검증**: 2025-01-27
-**버전**: 1.0
+**최종 검증**: 2026-04-23
+**버전**: 1.1
+
+> 2026-04-23 (#232 Sub-4): Codex 기반 단계를 제거하고 현행 하네스 (Claude + gstack + GSD) 중심으로 재정비. 상세는 [`docs/ai-playbook/codex-profile.md`](codex-profile.md) deprecation 배너 참조.
 
 ## 기본 기능 워크플로우
 
@@ -18,7 +20,9 @@ tags: [agent, harness]
 ### 1. 정의
 
 - GitHub Issue를 생성하거나 다듬습니다.
-- Codex + `docs/prompts/codex/spec-from-issue.md`를 사용하여 `specs/feature/` 아래에 기능 스펙을 생성합니다.
+- `/gsd:discuss-phase N` → `/gsd:plan-phase N`으로 `.planning/phase-N/PLAN.md`를 생성합니다.
+  - 스펙이 GitHub Issue 단위라면 gstack `/plan-eng-review`가 보조 아키텍처 검토를 제공합니다.
+  - (이전에 사용하던 `Codex + docs/prompts/codex/spec-from-issue.md` 경로는 2026-04-23부로 폐기.)
 
 ### 2. 검토
 
@@ -28,10 +32,10 @@ tags: [agent, harness]
 
 ### 3. 구현
 
-- Cursor를 메인 코딩 어시스턴트로 사용:
+- Cursor 또는 Claude Code를 메인 코딩 어시스턴트로 사용:
   - 스펙을 읽습니다.
-  - `.cursor/rules/*` (base + frontend + ai-collab)를 적용합니다.
-  - 작은 커밋으로 변경사항을 구현합니다.
+  - `.cursor/rules/*` (base + frontend + ai-collab) 또는 `CLAUDE.md`를 적용합니다.
+  - 작은 커밋으로 변경사항을 구현합니다. 커밋 규약은 [`docs/wiki/wiki/harness/commit-protocol.md`](../wiki/wiki/harness/commit-protocol.md).
 
 ### 4. 문서화
 
@@ -54,16 +58,16 @@ tags: [agent, harness]
 ### 간단한 리팩토링
 
 1. **Claude**: 코드를 분석하고 리팩토링 계획을 제안
-2. **Cursor**: 계획에 따라 리팩토링 적용
+2. **Cursor / Claude Code**: 계획에 따라 리팩토링 적용
 
 ### 버그 수정
 
-1. **Codex**: 버그 수정 스펙 생성 (간단한 수정의 경우 선택사항)
-2. **Cursor**: 수정 구현
+1. **Claude / gstack `/investigate`**: 근본 원인 조사 (이전 "Codex 버그 수정 스펙 생성" 단계 대체)
+2. **Cursor / Claude Code**: 수정 구현
 3. **Gemini**: 수정 문서화 (선택사항)
 
 ## 통합 노트
 
 - **Harness Workflow**: gstack(기획/QA) + Superpowers(TDD) + GSD quick(유지보수). 상세: `CLAUDE.md`의 Harness Workflow 섹션 참조.
 - **Cursor Rules** (`.cursor/rules/`): Cursor 사용 시 자동 적용됩니다.
-- **템플릿**: Gemini와 Codex용 템플릿은 `docs/prompts/`에 있습니다.
+- **템플릿**: Gemini용 템플릿은 `docs/prompts/gemini/`에 있습니다. `docs/prompts/codex/`는 Codex 경로와 함께 deprecated — 새 작업에서 참조하지 않습니다.

--- a/docs/ai-playbook/codex-profile.md
+++ b/docs/ai-playbook/codex-profile.md
@@ -1,14 +1,24 @@
 ---
-title: Codex Profile
+title: Codex Profile (DEPRECATED)
 owner: human
-status: stale
-updated: 2026-04-17
+status: deprecated
+updated: 2026-04-23
 tags: [agent, harness, deprecated]
 ---
 
-# Codex Profile
+# Codex Profile (DEPRECATED)
 
-**Last verified**: 2025-01-27  
+> **⚠ DEPRECATED (2026-04-23, #232 Sub-4)** — 이 repo에서 Codex 기반 워크플로우는 더 이상 사용하지 않는다. 사유: 구독 없음 (전역 `CLAUDE.md` "No Codex (미구독)" 정책). 아래 내용은 히스토리 참고용으로만 남겨 둔다.
+>
+> **대체 경로**:
+>
+> - 스펙 생성 (issue → spec): `/gsd:discuss-phase` / `/gsd:plan-phase` 또는 gstack `/plan-eng-review` → `.planning/` 아티팩트
+> - 체크리스트: gstack `/review`, `/qa` 스킬이 생성
+> - 런북: `docs/runbooks/` 직접 편집
+>
+> 현행 워크플로우: [`docs/ai-playbook/02-workflow-overview.md`](02-workflow-overview.md)
+
+**Last verified**: 2025-01-27 (as active profile — deprecated 2026-04-23)  
 **Version**: 1.0
 
 ## Primary Use


### PR DESCRIPTION
## Summary

Issue #232 (Sub-4) Scope 중 **\"docs/ai-playbook/ stale 콘텐츠 (Codex 등) deprecation\"** 항목 처리. 전역 정책이 \"No Codex (미구독)\"인데 워크플로우 1단계가 Codex 기반 스펙 생성이라 새 기여자가 막다른 경로를 밟던 문제 해소.

## Changes

- `docs/ai-playbook/codex-profile.md`
  - 상단 **DEPRECATED (2026-04-23)** 배너 추가 + 대체 경로(`/gsd:discuss-phase`, `/gsd:plan-phase`, gstack `/plan-eng-review`, `docs/runbooks/`) 명시
  - frontmatter `status: stale` → `deprecated`, title/제목 갱신
  - 본문은 히스토리 보존 목적으로 그대로 유지
- `docs/ai-playbook/02-workflow-overview.md`
  - 1단계 "정의": Codex 경로 제거, `/gsd:discuss-phase` → `/gsd:plan-phase`로 교체
  - 버그 수정 흐름: "Codex 버그 수정 스펙 생성" → "Claude / gstack `/investigate`"
  - 통합 노트: `docs/prompts/codex/` deprecated 명시
  - commit-protocol harness 문서 교차 링크 추가
  - 버전/검증 날짜 갱신 (1.0 → 1.1)
- `docs/agent/ai-playbook-summary.md`
  - Purpose에서 Codex 제외
  - Canonical sources의 Codex 링크에 취소선 + deprecated 표기
  - Gotchas: "stale 가능성 → Sub-4 검토" → "deprecated 확정 + 대체 경로"

## Test plan

- [x] `bun run wiki:lint` 통과 (0 errors, 0 warnings)
- [x] `codex-profile.md` 상대 링크 (`02-workflow-overview.md`) 유효
- [x] `02-workflow-overview.md` 상대 링크 (`codex-profile.md`, `commit-protocol.md`) 유효
- [ ] Reviewer: 대체 경로가 현재 실제로 동작하는지 확인 (`/gsd:*`, gstack `/investigate` 접근 가능 여부)

## Refs

- Closes part of #232 (Sub-4 Scope — ai-playbook deprecation)
- 관련: PR #323 (Sub-4 Finding 1·2: summary-first routing + harness wiki 확장)
- 남은 Sub-4 scope: \`.cursor/rules/*.mdc\` 일관화, \`/ingest\`·\`/wiki\` slash command, Sub-3 CLI pre-push/CI 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)