### PR TITLE
docs(harness): /ingest, /wiki Claude Code slash command 정의 (#232)

### DIFF
--- a/.claude/commands/ingest.md
+++ b/.claude/commands/ingest.md
@@ -1,0 +1,76 @@
+---
+description: 현재 세션의 knowledge를 docs/wiki/wiki/ 노트로 ingest (Sub-3 CLI + LLM 채움)
+argument-hint: <topic> <title>
+allowed-tools: Bash(bun run wiki:ingest:*), Bash(bun run wiki:lint:*), Read, Edit, Bash(git status:*), Bash(git diff:*), Glob
+---
+
+# /ingest — Wiki 노트 생성 + 본문 채움
+
+현재 대화의 knowledge를 `docs/wiki/wiki/<topic>/` 아래 누적 노트로 ingest한다.
+
+## Arguments
+
+`$ARGUMENTS` 는 `<topic> <title ...>` 형태다.
+
+- `<topic>`: `harness` | `ops` | `tasks` | `incidents` 중 하나 (첫 토큰)
+- `<title>`: 나머지 전체 (공백 허용, 따옴표 불필요)
+
+Allowed topic vocabulary는 `tools/wiki/lib/config.ts`의 `INGEST_TOPICS`와 스펙(`docs/wiki/schema/tags.md`)이 SSOT다. 벗어난 topic은 CLI가 `INVALID_TOPIC` 으로 reject 한다.
+
+## 절차
+
+### 1. 인자 파싱·검증
+
+- `$ARGUMENTS` 를 공백 기준 첫 토큰 / 나머지로 분리
+- 첫 토큰이 허용 어휘에 없으면 사용자에게 반환하며 중단 (CLI를 돌리지 않는다)
+- title 이 비어 있으면 사용자에게 title 요청 후 중단
+
+### 2. CLI 호출로 skeleton 생성
+
+Bash 로 다음을 실행:
+
+```bash
+bun run wiki:ingest <topic> <title>
+```
+
+CLI 는 `docs/wiki/wiki/<topic>/<slug>.md` 를 생성하고 `docs/wiki/wiki/INDEX.md` 에 항목을 추가한다. 실패 시 stderr 를 그대로 사용자에게 전달.
+
+### 3. 생성된 파일 본문 채우기
+
+CLI stdout 에서 생성된 상대 경로(`created ...`)를 찾아 Read 로 로드한 뒤, 다음을 `Edit` 로 채운다:
+
+- `## Purpose` 섹션의 `TODO — ...` 를 **이 노트가 답하는 질문 한 줄**로 교체
+- 본문에 **현재 대화에서 얻어낸 factual knowledge** 를 섹션별로 정리
+  - owner 가 `llm` 인 파일이므로 객관적 사실 중심, 주관적 의견은 배제
+  - 참조한 파일·이슈·PR·커밋 SHA 는 [link text](path) 또는 `#NNN` 형식으로 인용
+  - `docs/wiki/schema/links.md` 의 규약 준수 (repo 상대 경로, Obsidian `[[]]` 금지)
+- `## Recent changes` 의 기존 줄은 유지하고, 필요 시 `today:` 로 주요 변경 항목 추가 가능
+
+Tag 정책: skeleton 에 이미 `<topic>`, `llm-write` 가 들어 있다. 필요 시 `docs/wiki/schema/tags.md` 어휘 내에서만 `tags` 를 확장한다.
+
+### 4. 유효성 검증
+
+`bun run wiki:lint` 를 실행해 frontmatter / H1 / related 경로 오류가 없는지 확인. 실패 시 오류를 고친 뒤 재실행.
+
+### 5. 사용자에게 전달할 요약
+
+다음을 포함해 간결하게 보고:
+
+- 생성 파일 경로
+- INDEX.md 갱신 여부
+- lint 결과
+- 다음 단계 제안 (`git add` / 커밋 / PR)
+
+## 주의
+
+- **스펙상 owner=llm 파일은 사람이 직접 편집하지 않는 것을 원칙으로 한다**. 이 커맨드가 공식 ingest 루트다. 긴급 수정은 PR 리뷰에서 근거를 남긴다 (`docs/wiki/schema/frontmatter.md`).
+- `docs/wiki/wiki/<topic>/<slug>.md` 가 이미 존재하면 CLI 가 `FILE_EXISTS` 로 중단한다. 같은 주제 재방문은 해당 기존 파일을 직접 `Edit` 하는 편이 맞다.
+- Ingest 는 **세션 산출물의 marshal** 이지 새로운 설계 도구가 아니다. 이미 합의된 fact 만 담는다.
+
+## Context
+
+- 생성 타깃: `docs/wiki/wiki/<topic>/<slug>.md`
+- 인덱스: `docs/wiki/wiki/INDEX.md`
+- CLI: `tools/wiki/cli.ts` (`bun run wiki:ingest`)
+- Schema SSOT: `docs/wiki/schema/{frontmatter,tags,links}.md`
+- Spec: `docs/superpowers/specs/2026-04-17-llm-wiki-foundation-design.md` §10

--- a/.claude/commands/wiki.md
+++ b/.claude/commands/wiki.md
@@ -1,0 +1,70 @@
+---
+description: docs/wiki/ 오리엔테이션 · lint · links · 검색 (Sub-3 CLI 래퍼)
+argument-hint: [lint|links|list|search <query>]
+allowed-tools: Bash(bun run wiki:lint:*), Bash(bun run wiki:links:*), Read, Grep, Glob
+---
+
+# /wiki — Wiki 오리엔테이션 · 검증 · 검색
+
+`docs/wiki/**` 에 쌓인 knowledge 를 조회·검증하는 래퍼. 기록 추가는 `/ingest` 를 사용한다.
+
+## 서브커맨드
+
+`$ARGUMENTS` 첫 토큰에 따라 동작:
+
+### (인자 없음) · `list` — 현재 상태 보고
+
+1. `docs/wiki/wiki/INDEX.md` 를 Read 로 로드
+2. topic 별 노트 개수 + 파일 목록을 표 형태로 요약
+3. `docs/wiki/schema/README.md` 를 pointer 로 제시 (컨벤션 SSOT)
+
+Glob 으로 실제 `docs/wiki/wiki/**/*.md` 를 확인해 INDEX.md drift(등재 누락) 가 있으면 flag 한다.
+
+### `lint` — frontmatter / H1 / related 경로 검증
+
+```bash
+bun run wiki:lint
+```
+
+Exit code:
+- `0` OK
+- `1` validation error (frontmatter 누락 / H1 불일치 / related 깨짐 등) — 상세 내역을 stdout 에 출력
+- `2` I/O · config error
+
+실패 시 원인 항목별로 수정 방향을 제시 (`docs/wiki/schema/frontmatter.md` / `tags.md` / `links.md` 참조).
+
+### `links` — 깨진 본문 링크 + 역링크 인덱스
+
+```bash
+bun run wiki:links
+```
+
+- body link (`[text](target)`) 중 존재하지 않는 target 목록
+- `related:` backlink 역인덱스
+
+깨진 링크 보고만 하고 자동 수정은 하지 않는다. 사용자에게 수정 여부를 확인받는다.
+
+### `search <query>`
+
+`docs/wiki/**/*.md` + `docs/agent/*-summary.md` 범위에서 query 를 Grep.
+
+1. `Grep` 으로 매칭 파일 + 컨텍스트 라인 수집 (case-insensitive, `-n` 라인번호)
+2. 결과를 topic / category 별로 그룹화해 보고
+3. 해당 파일들의 `title` · `status` · `updated` 를 frontmatter 에서 읽어 metadata 함께 출력
+
+관련도가 낮아 보이는 결과는 제외하지 말고 **있는 그대로** 보여준다 (LLM 자의적 필터링 금지).
+
+## 절차 원칙
+
+- 이 커맨드는 **조회·검증 전용**이다. `Edit` / `Write` 하지 않는다.
+- 신규 노트 추가는 `/ingest` 로 수행. 기존 `owner=llm` 파일 긴급 수정은 PR 리뷰에 근거를 남긴다.
+- CLI 는 `tools/wiki/cli.ts` 가 SSOT. 서브커맨드 추가는 먼저 CLI 를 확장한 뒤 여기 반영한다.
+
+## Context
+
+- 노트 루트: `docs/wiki/wiki/`
+- 인덱스: `docs/wiki/wiki/INDEX.md`
+- Schema: `docs/wiki/schema/`
+- CLI: `tools/wiki/` (`bun run wiki:lint` · `wiki:links` · `wiki:ingest`)
+- Pre-push / CI 통합: `scripts/git-pre-push.sh` · `.github/workflows/wiki-lint.yml`
+- Spec: `docs/superpowers/specs/2026-04-17-llm-wiki-foundation-design.md` + `2026-04-17-llm-wiki-sub3-cli-design.md`

--- a/docs/wiki/schema/harness.md
+++ b/docs/wiki/schema/harness.md
@@ -2,11 +2,13 @@
 title: Harness Boundaries
 owner: human
 status: draft
-updated: 2026-04-17
+updated: 2026-04-23
 tags: [harness, agent, gstack, superpowers, omc, gsd]
 related:
   - CLAUDE.md
   - docs/wiki/schema/conventions.md
+  - .claude/commands/ingest.md
+  - .claude/commands/wiki.md
 ---
 
 # Harness Boundaries
@@ -33,3 +35,15 @@ decoded-monorepo에서 사용하는 에이전트 하네스 도구의 역할과 �
 - 복잡한 작업은 워크트리 분리 (`.worktrees/<slug>` 패턴)
 - 이슈 시작은 `scripts/start-issue.sh <N> [type]` 통한 Draft PR 자동화
 - main/master 직접 push 금지
+
+## Custom slash commands (`.claude/commands/`)
+
+Sub-4 에서 Claude Code 프로젝트 스코프 커스텀 커맨드를 정의. Sub-3 CLI(`tools/wiki/`) 를 래핑해 세션 knowledge 를 `docs/wiki/wiki/**` 로 축적한다.
+
+| 커맨드 | 역할 | 래핑 대상 |
+| --- | --- | --- |
+| `/ingest <topic> <title>` | 새 노트 skeleton 생성 + 본문 LLM 채움 | `bun run wiki:ingest` |
+| `/wiki [lint\|links\|list\|search]` | 조회·검증·검색 (읽기 전용) | `bun run wiki:lint` / `wiki:links` |
+
+- 정의 위치: [.claude/commands/ingest.md](../../../.claude/commands/ingest.md) · [.claude/commands/wiki.md](../../../.claude/commands/wiki.md)
+- CI / pre-push 통합: `scripts/git-pre-push.sh`, `.github/workflows/wiki-lint.yml` (Sub-3 소관)


### PR DESCRIPTION
## Summary

Sub-4 남은 scope 중 **`/ingest`, `/wiki` 같은 Claude Code custom slash command 정의(`.claude/commands/`)** 항목 처리.

Sub-3 CLI(`tools/wiki/cli.ts`)를 프로젝트 스코프 slash command 로 래핑하여, Claude Code 세션에서 knowledge 를 `docs/wiki/wiki/**` 누적 노트로 바로 ingest / 조회할 수 있는 경로를 마련.

Spec: [docs/superpowers/specs/2026-04-17-llm-wiki-foundation-design.md §10.2](docs/superpowers/specs/2026-04-17-llm-wiki-foundation-design.md)

## Changes

### New files

| 파일 | 역할 |
|---|---|
| `.claude/commands/ingest.md` | `/ingest <topic> <title>` — skeleton 생성 + LLM 본문 채움 |
| `.claude/commands/wiki.md` | `/wiki [lint\|links\|list\|search <query>]` — 조회·검증 전용 |

### Modified

| 파일 | 변경 |
|---|---|
| `docs/wiki/schema/harness.md` | "Custom slash commands" 섹션 추가, `related` frontmatter 에 2개 커맨드 등재, `updated: 2026-04-23` bump |

총 161 insertions / 1 deletion.

## Command design notes

**`/ingest <topic> <title>`**
- 허용 topic: `harness | ops | tasks | incidents` (`tools/wiki/lib/config.ts` SSOT)
- 절차: 인자 검증 → `bun run wiki:ingest` → 생성 파일 Read → Edit 로 Purpose/본문 채움 → `bun run wiki:lint` 검증
- `owner=llm` 파일 정책(`docs/wiki/schema/frontmatter.md`) 명시: 사람은 이 경로를 통해서만 수정
- 이미 존재하는 `<slug>` 는 CLI 가 `FILE_EXISTS` 로 reject (기존 파일 직접 Edit 로 우회)

**`/wiki [subcommand]`**
- 조회·검증 전용(`Edit`/`Write` 금지)으로 safety boundary 유지
- `list`: `INDEX.md` + 실제 파일 drift(미등재) flag
- `lint`/`links`: Sub-3 CLI 출력을 그대로 전달, 자동 수정 안 함
- `search <query>`: `docs/wiki/**` + `docs/agent/*-summary.md` Grep, LLM 자의적 필터링 금지

## Verification

```
$ bun run wiki:lint
✓ 0 errors, 1 warnings across 56 files (checked in 0.04s)
# warning: docs/wiki/schema/conventions.md related >=6 (PR #325 에서 발생한 pre-existing)

$ bun run wiki:links
0 broken links across 56 files
# .claude/commands/ingest.md / wiki.md 양쪽 경로 모두 해석됨
```

## Sub-4 scope status

| Scope | 상태 | 비고 |
|---|---|---|
| CLAUDE.md routing·harness 재정비 | ✅ PR #323 merged | |
| `docs/ai-playbook/` Codex deprecation | ✅ PR #324 merged | |
| `.cursor/rules/*.mdc` schema 참조 일관화 | ✅ PR #325 merged | |
| `/ingest`, `/wiki` slash command 정의 | ⏳ 본 PR | |
| Sub-3 ingest CLI pre-push / CI 통합 | ✅ 이미 완료 | `scripts/git-pre-push.sh` + `.github/workflows/wiki-lint.yml` 에 통합 완료 상태 (재확인 필요 시 리뷰 반영) |

**발견**: 이슈 상단의 "Sub-3 CLI 와 통합 (pre-push, CI)" 항목은 이미 merge 된 이전 작업물(tools/wiki/README.md Integration 섹션 · git-pre-push.sh · wiki-lint.yml)에 포함되어 있어, 본 PR merge 후 이슈 #232 는 close 후보.

## Test plan

- [ ] `/ingest harness test-note` 실제 호출로 skeleton 생성 동작 확인 (로컬)
- [ ] `/wiki list` / `/wiki lint` / `/wiki links` 각 서브커맨드 동작 확인
- [ ] CI `wiki-lint` 통과 확인
- [ ] `docs/wiki/schema/harness.md` 의 `.claude/commands/*.md` 링크 클릭 정상

Refs: #232 (Sub-4 남은 scope 2/3 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)