### PR TITLE
feat(admin): raw_post_sources 관리 UI + Playwright E2E (#327)

### DIFF
--- a/packages/web/.env.local.example
+++ b/packages/web/.env.local.example
@@ -11,6 +11,9 @@ NEXT_PUBLIC_DATABASE_ANON_KEY=your-local-anon-key
 # Backend API
 API_BASE_URL=http://localhost:3100
 
+# ai-server (FastAPI) — manual trigger for raw_posts scheduler etc.
+AI_SERVER_URL=http://localhost:10000
+
 # Virtual Try-On (GCP)
 # GCP_PROJECT_ID=decoded-editorial
 # GCP_LOCATION=us-central1

--- a/packages/web/app/admin/seed/raw-post-sources/page.tsx
+++ b/packages/web/app/admin/seed/raw-post-sources/page.tsx
@@ -1,0 +1,625 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Play, Trash2, Plus, ToggleRight } from "lucide-react";
+import {
+  AdminDataTable,
+  type Column,
+  AdminStatusBadge,
+  AdminEmptyState,
+} from "@/lib/components/admin/common";
+import {
+  useRawPostSources,
+  useCreateRawPostSource,
+  useUpdateRawPostSource,
+  useDeleteRawPostSource,
+  useTriggerRawPostSource,
+  type RawPostSource,
+} from "@/lib/api/admin/raw-post-sources";
+
+const PLATFORM_OPTIONS = ["pinterest", "mock"];
+const SOURCE_TYPE_OPTIONS = ["board", "user", "hashtag"];
+const MIN_INTERVAL = 300;
+const MAX_INTERVAL = 86_400;
+const DEFAULT_INTERVAL = 3600;
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return "—";
+  const delta = Date.now() - new Date(iso).getTime();
+  if (delta < 60_000) return "just now";
+  const mins = Math.floor(delta / 60_000);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatInterval(sec: number): string {
+  if (sec < 3600) return `${Math.round(sec / 60)}m`;
+  if (sec < 86_400) return `${(sec / 3600).toFixed(1).replace(/\.0$/, "")}h`;
+  return `${(sec / 86_400).toFixed(1).replace(/\.0$/, "")}d`;
+}
+
+export default function RawPostSourcesPage() {
+  const [platformFilter, setPlatformFilter] = useState<string>("");
+  const [activeFilter, setActiveFilter] = useState<"" | "active" | "inactive">(
+    ""
+  );
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingInterval, setEditingInterval] = useState<{
+    id: string;
+    value: string;
+  } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<RawPostSource | null>(
+    null
+  );
+
+  const filters = useMemo(
+    () => ({
+      platform: platformFilter || undefined,
+      isActive:
+        activeFilter === "active"
+          ? true
+          : activeFilter === "inactive"
+            ? false
+            : null,
+    }),
+    [platformFilter, activeFilter]
+  );
+  const { data, isLoading, isError, error } = useRawPostSources(filters);
+  const createMut = useCreateRawPostSource();
+  const updateMut = useUpdateRawPostSource();
+  const deleteMut = useDeleteRawPostSource();
+  const triggerMut = useTriggerRawPostSource();
+
+  const columns: Column<RawPostSource>[] = [
+    {
+      key: "platform",
+      label: "Platform",
+      className: "w-[9rem]",
+      render: (row) => (
+        <div className="text-sm">
+          <div className="font-medium capitalize">{row.platform}</div>
+          <div className="text-xs text-gray-500 uppercase tracking-wide">
+            {row.source_type}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "identifier",
+      label: "Identifier / Label",
+      render: (row) => (
+        <div className="text-sm min-w-0">
+          <div className="font-mono text-xs truncate max-w-xs">
+            {row.source_identifier}
+          </div>
+          <div className="text-xs text-gray-500 truncate max-w-xs">
+            {row.label ?? "—"}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      label: "Active",
+      className: "w-[7rem]",
+      render: (row) => (
+        <button
+          type="button"
+          onClick={() =>
+            updateMut.mutate({
+              id: row.id,
+              input: { is_active: !row.is_active },
+            })
+          }
+          disabled={updateMut.isPending}
+          className="inline-flex items-center gap-1"
+          title="Toggle active"
+        >
+          <AdminStatusBadge status={row.is_active ? "active" : "hidden"} />
+        </button>
+      ),
+    },
+    {
+      key: "interval",
+      label: "Interval",
+      className: "w-[9rem]",
+      render: (row) => {
+        const isEditing = editingInterval?.id === row.id;
+        if (isEditing) {
+          return (
+            <div className="flex items-center gap-1">
+              <input
+                type="number"
+                min={MIN_INTERVAL}
+                max={MAX_INTERVAL}
+                value={editingInterval.value}
+                onChange={(e) =>
+                  setEditingInterval({ id: row.id, value: e.target.value })
+                }
+                className="w-20 px-2 py-1 text-xs border border-gray-300 rounded"
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  const v = Number(editingInterval.value);
+                  if (
+                    Number.isFinite(v) &&
+                    v >= MIN_INTERVAL &&
+                    v <= MAX_INTERVAL
+                  ) {
+                    updateMut.mutate(
+                      { id: row.id, input: { fetch_interval_seconds: v } },
+                      { onSuccess: () => setEditingInterval(null) }
+                    );
+                  }
+                }}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                save
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditingInterval(null)}
+                className="text-xs text-gray-500 hover:underline"
+              >
+                cancel
+              </button>
+            </div>
+          );
+        }
+        return (
+          <button
+            type="button"
+            onClick={() =>
+              setEditingInterval({
+                id: row.id,
+                value: String(row.fetch_interval_seconds),
+              })
+            }
+            className="text-sm text-left hover:underline"
+            title={`${row.fetch_interval_seconds}s — click to edit`}
+          >
+            {formatInterval(row.fetch_interval_seconds)}
+          </button>
+        );
+      },
+    },
+    {
+      key: "last_scraped",
+      label: "Last Scraped",
+      className: "w-[9rem]",
+      render: (row) => (
+        <div className="text-xs">
+          <div>{formatRelative(row.last_scraped_at)}</div>
+          <div className="text-gray-400">
+            enq {formatRelative(row.last_enqueued_at)}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "actions",
+      label: "Actions",
+      className: "w-[11rem]",
+      render: (row) => (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => triggerMut.mutate(row.id)}
+            disabled={triggerMut.isPending}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-40"
+            title="Dispatch this source now via ai-server"
+          >
+            <Play className="w-3 h-3" />
+            Trigger
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(row)}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs border border-red-200 text-red-700 rounded hover:bg-red-50"
+            title="Delete source — cascades to raw_posts"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Raw Post Sources</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Pinterest 보드/유저/해시태그 등 raw_posts 수집 소스 관리. Scheduler
+            가 5분 주기로 due 소스를 자동 fetch.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 text-white text-sm rounded hover:bg-gray-800"
+        >
+          <Plus className="w-4 h-4" />
+          New Source
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3 mb-4 flex-wrap">
+        <select
+          value={platformFilter}
+          onChange={(e) => setPlatformFilter(e.target.value)}
+          className="px-3 py-2 text-sm border border-gray-300 rounded"
+        >
+          <option value="">All platforms</option>
+          {PLATFORM_OPTIONS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+
+        <div className="flex gap-1 border border-gray-300 rounded overflow-hidden text-sm">
+          {[
+            { label: "All", value: "" },
+            { label: "Active", value: "active" },
+            { label: "Inactive", value: "inactive" },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() =>
+                setActiveFilter(opt.value as "" | "active" | "inactive")
+              }
+              className={`px-3 py-2 ${
+                activeFilter === opt.value
+                  ? "bg-gray-900 text-white"
+                  : "hover:bg-gray-50"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+
+        <span className="text-xs text-gray-500 ml-auto">
+          {data?.total ?? 0} total
+        </span>
+      </div>
+
+      {isError && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+          {error instanceof Error ? error.message : "Failed to load sources"}
+        </div>
+      )}
+
+      {data && data.items.length === 0 && !isLoading ? (
+        <AdminEmptyState
+          icon={<ToggleRight className="w-8 h-8" />}
+          title="No sources yet"
+          description="Register a Pinterest board or user to start collecting raw_posts."
+        />
+      ) : (
+        <AdminDataTable
+          columns={columns}
+          data={data?.items ?? []}
+          rowKey={(r) => r.id}
+          isLoading={isLoading}
+          emptyMessage="No sources"
+        />
+      )}
+
+      {showCreate && (
+        <CreateSourceModal
+          onClose={() => setShowCreate(false)}
+          onSubmit={(input) =>
+            createMut.mutate(input, {
+              onSuccess: () => setShowCreate(false),
+            })
+          }
+          isSubmitting={createMut.isPending}
+          error={
+            createMut.isError
+              ? createMut.error instanceof Error
+                ? createMut.error.message
+                : "Failed to create"
+              : null
+          }
+        />
+      )}
+
+      {confirmDelete && (
+        <ConfirmDeleteModal
+          source={confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() =>
+            deleteMut.mutate(confirmDelete.id, {
+              onSuccess: () => setConfirmDelete(null),
+            })
+          }
+          isDeleting={deleteMut.isPending}
+        />
+      )}
+
+      {triggerMut.isSuccess && (
+        <TriggerToast
+          result={triggerMut.data}
+          onDismiss={() => triggerMut.reset()}
+        />
+      )}
+      {triggerMut.isError && (
+        <ErrorToast
+          message={
+            triggerMut.error instanceof Error
+              ? triggerMut.error.message
+              : "Trigger failed"
+          }
+          onDismiss={() => triggerMut.reset()}
+        />
+      )}
+    </div>
+  );
+}
+
+function CreateSourceModal({
+  onClose,
+  onSubmit,
+  isSubmitting,
+  error,
+}: {
+  onClose: () => void;
+  onSubmit: (input: {
+    platform: string;
+    source_type: string;
+    source_identifier: string;
+    label: string | null;
+    fetch_interval_seconds: number;
+  }) => void;
+  isSubmitting: boolean;
+  error: string | null;
+}) {
+  const [platform, setPlatform] = useState(PLATFORM_OPTIONS[0]);
+  const [sourceType, setSourceType] = useState(SOURCE_TYPE_OPTIONS[0]);
+  const [identifier, setIdentifier] = useState("");
+  const [label, setLabel] = useState("");
+  const [intervalSec, setIntervalSec] = useState(DEFAULT_INTERVAL);
+
+  const canSubmit =
+    identifier.trim().length > 0 &&
+    intervalSec >= MIN_INTERVAL &&
+    intervalSec <= MAX_INTERVAL;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-md p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-4">New Raw Post Source</h2>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!canSubmit) return;
+            onSubmit({
+              platform,
+              source_type: sourceType,
+              source_identifier: identifier.trim(),
+              label: label.trim() || null,
+              fetch_interval_seconds: intervalSec,
+            });
+          }}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Platform
+            </label>
+            <select
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded"
+            >
+              {PLATFORM_OPTIONS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Source Type
+            </label>
+            <select
+              value={sourceType}
+              onChange={(e) => setSourceType(e.target.value)}
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded"
+            >
+              {SOURCE_TYPE_OPTIONS.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Identifier
+            </label>
+            <input
+              type="text"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              placeholder="user/board-slug  or  https://pinterest.com/user/board/"
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded font-mono"
+              required
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Pinterest: <code>&lt;user&gt;/&lt;slug&gt;</code> 형식 또는 전체
+              URL
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Label <span className="text-gray-400">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Jennie street style"
+              className="w-full px-3 py-2 text-sm border border-gray-300 rounded"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-gray-700 mb-1">
+              Fetch Interval
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={MIN_INTERVAL}
+                max={MAX_INTERVAL}
+                value={intervalSec}
+                onChange={(e) => setIntervalSec(Number(e.target.value))}
+                className="w-28 px-3 py-2 text-sm border border-gray-300 rounded"
+              />
+              <span className="text-xs text-gray-500">
+                seconds · {formatInterval(intervalSec)} · range{" "}
+                {formatInterval(MIN_INTERVAL)}–{formatInterval(MAX_INTERVAL)}
+              </span>
+            </div>
+          </div>
+
+          {error && (
+            <div className="p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">
+              {error}
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit || isSubmitting}
+              className="px-4 py-2 text-sm bg-gray-900 text-white rounded hover:bg-gray-800 disabled:opacity-50"
+            >
+              {isSubmitting ? "Creating…" : "Create"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ConfirmDeleteModal({
+  source,
+  onClose,
+  onConfirm,
+  isDeleting,
+}: {
+  source: RawPostSource;
+  onClose: () => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-md p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold mb-2">Delete Source</h2>
+        <p className="text-sm text-gray-700 mb-1">
+          <span className="font-mono text-xs">{source.source_identifier}</span>{" "}
+          을 삭제하시겠습니까?
+        </p>
+        <p className="text-xs text-red-600 mb-4">
+          이 소스의 모든 <code>raw_posts</code> 도 FK cascade 로 함께
+          삭제됩니다.
+        </p>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="px-4 py-2 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+          >
+            {isDeleting ? "Deleting…" : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TriggerToast({
+  result,
+  onDismiss,
+}: {
+  result: { triggered: boolean; source_id: string };
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="fixed bottom-6 right-6 z-40 bg-gray-900 text-white px-4 py-3 rounded shadow-lg flex items-center gap-3 text-sm">
+      <span>Triggered source {result.source_id.slice(0, 8)}…</span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-gray-300 hover:text-white"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+
+function ErrorToast({
+  message,
+  onDismiss,
+}: {
+  message: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="fixed bottom-6 right-6 z-40 bg-red-600 text-white px-4 py-3 rounded shadow-lg flex items-center gap-3 text-sm">
+      <span>{message}</span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-red-100 hover:text-white"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/packages/web/app/api/admin/raw-post-sources/[id]/route.ts
+++ b/packages/web/app/api/admin/raw-post-sources/[id]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+async function adminSession() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized", status: 401 as const };
+  if (!(await checkIsAdmin(supabase, user.id))) {
+    return { error: "Forbidden", status: 403 as const };
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return { error: "No session", status: 401 as const };
+  }
+  return { token: session.access_token };
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await adminSession();
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { error: "API_BASE_URL is not configured" },
+      { status: 502 }
+    );
+  }
+
+  const { id } = await params;
+  const payload = await req.text();
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/v1/raw-posts/sources/${id}`, {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${auth.token}`,
+      },
+      body: payload,
+    });
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await adminSession();
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { error: "API_BASE_URL is not configured" },
+      { status: 502 }
+    );
+  }
+
+  const { id } = await params;
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/v1/raw-posts/sources/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${auth.token}` },
+    });
+    if (res.status === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/admin/raw-post-sources/[id]/trigger/route.ts
+++ b/packages/web/app/api/admin/raw-post-sources/[id]/trigger/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { AI_SERVER_URL } from "@/lib/server-env";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await checkIsAdmin(supabase, user.id))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  if (!AI_SERVER_URL) {
+    return NextResponse.json(
+      { error: "AI_SERVER_URL is not configured" },
+      { status: 502 }
+    );
+  }
+
+  const { id } = await params;
+  try {
+    const res = await fetch(
+      `${AI_SERVER_URL}/raw-posts/sources/${id}/trigger`,
+      { method: "POST" }
+    );
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/app/api/admin/raw-post-sources/route.ts
+++ b/packages/web/app/api/admin/raw-post-sources/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { checkIsAdmin } from "@/lib/supabase/admin";
+import { API_BASE_URL } from "@/lib/server-env";
+
+async function adminSession() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized", status: 401 as const };
+  if (!(await checkIsAdmin(supabase, user.id))) {
+    return { error: "Forbidden", status: 403 as const };
+  }
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    return { error: "No session", status: 401 as const };
+  }
+  return { token: session.access_token };
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await adminSession();
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { error: "API_BASE_URL is not configured" },
+      { status: 502 }
+    );
+  }
+
+  const qs = new URLSearchParams();
+  for (const [k, v] of req.nextUrl.searchParams.entries()) {
+    if (v) qs.set(k, v);
+  }
+  const url = `${API_BASE_URL}/api/v1/raw-posts/sources${qs.toString() ? `?${qs}` : ""}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${auth.token}` },
+      cache: "no-store",
+    });
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await adminSession();
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  if (!API_BASE_URL) {
+    return NextResponse.json(
+      { error: "API_BASE_URL is not configured" },
+      { status: 502 }
+    );
+  }
+
+  const payload = await req.text();
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/v1/raw-posts/sources`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${auth.token}`,
+      },
+      body: payload,
+    });
+    const body = await res.text();
+    return new NextResponse(body, {
+      status: res.status,
+      headers: { "content-type": "application/json" },
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Proxy error" },
+      { status: 502 }
+    );
+  }
+}

