### PR TITLE
fix(api-server/raw-posts): admin middleware order + wrong variant 교정 (#330)

### DIFF
--- a/packages/api-server/src/domains/raw_posts/handlers.rs
+++ b/packages/api-server/src/domains/raw_posts/handlers.rs
@@ -214,18 +214,30 @@ pub async fn stats(State(state): State<AppState>) -> AppResult<Json<RawPostsStat
 // router
 // --------------------
 
-pub fn router(app_config: AppConfig) -> Router<AppState> {
+pub fn router(state: AppState, app_config: AppConfig) -> Router<AppState> {
     Router::new()
         .route("/sources", get(list_sources).post(create_source))
         .route("/sources/{id}", patch(update_source).delete(delete_source))
         .route("/items", get(list_items))
         .route("/items/{id}", get(get_item))
         .route("/stats", get(stats))
+        // Layer order matters: last .layer() is outermost → runs first.
+        // admin_db_middleware reads the User extension that auth_middleware
+        // injects, so auth MUST be outer (added last). The previous order
+        // made every raw-posts admin request fail with 401
+        // "Authentication required" — same trap documented in #257.
+        //
+        // Use `admin_db_middleware` (DB `users.is_admin`), not the JWT-role
+        // variant: Supabase signs `role=authenticated` for normal sessions
+        // so the JWT check would always 403. Other admin routes (dashboard,
+        // editorial_candidates, magazine_sessions) use the `_db` variant
+        // for the same reason.
         .layer(axum::middleware::from_fn_with_state(
-            app_config.clone(),
-            crate::middleware::auth_middleware,
+            state,
+            crate::middleware::admin_db_middleware,
         ))
-        .layer(axum::middleware::from_fn(
-            crate::middleware::admin_middleware,
+        .layer(axum::middleware::from_fn_with_state(
+            app_config,
+            crate::middleware::auth_middleware,
         ))
 }

--- a/packages/api-server/src/router.rs
+++ b/packages/api-server/src/router.rs
@@ -28,7 +28,10 @@ pub fn build_api_router(state: AppState) -> Router<AppState> {
             "/admin",
             domains::admin::router(state.clone(), config.clone()),
         )
-        .nest("/raw-posts", domains::raw_posts::router(config.clone()))
+        .nest(
+            "/raw-posts",
+            domains::raw_posts::router(state.clone(), config.clone()),
+        )
         // Config가 필요 없는 라우터들
         .nest("/post-magazines", domains::post_magazines::router())
         .nest("/categories", domains::categories::router())


### PR DESCRIPTION
Closes #330.

## 요약

\`packages/api-server/src/domains/raw_posts/handlers.rs:router()\` 에서 두 개의 관련 admin auth 버그를 수정:

1. **미들웨어 순서 역전** — \`auth_middleware\` 가 inner, \`admin_middleware\` 가 outer 로 돼있어서 admin 이 User 를 찾기 전에 먼저 실행됨 → 401 \`Authentication required\`. \`domains/admin/categories.rs\` 의 #257 경고 주석 패턴으로 교정.
2. **잘못된 admin 미들웨어 변형** — \`admin_middleware\` (JWT \`role=admin\` 검사) 를 쓰고 있었는데 Supabase 는 일반 세션에 \`role=authenticated\` 를 부여해서 항상 403. Dashboard / Editorial candidates / Magazine sessions 등 다른 admin 라우트는 모두 \`admin_db_middleware\` (DB \`users.is_admin\`) 를 씀. 그에 맞춤.

라우터 시그니처를 \`router(app_config)\` → \`router(state, app_config)\` 로 변경 (dashboard 등과 동일 패턴). \`build_api_router\` 호출부도 업데이트.

## 증거

수정 후 local 에서 admin 세션으로:
- \`GET /api/v1/raw-posts/sources\` → **200** (이전: 401 → 403)

## Test plan

- [x] \`cargo check\` 통과
- [ ] #327 Playwright E2E 재실행 → create/toggle/edit/delete 통과
- [ ] 기존 #258 unit tests 통과 (시그니처 변경 영향 없음 — 테스트는 핸들러 단위)

## 배경

두 버그 모두 #258 머지 전 admin 세션 실측 integration test 가 없어서 놓쳤습니다. 후속으로 admin 세션 smoke test 1–2개 추가하는 별도 이슈 추천 (범위 밖).