### PR TITLE
fix(ai-server): repo-root .env.backend.dev 도 로드해서 공유 env 갭 해소 (#328)

### DIFF
--- a/packages/ai-server/src/config/_environment.py
+++ b/packages/ai-server/src/config/_environment.py
@@ -129,19 +129,30 @@ class Environment(BaseModel):
     def from_environ(*, env_file: Optional[str] = None):
         """Load env file(s). If `env_file` is set, only that path is used when it exists.
 
-        Default (로컬 dev): `.dev.env` 우선, 없으면 `.env`.
+        Default (로컬 dev) load order — later entries fill in gaps from earlier ones
+        (dotenv default: existing keys win, so package-level overrides repo-root):
+          1. repo-root `.env.backend.dev` — shared DATABASE_URL / R2 creds / Supabase keys,
+             populated by `scripts/local-env-sync.sh`. Acts as the single SOT for
+             values that api-server and ai-server both need.
+          2. package-level `.dev.env` — ai-server-specific (GEMINI_API_KEY, REDIS_*, gRPC).
+          3. package-level `.env` — final fallback.
         """
         cwd = getcwd()
         if env_file is not None:
             if exists(env_file):
                 load_dotenv(env_file)
         else:
+            # package-level first (wins on conflict via dotenv default override=False)
             dev = join(cwd, ".dev.env")
             dotenv_path = join(cwd, ".env")
             if exists(dev):
                 load_dotenv(dev)
             elif exists(dotenv_path):
                 load_dotenv(dotenv_path)
+            # repo-root shared backend env (two levels up from packages/ai-server)
+            repo_root_backend = Path(cwd).parents[1] / ".env.backend.dev"
+            if repo_root_backend.exists():
+                load_dotenv(repo_root_backend)
         _apply_legacy_env_aliases()
         return Environment(**os.environ)
 


### PR DESCRIPTION
Closes #328.

## 요약

- ai-server 의 env 로더 (`_environment.py:from_environ()`) 가 `packages/ai-server/.dev.env` 외에 **repo-root `.env.backend.dev`** 도 로드하도록 수정.
- `scripts/local-env-sync.sh` 가 자동 생성/갱신하는 공유 값 (`DATABASE_URL`, `DATABASE_SERVICE_ROLE_KEY`, `R2_*`, `GEMINI_API_KEY` 등) 을 **ai-server 도 자동 상속** 받게 됨 → Pinterest 파이프라인 (#214) 로컬 기동 즉시 가능.
- `load_dotenv` default 가 `override=False` 이므로 **package-level 가 우선**, repo-root 는 갭만 채움. ai-server 고유 값 (GEMINI_API_KEY, REDIS_*, gRPC 등) 은 기존대로 `.dev.env` 에 유지.

## 배경

#282 (Supabase self-hosting 전환) 에서 `local-env-sync.sh` 가 repo-root `.env.backend.dev` 를 SOT 로 삼고 공유 값들을 거기에 채웁니다. api-server 는 이미 해당 파일을 로드하지만 ai-server 는 `.dev.env` 만 읽어서 같은 값을 중복 세팅해야 했습니다. 이 PR 로 ai-server 도 같은 SOT 에서 읽음.

## 검증

로컬 재현:
1. \`packages/ai-server/.dev.env\` 에서 \`DATABASE_URL\` 제거 (이 PR 이전엔 이게 있어야만 돌아감)
2. ai-server 재기동
3. 스케줄러 DB pool 에러 없음
4. \`POST /raw-posts/sources/{id}/trigger\` → \`200 OK\`, Pinterest 어댑터 페이지네이션 성공, \`last_enqueued_at\` / \`last_scraped_at\` / \`initial_scraped_at\` DB 기록 확인
5. R2 credentials 자동 인식 (\`R2Client not configured\` warning 사라짐)

## Test plan

- [ ] \`just dev-reset && just dev\` 후 ai-server 에서 \`DATABASE_URL is not configured\` 에러 발생 안 함
- [ ] \`POST /raw-posts/sources/{id}/trigger\` 200 반환
- [ ] \`pytest -m "not integration and not e2e"\` 통과
- [ ] \`uv run flake8 src\` 통과