### PR TITLE
docs(harness): .cursor/rules schema 참조 일관화 (#232)

### DIFF
--- a/.cursor/rules/api-routes.mdc
+++ b/.cursor/rules/api-routes.mdc
@@ -54,3 +54,7 @@ const limit = Number(request.nextUrl.searchParams.get('limit')) || 20;
 - Set appropriate status codes (200, 201, 400, 401, 404, 500)
 - Log errors server-side before returning generic error messages
 - Use `export const dynamic = 'force-dynamic'` for non-cacheable routes
+
+## Conventions (shared)
+
+공용 컨벤션(commit, lint, env, generated API 등)은 [docs/wiki/schema/conventions.md](../../docs/wiki/schema/conventions.md)를 참조한다. 이 파일은 Next.js API route 특이사항만 유지한다.

--- a/.cursor/rules/react-components.mdc
+++ b/.cursor/rules/react-components.mdc
@@ -56,3 +56,7 @@ export function MyComponent({ title, variant = 'default', className, ...props }:
 ## State Management
 - Zustand stores in `lib/stores/` (e.g., `authStore.ts`, `searchStore.ts`)
 - Pattern: `create<T>()((set, get) => ({ ... }))`
+
+## Conventions (shared)
+
+공용 컨벤션(commit, lint, env, generated API 등)은 [docs/wiki/schema/conventions.md](../../docs/wiki/schema/conventions.md)를 참조한다. React 19 / Next.js 16 / Design System 전역 사항은 [.cursor/rules/monorepo.mdc](./monorepo.mdc)가 담고, 이 파일은 tsx 컴포넌트 패턴 특이사항만 유지한다.

--- a/.cursor/rules/rust-api.mdc
+++ b/.cursor/rules/rust-api.mdc
@@ -62,3 +62,7 @@ packages/api-server/
 - This package is NOT in bun workspaces (independent Cargo workspace)
 - gRPC communication with `packages/ai-server`
 - Port alignment: GRPC_PORT must match AI server's GRPC_BACKEND_PORT
+
+## Conventions (shared)
+
+공용 컨벤션(commit, env, migration 등)은 [docs/wiki/schema/conventions.md](../../docs/wiki/schema/conventions.md)를 참조한다. api-server 전용 세부 규칙은 [`packages/api-server/CLAUDE.md`](../../packages/api-server/CLAUDE.md)에 있으며, 이 파일은 Cursor 네이티브 규칙(globs, description)과 핵심 스택 요약만 유지한다.

--- a/docs/wiki/schema/conventions.md
+++ b/docs/wiki/schema/conventions.md
@@ -2,12 +2,15 @@
 title: Coding & Build Conventions
 owner: human
 status: approved
-updated: 2026-04-17
+updated: 2026-04-23
 tags: [harness, agent]
 related:
   - docs/wiki/schema/ownership-matrix.md
   - CLAUDE.md
   - .cursor/rules/monorepo.mdc
+  - .cursor/rules/api-routes.mdc
+  - .cursor/rules/react-components.mdc
+  - .cursor/rules/rust-api.mdc
 ---
 
 # Coding & Build Conventions


### PR DESCRIPTION
## Summary

Sub-4 남은 scope 중 **.cursor/rules/*.mdc schema 참조 일관화** 처리.

기존 상태: `monorepo.mdc`만 `docs/wiki/schema/conventions.md`를 pointer로 참조하고, 나머지 3개 cursor rule(`api-routes`, `react-components`, `rust-api`)은 schema 참조가 누락 상태였음. 모든 cursor rule이 일관되게 SSOT(schema/conventions.md)를 가리키도록 정렬.

## Changes

| 파일 | 변경 |
|---|---|
| `.cursor/rules/api-routes.mdc` | "Conventions (shared)" 섹션 신설 — schema pointer |
| `.cursor/rules/react-components.mdc` | "Conventions (shared)" 섹션 신설 + monorepo.mdc 전역 사항 포인터 |
| `.cursor/rules/rust-api.mdc` | "Conventions (shared)" 섹션 신설 + packages/api-server/CLAUDE.md 포인터 |
| `docs/wiki/schema/conventions.md` | `related` frontmatter 확장(3개 cursor rule) + `updated: 2026-04-23` |

총 16 insertions / 1 deletion — content 중복 제거 없이 pointer만 추가하는 surgical 패치.

## Rationale

- Sub-3 frontmatter linter가 도입되면 cursor rule에서도 schema 참조가 있는 쪽이 검증 난이도가 낮아짐
- 새 규약이 추가될 때 `schema/conventions.md` 한 곳만 갱신하면 되는 SSOT 패턴 완결
- 기존 PR #323(Finding 1·2)와 동일한 pointer 축소 전략 유지

## Scope boundary (NOT in this PR)

Sub-4 남은 2개 scope는 별도 PR로 처리:
- `/ingest`, `/wiki` Claude Code slash command 정의 (`.claude/commands/`)
- Sub-3 ingest CLI pre-push / CI 통합

## Test plan

- [ ] 각 cursor rule 하단 "Conventions (shared)" 섹션이 렌더되는지 GitHub diff에서 확인
- [ ] schema/conventions.md frontmatter가 YAML 파서에서 깨지지 않는지 확인(`related` 6항목)
- [ ] 상대 경로 `../../docs/wiki/schema/conventions.md`가 cursor rules에서 정상 해석되는지 링크 클릭 검증

Refs: #232 (Sub-4 남은 scope 1/3 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)