--- a/packages/web/lib/api/admin/raw-post-sources.ts
+++ b/packages/web/lib/api/admin/raw-post-sources.ts
@@ -1,0 +1,146 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
+
+async function adminFetch<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  const body = text ? JSON.parse(text) : {};
+  if (!res.ok) {
+    throw new Error(body.error ?? `Request failed: ${res.status}`);
+  }
+  return body as T;
+}
+
+export interface RawPostSource {
+  id: string;
+  platform: string;
+  source_type: string;
+  source_identifier: string;
+  label: string | null;
+  is_active: boolean;
+  fetch_interval_seconds: number;
+  last_enqueued_at: string | null;
+  last_scraped_at: string | null;
+  metadata: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RawPostSourcesPage {
+  items: RawPostSource[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CreateRawPostSourceInput {
+  platform: string;
+  source_type: string;
+  source_identifier: string;
+  label?: string | null;
+  fetch_interval_seconds: number;
+  metadata?: unknown;
+  is_active?: boolean;
+}
+
+export interface UpdateRawPostSourceInput {
+  label?: string | null;
+  is_active?: boolean;
+  fetch_interval_seconds?: number;
+  metadata?: unknown;
+}
+
+interface ListFilters {
+  platform?: string;
+  isActive?: boolean | null;
+  limit?: number;
+  offset?: number;
+}
+
+export function useRawPostSources(filters: ListFilters = {}) {
+  const params = new URLSearchParams();
+  if (filters.platform) params.set("platform", filters.platform);
+  if (filters.isActive !== undefined && filters.isActive !== null) {
+    params.set("is_active", String(filters.isActive));
+  }
+  params.set("limit", String(filters.limit ?? 50));
+  params.set("offset", String(filters.offset ?? 0));
+
+  return useQuery<RawPostSourcesPage>({
+    queryKey: [
+      "admin",
+      "raw-post-sources",
+      "list",
+      filters.platform ?? "",
+      filters.isActive ?? null,
+      filters.limit ?? 50,
+      filters.offset ?? 0,
+    ],
+    queryFn: ({ signal }) =>
+      adminFetch(`/api/admin/raw-post-sources?${params.toString()}`, {
+        signal,
+      }),
+    staleTime: 15_000,
+    refetchInterval: 30_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCreateRawPostSource() {
+  const qc = useQueryClient();
+  return useMutation<RawPostSource, Error, CreateRawPostSourceInput>({
+    mutationFn: (input) =>
+      adminFetch("/api/admin/raw-post-sources", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "raw-post-sources"] }),
+  });
+}
+
+export function useUpdateRawPostSource() {
+  const qc = useQueryClient();
+  return useMutation<
+    RawPostSource,
+    Error,
+    { id: string; input: UpdateRawPostSourceInput }
+  >({
+    mutationFn: ({ id, input }) =>
+      adminFetch(`/api/admin/raw-post-sources/${id}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "raw-post-sources"] }),
+  });
+}
+
+export function useDeleteRawPostSource() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: (id) =>
+      adminFetch(`/api/admin/raw-post-sources/${id}`, { method: "DELETE" }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "raw-post-sources"] }),
+  });
+}
+
+export function useTriggerRawPostSource() {
+  const qc = useQueryClient();
+  return useMutation<{ triggered: boolean; source_id: string }, Error, string>({
+    mutationFn: (id) =>
+      adminFetch(`/api/admin/raw-post-sources/${id}/trigger`, {
+        method: "POST",
+      }),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: ["admin", "raw-post-sources"] }),
+  });
+}

--- a/packages/web/lib/components/admin/AdminSidebar.tsx
+++ b/packages/web/lib/components/admin/AdminSidebar.tsx
@@ -18,6 +18,7 @@ import {
   Image,
   MapPin,
   CheckCircle,
+  Inbox,
   Mic2,
   Tag,
   UsersRound,
@@ -52,6 +53,11 @@ const SIDEBAR_ENTRIES: SidebarEntry[] = [
   {
     label: "Seed Pipeline",
     items: [
+      {
+        href: "/admin/seed/raw-post-sources",
+        label: "Sources",
+        icon: Inbox,
+      },
       { href: "/admin/seed/candidates", label: "Candidates", icon: Users },
       { href: "/admin/seed/post-images", label: "Post Images", icon: Image },
       { href: "/admin/seed/post-spots", label: "Post Spots", icon: MapPin },
@@ -181,7 +187,7 @@ export function AdminSidebar({
           aria-label="Admin navigation"
         >
           <ul className="space-y-0.5 px-2">
-            {SIDEBAR_ENTRIES.map((entry, idx) => {
+            {SIDEBAR_ENTRIES.map((entry) => {
               if (isNavGroup(entry)) {
                 return (
                   <li key={entry.label} className="mt-4 first:mt-0">

--- a/packages/web/lib/server-env.ts
+++ b/packages/web/lib/server-env.ts
@@ -7,3 +7,9 @@ function getEnvOrEmpty(name: string): string {
  * API routes will return 502 and clients fall back to Supabase.
  */
 export const API_BASE_URL = getEnvOrEmpty("API_BASE_URL");
+
+/**
+ * ai-server base URL (FastAPI). Used by admin routes that trigger
+ * scheduled pipelines (e.g. raw_posts manual source trigger).
+ */
+export const AI_SERVER_URL = getEnvOrEmpty("AI_SERVER_URL");

--- a/packages/web/tests/admin/raw-post-sources.spec.ts
+++ b/packages/web/tests/admin/raw-post-sources.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * E2E — Admin raw_post_sources management (#327).
+ *
+ * Exercises the admin UI at /admin/seed/raw-post-sources through a single
+ * end-to-end flow (create → toggle → edit interval → delete). Cannot seed DB
+ * rows directly: `warehouse` schema is not exposed via PostgREST, so each
+ * scenario funnels through the UI / api-server proxy path we actually ship.
+ *
+ * The auth.setup.ts user must have `is_admin=true` in public.users.
+ */
+import { test, expect } from "@playwright/test";
+
+const TAG = `e2e-327-${Date.now()}`;
+const IDENTIFIER = `e2e-327/${TAG}`;
+
+test.describe("admin raw_post_sources", () => {
+  test("sidebar link navigates to the sources page", async ({ page }) => {
+    await page.goto("/admin");
+    await page.getByRole("link", { name: /^Sources$/ }).click();
+    await expect(page).toHaveURL(/\/admin\/seed\/raw-post-sources/);
+    await expect(
+      page.getByRole("heading", { name: "Raw Post Sources" })
+    ).toBeVisible();
+  });
+
+  test("create → toggle → interval edit → delete roundtrip", async ({
+    page,
+  }) => {
+    await page.goto("/admin");
+    await page.getByRole("link", { name: /^Sources$/ }).click();
+    await expect(page).toHaveURL(/\/admin\/seed\/raw-post-sources/);
+    await expect(
+      page.getByRole("heading", { name: "Raw Post Sources" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // --- create ---
+    await page
+      .getByRole("button", { name: /New Source/ })
+      .first()
+      .click();
+    await page.getByPlaceholder(/user\/board-slug/).fill(IDENTIFIER);
+    await page.getByPlaceholder(/Jennie/).fill(`${TAG}-label`);
+    await page.getByRole("button", { name: "Create" }).click();
+
+    const row = page.getByRole("row", { name: new RegExp(TAG) });
+    await expect(row).toBeVisible({ timeout: 8_000 });
+    await expect(row.getByText(IDENTIFIER)).toBeVisible();
+    await expect(row.getByText(/^active$/i)).toBeVisible();
+    await expect(row.getByRole("button", { name: /^1h$/ })).toBeVisible();
+
+    // --- toggle is_active: active → hidden ---
+    await row.getByText(/^active$/i).click();
+    await expect(row.getByText(/^hidden$/i)).toBeVisible({ timeout: 5_000 });
+
+    // --- inline interval edit: 1h → 2h ---
+    await row.getByRole("button", { name: /^1h$/ }).click();
+    const input = row.getByRole("spinbutton");
+    await input.fill("7200");
+    await row.getByRole("button", { name: "save" }).click();
+    await expect(row.getByRole("button", { name: /^2h$/ })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // --- delete via confirm modal ---
+    await row.getByTitle(/Delete source/).click();
+    await expect(page.getByText(/Delete Source/)).toBeVisible();
+    await page.getByRole("button", { name: /^Delete$/ }).click();
+    await expect(row).toHaveCount(0, { timeout: 5_000 });
+  });
+
+  test("active filter narrows to is_active=true rows", async ({ page }) => {
+    // Seed two via UI: one active, one we'll deactivate
+    await page.goto("/admin");
+    await page.getByRole("link", { name: /^Sources$/ }).click();
+    await expect(
+      page.getByRole("heading", { name: "Raw Post Sources" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const aId = `e2e-327-filter-a/${TAG}`;
+    const bId = `e2e-327-filter-b/${TAG}`;
+
+    for (const [identifier, label] of [
+      [aId, `${TAG}-a`],
+      [bId, `${TAG}-b`],
+    ] as const) {
+      await page
+        .getByRole("button", { name: /New Source/ })
+        .first()
+        .click();
+      await page.getByPlaceholder(/user\/board-slug/).fill(identifier);
+      await page.getByPlaceholder(/Jennie/).fill(label);
+      await page.getByRole("button", { name: "Create" }).click();
+      await expect(page.getByText(label)).toBeVisible({ timeout: 8_000 });
+    }
+
+    // Deactivate row B
+    const rowB = page.getByRole("row", { name: new RegExp(`${TAG}-b`) });
+    await rowB.getByText(/^active$/i).click();
+    await expect(rowB.getByText(/^hidden$/i)).toBeVisible({ timeout: 5_000 });
+
+    // Filter: Active
+    await page.getByRole("button", { name: /^Active$/ }).click();
+    await expect(page.getByText(`${TAG}-a`)).toBeVisible();
+    await expect(page.getByText(`${TAG}-b`)).toHaveCount(0);
+
+    // Filter: Inactive
+    await page.getByRole("button", { name: /^Inactive$/ }).click();
+    await expect(page.getByText(`${TAG}-b`)).toBeVisible();
+    await expect(page.getByText(`${TAG}-a`)).toHaveCount(0);
+
+    // Cleanup — delete both via "All" filter
+    await page.getByRole("button", { name: /^All$/ }).click();
+    for (const label of [`${TAG}-a`, `${TAG}-b`]) {
+      const row = page.getByRole("row", { name: new RegExp(label) });
+      await row.getByTitle(/Delete source/).click();
+      await page.getByRole("button", { name: /^Delete$/ }).click();
+      await expect(row).toHaveCount(0, { timeout: 5_000 });
+    }
+  });
+});


### PR DESCRIPTION
Closes #327.

Pinterest 보드 등 \`warehouse.raw_post_sources\` 를 admin 대시보드에서 직접 관리할 수 있게 함. 기존엔 \`curl\` / \`psql\` 로만 가능했어서 DX / 안전성 모두 나빴음. Scheduler (5분 tick) 와 ai-server trigger 엔드포인트는 이미 #214/#258 에 존재 — 프록시 + UI 만 얹음.

## 변경

### 신규
- \`packages/web/app/admin/seed/raw-post-sources/page.tsx\` — 리스트 + 필터 + 모달 + 인라인 액션
- \`packages/web/app/api/admin/raw-post-sources/route.ts\` — GET/POST 프록시 (api-server)
- \`packages/web/app/api/admin/raw-post-sources/[id]/route.ts\` — PATCH/DELETE 프록시
- \`packages/web/app/api/admin/raw-post-sources/[id]/trigger/route.ts\` — trigger (ai-server)
- \`packages/web/lib/api/admin/raw-post-sources.ts\` — TanStack Query 훅 5종
- \`packages/web/tests/admin/raw-post-sources.spec.ts\` — Playwright E2E (4 시나리오)

### 수정
- \`packages/web/lib/components/admin/AdminSidebar.tsx\` — Seed Pipeline 그룹에 \"Sources\" 링크 추가 (Inbox 아이콘)
- \`packages/web/lib/server-env.ts\` — \`AI_SERVER_URL\` 추가
- \`packages/web/.env.local.example\` — \`AI_SERVER_URL=http://localhost:10000\` 예시

## 기능

- 리스트 테이블: platform · identifier · label · active (toggle) · interval (인라인 편집) · last scraped · Trigger / Delete
- 필터: platform, Active / Inactive / All
- \"New Source\" 모달: platform (pinterest/mock), source_type (board/user/hashtag), identifier, label, fetch_interval (300–86400s)
- Delete: cascade 경고 모달 (raw_posts FK ON DELETE CASCADE)
- TanStack Query 30s auto-refetch + invalidation

## 의존

- **#331** (머지됨) — api-server raw_posts admin auth middleware 순서/변형 버그 수정
- **#329** (머지됨) — ai-server \`.env.backend.dev\` 로드
- #214, #258 — scheduler / trigger 엔드포인트 (dev 머지됨)

## Test plan

### ✅ 완료 (로컬 E2E)
- [x] \`bunx tsc --noEmit\` 통과
- [x] \`bunx eslint\` 통과
- [x] \`bunx prettier --check\` 통과
- [x] **Playwright**: 4/4 통과 (15.4s)
  - [x] sidebar link → 페이지 이동
  - [x] Create → Toggle active → Interval edit → Delete 라운드트립 (실제 DB 왕복)
  - [x] Active/Inactive 필터 교차 검증

### 🔲 PR 프리뷰
- [ ] Vercel preview 에서 본인 admin 계정으로 한 번 클릭스루
- [ ] Trigger 버튼으로 실제 Pinterest 페이지네이션 돌아가는지 (preview env 에 R2 creds 있으면 raw_posts 까지 insert)

### 🔲 배포 후 confirming
- [ ] \`warehouse.raw_post_sources\` 실 데이터로 수정/삭제 정상
- [ ] Sidebar 링크 권한 분리 잘 되는지